### PR TITLE
doc: Prepare quick start page

### DIFF
--- a/applications/gesture_recognition/README.rst
+++ b/applications/gesture_recognition/README.rst
@@ -16,17 +16,17 @@ Application overview
 
    Currently, the gesture recognition application supports only Neuton CPU-based neural network models.
 
-The gesture recognition application demonstrates how to use an nRF Edge AI model to recognize hand gestures from motion sensor data and expose them as standard HID inputs over Bluetooth® Low Energy. 
+The gesture recognition application demonstrates how to use an nRF Edge AI model to recognize hand gestures from motion sensor data and expose them as standard HID inputs over Bluetooth® Low Energy.
 When connected to a PC, the device appears as a Bluetooth LE HID device, allowing recognized gestures to control media playback or presentation slides.
 Based on accelerometer and gyroscope data, the nRF Edge AI model recognizes eight gesture classes:
 
-* Swipe right 
+* Swipe right
 * Swipe left
-* Double shake 
-* Double tap 
-* Rotation clockwise 
+* Double shake
+* Double tap
+* Rotation clockwise
 * Rotation counter-clockwise
-* No gestures (IDLE) 
+* No gestures (IDLE)
 * Unknown gesture
 
 The neural network model is trained using the `Nordic Edge AI Lab platform`_.
@@ -68,7 +68,7 @@ Development kits
 
          * - .. figure:: images/sensor_EB_top.jpeg
                 :alt: Sensor Evaluation Board top view
-    
+
            - .. figure:: images/sensor_EB_bottom.jpeg
                 :alt: Sensor Evaluation Board bottom view
 
@@ -212,7 +212,7 @@ The output consists of 16-bit integers separated by a comma, in the following or
 
    <acc_x>,<acc_y>,<acc_z>,<gyro_x>,<gyro_y>,<gyro_z>
 
-Column headers are not included. 
+Column headers are not included.
 The output rate is the configured sampling frequency (default 100 Hz).
 
 You can find raw datasets used for model training on the `training dataset`_ page.

--- a/doc/axon_compiler/Axon_npu_tflite_compiler.rst
+++ b/doc/axon_compiler/Axon_npu_tflite_compiler.rst
@@ -64,6 +64,8 @@ You should not modify the tools directory structure, as the executor expects the
 
 You must activate the Python environment from this directory to run the executor.
 
+.. _axon_npu_tflite_compiler_setup_executor:
+
 Setting up the executor
 ***********************
 

--- a/doc/includes/build_and_run_general.txt
+++ b/doc/includes/build_and_run_general.txt
@@ -1,0 +1,2 @@
+To build an application, follow the instructions in `Building an application`_ for your preferred building environment.
+See also `Programming`_ for programming steps and `Testing and optimization`_ for general information about testing and debugging in the |NCS|.

--- a/doc/libraries/nrf_edgeai.rst
+++ b/doc/libraries/nrf_edgeai.rst
@@ -56,6 +56,8 @@ Once you enable the ``CONFIG_NRF_EDGEAI`` Kconfig option, the build system autom
 #. It compiles and links your `Nordic Edge AI Lab`_-generated model sources with the your application. (for example, :file:`nrf_edgeai_user_model.c`)
 #. It compiles and links your firmware application with the library.
 
+.. _nrf_edgeai_lib_api:
+
 API Reference
 *************
 

--- a/doc/links.txt
+++ b/doc/links.txt
@@ -14,10 +14,13 @@
 .. _`nRF54LM20A`: https://www.nordicsemi.com/Products/Development-hardware/nRF54LM20-DK/Hardware-files
 .. _`EdgeAI Inference Runner`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/doc/model_creating_pipeline/run_inference_on_the_desktop.html
 .. _`Signal Processing Block`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/doc/model_creating_pipeline/signal_processing.html
-.. _`nRF54LM20B`: https://www.nordicsemi.com/Products/nRF54LM20B
 .. _`Nordic Edge AI Lab platform`: https://ai.lab.nordicsemi.com/
 .. _`Nordic Edge AI Lab`: http://ai.lab.nordicsemi.com/
