### PR TITLE
Integrate libs copied from nrf

### DIFF
--- a/applications/machine_learning/app_desc.rst
+++ b/applications/machine_learning/app_desc.rst
@@ -125,7 +125,7 @@ The application uses the :ref:`app_event_manager` to distribute events between m
 The following figure shows the application architecture.
 The figure visualizes relations between Application Event Manager, modules, drivers, and libraries.
 
-.. figure:: /images/ml_app_architecture.svg
+.. figure:: /applications/images/ml_app_architecture.svg
    :alt: nRF Machine Learning application architecture
 
    nRF Machine Learning application architecture
@@ -144,7 +144,7 @@ PPR handles sensor sampling and sending of data to the application processor.
 
 The following figure shows the application architecture for the nRF54H20 DK, visualizing the relations between the Application Event Manager, modules, drivers, and libraries.
 
-.. figure:: /images/ml_app_architecture_nrf54h20.svg
+.. figure:: /applications/images/ml_app_architecture_nrf54h20.svg
    :alt: nRF Machine Learning application architecture for the nRF54H20 DK
 
    Architecture of the nRF Machine Learning application for the nRF54H20 DK
@@ -690,7 +690,7 @@ To start forwarding data to Edge Impulse studio:
    a. Select the :guilabel:`Data acquisition` tab.
    #. In the **Record new data** panel, set the desired values and click :guilabel:`Start sampling`.
 
-      .. figure:: /images/ei_data_acquisition.png
+      .. figure:: /samples/images/ei_data_acquisition.png
          :scale: 50%
          :alt: Sampling under Data acquisition in Edge Impulse studio
 
@@ -699,7 +699,7 @@ To start forwarding data to Edge Impulse studio:
    #. Observe the received sample data on the raw data graph under the panel.
       The observed signal depends on the acceleration readouts.
 
-      .. figure:: /images/ei_start_sampling.png
+      .. figure:: /samples/images/ei_start_sampling.png
          :scale: 50%
          :alt: Sampling example
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,11 +3,13 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first three.
-SPHINXOPTS    	?=
-SPHINXBUILD   	?= sphinx-build
+SPHINXOPTS      ?=
+SPHINXBUILD     ?= sphinx-build
 SPHINXAUTOBUILD ?= sphinx-autobuild
-SOURCEDIR     	= .
-BUILDDIR      	= build
+SOURCEDIR       = _build/src
+BUILDDIR        = _build/
+
+SPHINXOPTS := ${SPHINXOPTS} --conf-dir .
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -15,10 +17,17 @@ help:
 
 .PHONY: help Makefile
 
