### PR TITLE
doc: ww_kws: add Nordic Edge AI Lab link and update note

### DIFF
--- a/applications/ww_kws/README.rst
+++ b/applications/ww_kws/README.rst
@@ -21,9 +21,11 @@ When a wakeword is detected, the application:
 * Blinks **LED0** for one second.
 * Sends a status message on UART30.
 
+You can easily replace the bundled wakeword with a custom one using the Text to Wake Word feature of the `Nordic Edge AI Lab`_.
+
 .. note::
    The current implementation in this application performs wakeword detection.
-   A separate keyword classification stage is not supported.
+   A separate keyword classification stage is will be added soon.
 
 Requirements
 ************


### PR DESCRIPTION
## Summary
- Add a hyperlink to the `Nordic Edge AI Lab`_ for the Text to Wake Word feature in the ww_kws application README.
- Update the note about keyword classification stage status.

## Test plan
- [ ] Build docs and verify the link renders correctly on the ww_kws page.