-.. _`Nordic Edge AI Lab documentation`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/doc/get_started.html
+.. _`nRF54LM20B`: https://www.nordicsemi.com/Products/nRF54LM20B
+.. _`Axon NPU`: https://www.nordicsemi.com/Products/Technologies/Edge-AI/Axon-NPU
+.. _`Neuton models`: https://www.nordicsemi.com/Products/Technologies/Edge-AI/Neuton-models
+.. _`nRF Edge Impulse`: https://www.nordicsemi.com/Products/Development-tools/nRF-Edge-Impulse
+.. _`nRF Programmer`: https://www.nordicsemi.com/Products/Development-tools/nRF-Programmer
 
 .. ### Source: docs.nordicsemi.com (do not update)
 
@@ -30,6 +33,14 @@
 .. _`nRF Connect for Visual Studio Code: Thread Viewer`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/reference/ui_panel.html#thread-viewer
 .. _`Nordic central UART sample`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/bluetooth/central_uart/README.html
 .. _`nRF54L15TAG`: https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/boards/nordic/nrf54l15tag/doc/index.html
+.. _`Nordic Edge AI Lab documentation`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/index.html
+.. _`Nordic Edge AI Lab Quick Start Guide`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/doc/get_started.html
+.. _`Nordic Edge AI Lab Model Creating Pipeline`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/doc/model_creating_pipeline.html
+.. _`Nordic Edge AI Lab Model Dataset Requirements`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/doc/model_creating_pipeline/dataset_requirements.html
+.. _`Nordic Edge AI Lab Model Dataset Uploading`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/doc/model_creating_pipeline/data_uploading_and_setup.html
+.. _`Nordic Edge AI Lab preloaded datasets`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/doc/model_creating_pipeline/data_uploading_and_setup.html#selecting_an_uploaded_or_preloaded_dataset
+.. _`Nordic Edge AI Lab Analytics Tools`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/doc/analytics_tools.html
+.. _`Nordic Edge AI Lab Anomaly detection`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/doc/anomaly_detection.html
 
 .. ### Source: docs.nordicsemi.com (update for each release)
 
@@ -82,6 +93,9 @@
 .. _`Edge Impulse Zephyr Module Deployment`: https://docs.edgeimpulse.com/hardware/deployments/run-zephyr-module
 .. _`Automated Deployment with West Commands`: https://docs.edgeimpulse.com/hardware/deployments/run-zephyr-module#automated-deployment-with-west-commands-early-access-preview
 .. _`Using the library from C`: https://docs.edgeimpulse.com/hardware/deployments/run-cpp-desktop#using-the-library-from-c
+.. _`Edge Impulse data acquisition`: https://docs.edgeimpulse.com/studio/projects/data-acquisition
+.. _`Edge Impulse C++ SDK`: https://docs.edgeimpulse.com/tools/libraries/sdks/inference/cpp
+.. _`Edge Impulse Datasets`: https://docs.edgeimpulse.com/datasets
 
 .. ### Source: github.com
 

--- a/doc/quick_start.rst
+++ b/doc/quick_start.rst
@@ -1,43 +1,57 @@
 .. _quick_start:
 
-Quick start
-###########
+Quick start guide
+#################
 
 .. contents::
    :local:
    :depth: 2
 
+
+This section includes quick start guides for running machine learning workloads on Nordic Semiconductor devices using nRF Edge AI.
+These pages cover common development paths, from simplified end‑to‑end solutions to lower‑level integrations with direct hardware control.
+
+Select the guide that best matches your required level of control, tooling preferences, and target hardware.
+Each guide walks through the required setup steps and shows how to deploy and run an edge AI application.
+
+If you are unsure which approach fits your use case, see the :ref:`solution_comparison` page for a comparison of features, performance characteristics, and supported workflows.
+
 Basic setup variants
 ********************
 
-You can set up your Edge AI application using one of the following variants:
+Use these options to get started quickly or when you prefer higher‑level tooling that abstracts most of the model deployment and runtime details.
+These workflows rely on integrated toolchains and APIs to reduce setup effort:
 