-live:
+mkdir:
+	mkdir -p ${SOURCEDIR}
+
+clean:
+	rm ${BUILDDIR} -r
+
+# this live will not update on file change due to zephyr.external_content sphinx extension
+live: mkdir
 	@$(SPHINXAUTOBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+%: mkdir Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/applications/index.rst
+++ b/doc/applications/index.rst
@@ -1,0 +1,11 @@
+.. _applications:
+
+Applications
+############
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :caption: Subpages:
+
+   /../applications/*/README

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,41 +1,43 @@
 # Configuration file for the Sphinx documentation builder.
-#
-# This file only contains a selection of the most common options. For a full
-# list see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 # -- Path setup --------------------------------------------------------------
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import sys
+from pathlib import Path
 
+import west.manifest
+
+manifest = west.manifest.Manifest.from_topdir()
+
+EDGE_AI_BASE = Path(manifest.repo_abspath)
+ZEPHYR_BASE = Path(manifest.get_projects(["zephyr"])[0].abspath)
+
+sys.path.extend(map(
+    lambda project: str(Path(project.abspath).absolute() / "doc" / "_extensions"),
+    manifest.get_projects(["zephyr", "nrf"])
+))
 
 # -- Project information -----------------------------------------------------
 
-project = 'nRF Connect SDK - Edge AI add-on'
-copyright = '2025, Nordic Semiconductor'
-author = 'Nordic Semiconductor'
+project = "nRF Connect SDK - Edge AI add-on"
+copyright = "2025, Nordic Semiconductor"
+author = "Nordic Semiconductor"
 
 # -- General configuration ---------------------------------------------------
-
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
 extensions = [
-    'sphinx.ext.intersphinx',
-    'sphinx_tabs.tabs',
+    "options_from_kconfig",
+    "sphinx_tabs.tabs",
+    "table_from_rows",
+    "zephyr.domain",
+    "zephyr.external_content",
+    "zephyr.kconfig",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The root document.
-root_doc = 'index'
+root_doc = "index"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -48,17 +50,38 @@ exclude_patterns = ["venv", "shortcuts.rst", "links.rst"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_ncs_theme'
+html_theme = "sphinx_ncs_theme"
 html_theme_options = {"docsets": {}}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
-plantuml = 'java -jar /usr/local/bin/plantuml.jar'
+plantuml = "java -jar /usr/local/bin/plantuml.jar"
 
 rst_epilog = """
 .. include:: /links.rst
 .. include:: /shortcuts.rst
 """
+
+
+# Options for options_from_kconfig ---------------------------------------------
+
+options_from_kconfig_base_dir = EDGE_AI_BASE
+options_from_kconfig_zephyr_dir = ZEPHYR_BASE
+
+
+# Options for table_from_rows --------------------------------------------------
+
+table_from_rows_base_dir = EDGE_AI_BASE
+table_from_sample_yaml_board_reference = "/includes/sample_board_rows.txt"
+
+
+# Options for external_content -------------------------------------------------
+
+external_content_contents = [
+    (EDGE_AI_BASE / "doc", "[!_]*"),
+    (EDGE_AI_BASE, "applications/**/*.rst"),
+    (EDGE_AI_BASE, "samples/**/*.rst"),
+]

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,13 +1,22 @@
 .. _index:
 
-Welcome to the Edge AI add-on for |NCS|
+Welcome to the |EAI| for |NCS|
 #######################################
 
 This is add-on for `nRF Connect SDK`_.
 
-The Edge AI add-on contains solutions and integrations for running machine learning models on Nordic devices.
+The |EAI| contains solutions and integrations for running machine learning models on Nordic Semiconductor devices.
+
+.. note::
+   You need to apply a patch for the ``sdk-nrf`` repository until the existing support for machine learning models is removed.
+   To apply the provided patch, run ``west patch apply``.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :glob:
    :caption: Subpages:
+
+   applications/index
+   samples/index
+   integrations/index
+   libraries/index

--- a/doc/integrations/index.rst
+++ b/doc/integrations/index.rst
@@ -1,0 +1,15 @@
+.. _integrations:
+
+Integrations
+############
+
+The |NCS| integration in |EAI| allows using |NCS| together with third-party software components.
+
+The following user guides describe the integrations available:
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :caption: Subpages:
+
+   *

--- a/doc/libraries/index.rst
+++ b/doc/libraries/index.rst
@@ -1,0 +1,15 @@
+.. _libraries:
+
+Libraries
+#########
+
+Nordic Semiconductor provides a variety of libraries and services that are used in samples and applications in the |EAI|.
+
+Here you can find documentation for these libraries, including API documentation.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :caption: Subpages:
+
+   *

--- a/doc/links.rst
+++ b/doc/links.rst
@@ -1,1 +1,20 @@
 .. _nRF Connect SDK: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html
