### PR TITLE
doc: Fix the top-level README.md to use the current add-on docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Documentation
 
 Browse the official Edge AI documentation:
 
-- To see the official nRF Connect SDK documentation, go to https://docs.nordicsemi.com/bundle/addon-edge-ai_v1.0.0-rc2/page/index.html
+- To see the official nRF Connect SDK documentation, go to https://docs.nordicsemi.com/bundle/addon-edge-ai_latest/page/index.html
 - Nordic Edge AI Lab documentation: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/doc/overview_of_nordic_edge_ai_lab.html
 
 Support


### PR DESCRIPTION
The link was pointing to the documentation in old version (v1.0.0-rc2) and should point to the latest - built and staged  automatically from main.