-Edge AI API with Axon
-=====================
+* :ref:`quick_start_nrf_edgeai` - Use it to train models with Nordic Edge AI Lab and deploy them with a unified API.
+  It supports both CPU execution (Neuton) and NPU acceleration (Axon) on compatible devices.
+  Use it for easy setup, standardized workflow, and the best Nordic Semiconductor device compatibility.
+* :ref:`quick_start_edge_impulse` - Use the Edge Impulse platform for an end-to-end machine learning solution.
+  It includes visual development tools, extensive documentation, and community support.
+  Use this option if you already work with Edge Impulse or require its tooling ecosystem.
 
-TBA
+.. toctree::
+   :maxdepth: 1
+   :hidden:
 
-Edge AI API with Neuton
-=======================
-
-TBA
-
-Edge Impulse
-============
-
-TBA
+   quick_start/nrf_edgeai
+   quick_start/edge_impulse
 
 Advanced setup variants
 ***********************
 
-For more control over the Edge AI application, you can use the following advanced solutions.
+Use these options when you need lower‑level control, custom inference pipelines, or direct access to hardware acceleration features.
+These workflows require more manual configuration but allow finer control over performance and resource usage.
 
-Axon driver
-===========
+* :ref:`quick_start_axon_driver` - Work directly with the Axon NPU driver API for maximum control, performance and low energy consumption.
+  Compile TensorFlow Lite models and implement custom inference pipelines.
+  Use this option for advanced optimization and direct NPU control.
+* :ref:`quick_start_axon_edge_impulse` - Combine Edge Impulse's user-friendly platform with Axon NPU hardware acceleration.
+  Use Edge Impulse SDK while benefiting from NPU performance on compatible devices.
+  Use this option if you want to keep the Edge Impulse workflow while targeting Axon hardware.
 
-TBA
+.. toctree::
+   :maxdepth: 1
+   :hidden:
 
-Edge Impulse with Axon
-======================
-
-TBA
+   quick_start/axon_driver
+   quick_start/axon_edge_impulse