+
+.. ### Source: edgeimpulse.com
+
+.. _`Edge Impulse`: https://www.edgeimpulse.com/
+.. _`Edge Impulse studio`: https://studio.edgeimpulse.com/login
+.. _`Edge Impulse studio signup`: https://studio.edgeimpulse.com/signup
+.. _`Edge Impulse getting started guide`: https://docs.edgeimpulse.com/docs/getting-started
+.. _`embedded machine learning`: https://docs.edgeimpulse.com/docs/what-is-embedded-machine-learning-anyway
+.. _`Continuous motion recognition tutorial`: https://docs.edgeimpulse.com/docs/continuous-motion-recognition
+.. _`Edge Impulse's data forwarder`: https://docs.edgeimpulse.com/docs/cli-data-forwarder
+.. _`Edge Impulse CLI installation guide`: https://docs.edgeimpulse.com/docs/cli-installation
+.. _`nRF Connect SDK simulated sensor machine learning model`: https://studio.edgeimpulse.com/public/18121/latest
+.. _`nRF Connect SDK hardware accelerometer machine learning model`: https://studio.edgeimpulse.com/public/33129/latest
+.. _`Nordic Semi Thingy:53 page`: https://docs.edgeimpulse.com/docs/development-platforms/officially-supported-mcu-targets/nordic-semi-thingy53
+.. _`Nordic Semi nRF5340 DK page`: https://docs.edgeimpulse.com/docs/nordic-semi-nrf5340-dk
+
+.. _`Serial Terminal app`: https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html
+
+.. _`nRF Connect for Mobile`: https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Connect-for-mobile