--- a/doc/quick_start/axon_driver.rst
+++ b/doc/quick_start/axon_driver.rst
@@ -1,0 +1,115 @@
+.. _quick_start_axon_driver:
+
+Axon driver
+###########
+
+.. contents::
+   :local:
+   :depth: 2
+
+The following guide explains how to use the Axon NPU driver API to run TensorFlow Lite models directly on the Axon NPU.
+It is ideal if you require low‑level control over inference execution, memory usage, and system integration.
+
+To follow this guide, you should be familiar with embedded systems development and C‑based APIs.
+Compared to higher‑level frameworks such as |EAILib|, using the driver API requires more manual setup but enables finer control over performance and resource utilization.
+
+After completing this guide, you will have compiled a TensorFlow Lite model for the Axon NPU and deployed a custom application that performs inference using the Axon driver API.
+
+Model compilation
+*****************
+
+Before you can deploy to the Axon NPU, you need a TensorFlow Lite model compiled specifically for Axon hardware.
+The :ref:`axon_npu_tflite_compiler` transforms your TFLite model into an optimized format that leverages the NPU's specialized hardware.
+
+.. rst-class:: numbered-step
+
+Set up the compiler
+===================
+
+First, set up the Axon compiler's environment on your development system.
+Follow the :ref:`Executor and compiler setup <axon_setup_compiler>` instructions to install the necessary tools.
+
+.. rst-class:: numbered-step
+
+Compile your model
+==================
+
+The Axon compiler analyzes your model's operations, maps them to hardware accelerators, and generates efficient code for the NPU.
+Whether you're using a pre-trained model or one you have trained yourself, you will need to run it through this compilation process.
+
+Follow the :ref:`axon_npu_tflite_compiler_setup_executor` instructions to transform your TFLite model into an Axon-optimized model.
+
+.. rst-class:: numbered-step
+
+Verify compilation
+==================
+
+Test your compiled model to ensure it works correctly before integrating it into your application.
+
+Run :ref:`test_nn_inference` to confirm your compiled model produces correct results.
+This validation step checks for compilation issues early in the development process.
+
+Application development
+***********************
+
+Once you have a compiled model, you must integrate it into your embedded application.
+Use the Axon driver API to load your model, manage memory, and execute inference directly on the NPU hardware.
+
+.. rst-class:: numbered-step
+
+Get compatible hardware
+=======================
+
+The Axon driver requires direct access to NPU hardware.
+Obtain a development board with `Axon NPU`_.
+Keep in mind the NPU is only available on select Nordic devices, so verify compatibility before starting.
+
+.. rst-class:: numbered-step
+
+Set up the Axon driver
+=======================
+
+Install the Axon runtime library and driver components on your development system.
+Follow the :ref:`Axon driver setup <setup_axon>` instructions to prepare your environment for building and deploying Axon applications.
+
+.. rst-class:: numbered-step
+
+Verify your setup
+=================
+
+Before developing your own application, verify that everything is working correctly.
+Run the :ref:`sample_hello_axon` sample application to confirm the driver can communicate with the NPU hardware.
+
+.. note::
+   Successfully running this sample means your development environment is ready.
+   Any issues at this stage are typically related to hardware setup or driver installation.
+
+.. rst-class:: numbered-step
+
+Develop your application
+========================
+
+With your environment set up and model compiled, you can start building your Axon application.
+Use the Axon driver API to load your compiled model, manage memory buffers, and execute inference.
+
+.. tip::
+   Start by modifying the :ref:`sample_hello_axon` sample to understand the basic API flow before building your custom application from scratch.
+
+Follow the :ref:`ug_axon_integration` guide for detailed instructions on:
+
+* Initializing the Axon driver
+* Initializing your compiled model for synchronous or asynchronous inference
+* Executing inference and handling results
+* Integrating the model into your application
+
+.. rst-class:: numbered-step
+
+Deploy and optimize
+===================
+
+Build your application and flash it to your Nordic device.
+
+.. include:: /includes/build_and_run_general.txt
+
+Monitor performance metrics like inference time and current consumption to ensure your application meets requirements.
+The direct driver access gives you the control needed to fine-tune performance for demanding embedded AI applications.

--- a/doc/quick_start/axon_edge_impulse.rst
+++ b/doc/quick_start/axon_edge_impulse.rst
@@ -1,0 +1,26 @@
+.. _quick_start_axon_edge_impulse:
+
+Axon Edge Impulse
+#################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The following guide explains how to run Edge Impulse models on Nordic devices using Axon NPU hardware acceleration.
+It is ideal if you want to use the Edge Impulse SDK while targeting the Axon NPU for inference execution.
+
+To follow this guide, you should be familiar with the Edge Impulse development workflow and embedded application development.
+Compared to using |EAILib| or working directly with the Axon driver API, this approach relies on the Edge Impulse SDK for model integration while still enabling NPU‑accelerated inference on supported devices.
+
+After completing this guide, you will have deployed an Edge Impulse model that runs on the Axon NPU using the Edge Impulse SDK.
+
+Model training
+**************
+
+TBA
+
+Application development
+***********************
+
+TBA

--- a/doc/quick_start/edge_impulse.rst
+++ b/doc/quick_start/edge_impulse.rst
@@ -1,0 +1,132 @@
+.. _quick_start_edge_impulse:
+
+Edge Impulse
+############
+
+.. contents::
+   :local:
+   :depth: 2
+
+The following guide explains how to develop and deploy machine learning applications on Nordic Semiconductor devices using |EI|.
+It is ideal if you want an end‑to‑end workflow for data collection, model training, and deployment on embedded targets.
+
+To follow this guide, you should be familiar with basic embedded systems development.
+The guide covers the steps required to collect data, train a model using Edge Impulse tools, and deploy the resulting model to a Nordic device.
+
+After completing this guide, you will have a machine learning application running on a Nordic Semiconductor device using |EI|.
+
+Model training
+***************
+
+This section will guide you through the complete workflow from data collection to model deployment using |EIS|.
+The platform's visual interface makes it easy to experiment with different model architectures and signal processing techniques.
+
+.. rst-class:: numbered-step
+
+Create an account
+=================
+
+First, create a free `Edge Impulse studio account <Edge Impulse studio signup_>`_.
+Your account gives you access to |EIS|, where you can manage projects, collect and label data, train models, and deploy them to your devices.
+The platform provides generous free tier access, making it perfect for learning and prototyping.
+
+.. rst-class:: numbered-step
+
+Collect data
+============
+
+Data is the foundation of your machine learning model.
+You will need representative samples that capture the patterns, events, or conditions you want your model to recognize.
+|EI| makes data collection straightforward with multiple options to fit your workflow.
+
+Choose the method that works best for your project:
+
+* Directly from your development board - Use or modify the :ref:`ei_data_forwarder_sample` to stream sensor data directly from your Nordic board to |EIS|.
+  Use it for custom hardware setups to have full control over data collection.
+
+* Quick start with Thingy:53 - If you have a Thingy:53, install the Edge Impulse - Wi-Fi firmware using the `nRF Programmer`_ mobile app, then use the `nRF Edge Impulse` mobile app to forward sensor data wirelessly.
+  This is the fastest way to start collecting data without writing any code.
+
+* Upload existing datasets - If you already have data, you can upload synthetic data or public datasets directly to |EIS|.
+  Check `Edge Impulse Datasets`_ for community-contributed datasets you can use as a starting point.
+
+.. tip::
+   * For time-series data (sensor readings, audio), start with at least 5-10 minutes of varied data per class.
+   * For image data, aim for 50-100 images per class as a starting point, with good variety in lighting, angles, and backgrounds.
+   * For all data types, prioritize dataset diversity and balance the number of samples across classes to improve model performance.
+
+For more details on data collection strategies, follow the `Edge Impulse data acquisition` guide.
+
+.. rst-class:: numbered-step
+
+Train your model
+================
+
+|EIS| guides you through creating an "Impulse", which is a pipeline that processes your raw sensor data, extracts meaningful features, and trains a neural network to recognize patterns.
+The visual workflow makes it easy to experiment with different configurations and see results in real-time.
+
+Train and deploy your model using `Edge Impulse studio`_:
+
+* Start with :ref:`ug_edge_impulse_adding_preparing` to learn the basics of preparing and deploying your model for Nordic devices.
+* Explore the comprehensive `Edge Impulse getting started guide`_ for in-depth tutorials on building different types of ML applications.
+
+Your model is now trained and ready for deployment on Nordic devices.
+
+Application development
+***********************
+
+This section covers integration steps for a trained |EI| model into your embedded application.
+The |EI| SDK provides a C++ API that makes it straightforward to run inference on your device.
+
+.. rst-class:: numbered-step
+
+Prepare your environment
+========================
+
+Before integrating your model, set up the |EI| development environment on your system.
+This one-time setup prepares everything you need to build and deploy |EI| applications on Nordic devices.
+
+1. :ref:`Set up Edge Impulse SDK <setup_edge_impulse>`.
+#. Run the :ref:`hello_ei_sample` sample application to verify everything is working correctly.
+
+Successfully running the :ref:`hello_ei_sample` confirms your toolchain is properly configured and ready for development.
+
+.. rst-class:: numbered-step
+
+Develop your application
+========================
+
+Now you can integrate your trained model into your application.
+The |EI| SDK makes it easy to load your model, feed it sensor data, and get predictions with just a few API calls.
+
+1. Add your model - Include the generated model package in your application following the instructions in :ref:`ug_edge_impulse_adding_building`.
+   |EI| packages your entire inference pipeline into a portable library.
+
+#. Implement your application logic using the |EI| SDK API:
+
+   * See :ref:`hello_ei_sample` for a simple example showing the basic API flow from initialization to inference.
+   * Explore :ref:`ei_data_forwarder_sample` if you want to add data forwarding capabilities for continuous learning and debugging.
+   * Read the `Edge Impulse C++ SDK`_ documentation for comprehensive API reference and advanced features.
+
+.. tip::
+   Start with one of the sample applications and modify it incrementally. 
+   This will help you understand the API structure before building your custom application from scratch.
+
+.. rst-class:: numbered-step
+
+Deploy your application
+=======================
+
+Build your application, flash it to your Nordic device, and verify its real-time inference on live sensor data.
+
+.. include:: /includes/build_and_run_general.txt
+
+Your Nordic device is now running intelligent edge AI powered by |EI|.
+
+Next steps
+**********
+
+To work on advanced solutions, see further documentation:
+
+* Accelerate with Axon NPU - If you have a device with `Axon NPU`_, see :ref:`quick_start_axon_edge_impulse` to learn how to combine |EI| with Axon hardware acceleration for significantly faster inference times.
+* Explore advanced features - Dive deeper into the `Edge Impulse C++ SDK`_ documentation to discover advanced capabilities like anomaly detection, continuous learning, and custom processing blocks.