--- a/doc/samples/edge_impulse.rst
+++ b/doc/samples/edge_impulse.rst
@@ -1,0 +1,13 @@
+.. _edge_impulse_samples:
+
+Edge Impulse samples
+####################
+
+This section lists the |EAI| samples for :ref:`integrating Edge Impulse with the nRF Connect SDK <ug_edge_impulse>`.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :caption: Subpages
+
+   /../samples/edge_impulse/*/README

--- a/doc/samples/index.rst
+++ b/doc/samples/index.rst
@@ -1,0 +1,11 @@
+.. _samples:
+
+Samples
+#######
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :caption: Subpages:
+
+   edge_impulse

--- a/doc/shortcuts.rst
+++ b/doc/shortcuts.rst
@@ -1,1 +1,10 @@
 .. |NCS| replace:: nRF Connect SDK
+.. |EAI| replace:: Edge AI add-on
+.. |nRFVSC| replace:: nRF Connect for VS Code extension
+.. |config| replace:: See :ref:`configure_application` for information about how to permanently or temporarily change the configuration.
+.. |connect_terminal| replace:: Connect to the kit with a terminal emulator (for example, the `Serial Terminal app`_).
+   See :ref:`test_and_optimize` for the required settings and steps.
+.. |sysbuild_autoenabled_ncs| replace:: When building :ref:`repository applications <create_application_types_repository>` in the :ref:`SDK repositories <dm_repo_types>`, building with sysbuild is :ref:`enabled by default <sysbuild_enabled_ncs>`.
+   If you work with out-of-tree :ref:`freestanding applications <create_application_types_freestanding>`, you need to manually pass the ``--sysbuild`` parameter to every build command or :ref:`configure west to always use it <sysbuild_enabled_ncs_configuring>`.
+.. |thingy53_sample_note| replace:: If you build this application for Thingy:53, it enables additional features. See :ref:`thingy53_app_guide` for details.
+.. |54H_engb_2_8| replace:: The nRF54H20 DK Engineering A and B (up to version 0.8.2) are no longer supported starting with |NCS| v2.9.0.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+add_subdirectory_ifdef(CONFIG_EDGE_IMPULSE edge_impulse)

--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+menu "Libraries"
+
+rsource "edge_impulse/Kconfig"
+
+endmenu

--- a/samples/edge_impulse/data_forwarder/README.rst
+++ b/samples/edge_impulse/data_forwarder/README.rst
@@ -69,7 +69,7 @@ After programming the sample to your development kit, test it by performing the 
    a. Go to the :guilabel:`Data acquisition` tab.
    #. In the **Record new data** panel, set the desired values and click :guilabel:`Start sampling`.
 
-      .. figure:: ../../../doc/nrf/images/ei_data_acquisition.png
+      .. figure:: /samples/images/ei_data_acquisition.png
          :scale: 50 %
          :alt: Sampling under Data acquisition in Edge Impulse studio
 
@@ -78,7 +78,7 @@ After programming the sample to your development kit, test it by performing the 
    #. Observe the received sample data on the raw data graph under the panel.
       For the default sample configuration, you should observe sine waves.
 
-      .. figure:: ../../../doc/nrf/images/ei_start_sampling.png
+      .. figure:: /samples/images/ei_start_sampling.png
          :scale: 50 %
          :alt: Sampling example
 

--- a/samples/edge_impulse/wrapper/README.rst
+++ b/samples/edge_impulse/wrapper/README.rst
@@ -54,7 +54,7 @@ To run the sample using a custom machine learning model, you must complete the f
    #. In the **Classifying existing test sample** panel, select one of the test samples.
    #. Click :guilabel:`Load sample` to display the raw data preview.
 
-      .. figure:: ../../../doc/nrf/images/ei_loading_test_sample.png
+      .. figure:: /samples/images/ei_loading_test_sample.png
          :scale: 50 %
          :alt: Loading test sample input data in Edge Impulse studio
 
@@ -62,7 +62,7 @@ To run the sample using a custom machine learning model, you must complete the f
 
       The classification results will be displayed, with raw data preview.
 
-      .. figure:: ../../../doc/nrf/images/ei_raw_features.png
+      .. figure:: /samples/images/ei_raw_features.png
          :scale: 50 %
          :alt: Raw data preview in Edge Impulse studio
 

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR}/lib lib)

--- a/zephyr/Kconfig.edge_ai
+++ b/zephyr/Kconfig.edge_ai
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+menu "Edge AI add-on"
+
+source "$(ZEPHYR_EDGE_AI_MODULE_DIR)/lib/Kconfig"
+
+endmenu

--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -1,0 +1,10 @@
+patches:
+  - path: nrf/disable-edge-impulse.patch
+    sha256sum: b10e5debe9e40171bb724d5c2bf39a207d384425c7912c0f967b08b0eb7e831c
+    module: nrf
+    author: Szymon Antkowiak
+    email: szymon.antkowiak@nordicsemi.no
+    date: 2025-07-31
+    upstreamable: false
+    comments: |
+      Disable edge-impules from nrf by commenting line in Kconfig and CMakeLists.txt

--- a/zephyr/patches/nrf/disable-edge-impulse.patch
+++ b/zephyr/patches/nrf/disable-edge-impulse.patch
@@ -1,0 +1,26 @@
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index 705274168a..ec82526615 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -30,7 +30,7 @@ add_subdirectory_ifdef(CONFIG_GCF_SMS gcf_sms)
+ add_subdirectory_ifdef(CONFIG_SUPL_CLIENT_LIB supl)
+ add_subdirectory_ifdef(CONFIG_DATE_TIME date_time)
+ add_subdirectory_ifdef(CONFIG_HW_ID_LIBRARY hw_id)
+-add_subdirectory_ifdef(CONFIG_EDGE_IMPULSE edge_impulse)
++#add_subdirectory_ifdef(CONFIG_EDGE_IMPULSE edge_impulse)
+ add_subdirectory_ifdef(CONFIG_WAVE_GEN_LIB wave_gen)
+ add_subdirectory_ifdef(CONFIG_HW_UNIQUE_KEY_SRC hw_unique_key)
+ add_subdirectory_ifdef(CONFIG_APP_JWT app_jwt)
+diff --git a/lib/Kconfig b/lib/Kconfig
+index 4f068905ef..9a10a5d053 100644
+--- a/lib/Kconfig
++++ b/lib/Kconfig
+@@ -32,7 +32,7 @@ rsource "supl/Kconfig"
+ rsource "date_time/Kconfig"
+ rsource "hw_id/Kconfig"
+ rsource "ram_pwrdn/Kconfig"
+-rsource "edge_impulse/Kconfig"
++#rsource "edge_impulse/Kconfig"
+ rsource "wave_gen/Kconfig"
+ rsource "hw_unique_key/Kconfig"
+ rsource "modem_jwt/Kconfig"


### PR DESCRIPTION
Documentation builds but is littered with undefined labels to other parts of NCS documentation. This will be resolved with documentation updates in future.

CMakeLists and Kconfig introduced to use copied edge_impulse library. Patch for nRF is provided to disable this lib there.