--- a/doc/quick_start/nrf_edgeai.rst
+++ b/doc/quick_start/nrf_edgeai.rst
@@ -1,0 +1,153 @@
+.. _quick_start_nrf_edgeai:
+
+nRF Edge AI API
+###############
+
+.. contents::
+   :local:
+   :depth: 2
+
+The following guide explains how to develop and deploy machine learning applications on Nordic Semiconductor devices using the nRF Edge AI API.
+This guide will walk you through bringing machine learning to your Nordic Semiconductor devices.
+Whether you are training your first model or integrating AI into an existing application, you will find everything you need to get started.
+
+The nRF Edge AI solution supports two types of models:
+
+* `Neuton models`_ - Designed for CPU execution, compatible with a wide range of Nordic devices.
+* `Axon NPU`_ models - Designed for NPU acceleration on devices equipped with the `Axon NPU`_.
+
+After completing this guide, you will have a trained machine learning model running on your Nordic development board.
+
+Model training
+**************
+
+This section describes how to train a machine learning model using Nordic Edge AI Lab.
+It is ideal if you want to create and train custom models without implementing the full training pipeline manually.
+If you are new to machine learning, the Nordic Edge AI Lab provides a user-friendly interface that abstracts much of the complexity.
+
+The training workflow uses the Nordic Edge AI Lab interface to configure data, select model parameters, and run training.
+The tooling abstracts many of the underlying optimization details to simplify model development.
+
+Follow the steps below to create a machine learning model.
+For a detailed walkthrough of the training workflow, see the `Nordic Edge AI Lab Quick Start Guide`_.
+
+.. rst-class:: numbered-step
+
+Create an account
+=================
+
+Create your `Nordic Edge AI Lab`_ account.
+This web tooling will enable you to generate a model package that is compatible with the |EAILib| API.
+
+.. rst-class:: numbered-step
+
+Collect training data
+=====================
+
+Data is the foundation of any machine learning model.
+The quality and quantity of your training data directly impact how well your model will perform in real-world scenarios.
+You will need labeled data that represents the various conditions and scenarios your application will encounter.
+
+You can obtain training data in one of the following ways:
+
+* Start with preloaded datasets - Ideal for learning and experimentation.
+  `Nordic Edge AI Lab`_ includes `sample datasets <Nordic Edge AI Lab preloaded datasets_>`_  that you can use.
+* Use your own data - If you have custom datasets or want to use publicly available ones, you can upload them directly to the platform.
+* Collect live sensor data - Use or modify the :ref:`app_gesture_recognition` application to gather real-time data from sensors on your Nordic development board.
+  See :ref:`building_firmware_for_data_collection` for steps on how to build the application in the data collection mode.
+
+Refer to `Nordic Edge AI Lab Model Dataset Requirements`_ for details on data format, size requirements, and best practices for preparing your dataset.
+
+.. note::
+   Your dataset must include a ``target`` column that contains the labels or values for each data sample.
+   For classification tasks, the ``target`` values must be integers starting from ``0``.
+
+.. rst-class:: numbered-step
+
+Train your model
+================
+
+The Nordic Edge AI Lab automates the complex process of model training, optimization, and packaging.
+You will upload your dataset, configure your model parameters, and let the platform handle the processing.
+The result is a highly optimized model ready to run on your Nordic device.
+
+Train and deploy your model using `Nordic Edge AI Lab`_.
+Refer to `Nordic Edge AI Lab Model Creating Pipeline`_ to see how to create and deploy a model.
+
+.. note::
+   If you want to train a model that is going to be executed on `Axon NPU`_, make sure to select the appropriate target hardware during the model creation process in `Nordic Edge AI Lab`_.
+
+.. rst-class:: numbered-step
+
+Next steps
+==========
+
+Once completed, you can refer to further documentation:
+
+* Learn about `Anomaly detection <Nordic Edge AI Lab Anomaly detection_>`_ to identify unusual conditions or failures without labeled training data.
+* Use `Nordic Edge AI Lab Analytics Tools`_ to analyze and improve your model's performance.
+* Continue to the :ref:`quick_start_nrf_edgeai_app_dev` section to integrate your model into an application.
+
+.. _quick_start_nrf_edgeai_app_dev:
+
+Application development
+***********************
+
+Whether you trained your own model or are working with an existing one, this section will help you integrate it into your application.
+You will set up your development environment, learn to use the nRF Edge AI API, and deploy your AI-powered application.
+
+.. rst-class:: numbered-step
+
+Prepare your environment
+========================
+
+Before you can start developing, you need to set up your development environment with the necessary tools and libraries.
+This is a one-time setup that will enable you to build, flash, and debug AI applications on Nordic devices.
+
+1. :ref:`Set up Edge AI library <setup_nrf_edgeai_lib>`.
+#. Build and run one of the :ref:`nRF Edge AI Samples <samples_nrf_edgeai_overview>` or the :ref:`app_gesture_recognition` application to verify the setup.
+
+.. rst-class:: numbered-step
+
+Develop your application
+========================
+
+You must integrate the nRF Edge AI library into your application.
+Complete the following steps:
+
+1. Download your model package from `Nordic Edge AI Lab`_ after training completes.
+   The package contains data required to integrate your model into your application.
+   Refer to :ref:`ug_nrf_edgeai_integration` for step-by-step instructions on including the library package in your project.
+
+#. Implement the AI functionality using :ref:`nRF Edge AI API <nrf_edgeai_lib_api>`.
+   The API provides simple functions to initialize your model, run inference on input data, and retrieve predictions.
+
+   For practical examples and code patterns, refer to:
+
+   * The :ref:`nRF Edge AI Samples <samples_nrf_edgeai_overview>` page, that demonstrates different AI use cases.
+   * The :ref:`app_gesture_recognition` application, that serves as a complete end-to-end example.
+
+
+Start by running one of the sample applications to understand the API flow before customizing it for your needs.
+
+.. rst-class:: numbered-step
+
+Deploy your application
+=======================
+
+Build your application, flash it to your Nordic device, and verify its real-time inference on live sensor data.
+
+.. include:: /includes/build_and_run_general.txt
+
+.. note::
+   * Axon models require a device with `Axon NPU`_ to leverage hardware acceleration.
+   * Neuton models run on the CPU and are compatible with a wider range of Nordic Semiconductor devices.
+
+Your Nordic device is now powered by edge AI, capable of making intelligent decisions locally without relying on cloud connectivity.
+
+Next steps
+**********
+
+See further documentation:
+
+* Read through :ref:`nrf_edgeai_lib` to understand more about the library and its capabilities.

--- a/doc/samples.rst
+++ b/doc/samples.rst
@@ -4,10 +4,6 @@
 Samples and tests
 #################
 
-.. contents::
-   :local:
-   :depth: 2
-
 The |EAI| repository provides several samples showcasing its functionality.
 You can build the samples for a variety of board targets and configure them for different usage scenarios.
 


### PR DESCRIPTION
Prepare quick start pages for different solutions. They function as an aggregator of links to different articles and pages that are required for running different variants of edge AI.

Merge nRF Edge AI Neuton and Axon into one quick start guide because it does not differ too much a this point.

Edge Impulse + Axon is an empty instruction for now. Waiting for release from Edge Impulse.

Jira: NCSDK-37507