### PR TITLE
applications: gesture_recognition: refactor ble_hid to use HID Service from sdk-nrf

### DIFF
--- a/applications/gesture_recognition/README.rst
+++ b/applications/gesture_recognition/README.rst
@@ -304,13 +304,13 @@ Testing
       :class: highlight
 
       Predicted class: DOUBLE SHAKE, with probability 96 %
-      BLE HID Key 8 sent successfully
+      BLE HID key sent successfully
       Predicted class: SWIPE RIGHT, with probability 99 %
-      BLE HID Key 32 sent successfully
+      BLE HID key sent successfully
       Predicted class: SWIPE LEFT, with probability 99 %
-      BLE HID Key 16 sent successfully
+      BLE HID key sent successfully
       Predicted class: ROTATION RIGHT, with probability 93 %
-      BLE HID Key 1 sent successfully
+      BLE HID key sent successfully
 
    Once the device is running, Bluetooth LE advertising starts as a HID device and waits for a connection request from the PC.
    Devices can be connected in the same way as a regular Bluetooth keyboard.
@@ -322,9 +322,6 @@ Testing
 
       Connected 9C:B6:D0:C0:CE:FC (public)
       Security changed: 9C:B6:D0:C0:CE:FC (public) level 2
-      Input CCCD enabled
-      Input attribute handle: 0
-      Consumer CCCD enabled
 
    After Bluetooth connection, the device changes LED indication from red to green, or red to blue depending on the keyboard control mode.
    You can now use the device to control media playback or presentation slides by making gestures.

--- a/applications/gesture_recognition/README.rst
+++ b/applications/gesture_recognition/README.rst
@@ -491,6 +491,7 @@ Dependencies
 This sample uses the following |NCS| services:
 
 * `Nordic UART Service (NUS)`_
+* `HID Service`_
 
 This sample uses the following Zephyr libraries:
 

--- a/applications/gesture_recognition/src/ble/hid/ble_hid.c
+++ b/applications/gesture_recognition/src/ble/hid/ble_hid.c
@@ -14,7 +14,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/settings/settings.h>
 
-LOG_MODULE_REGISTER(ble_hid, CONFIG_BT_HIDS_LOG_LEVEL);
+LOG_MODULE_REGISTER(ble_hid);
 
 
 #define KEY_ARROW_LEFT (0x50)

--- a/applications/gesture_recognition/src/ble/hid/ble_hid.c
+++ b/applications/gesture_recognition/src/ble/hid/ble_hid.c
@@ -61,6 +61,8 @@ static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_UUID16_ALL,
 				  BT_UUID_16_ENCODE(BT_UUID_HIDS_VAL),
 				  BT_UUID_16_ENCODE(BT_UUID_BAS_VAL)),
+	BT_DATA_BYTES(BT_DATA_GAP_APPEARANCE,
+				  BT_BYTES_LIST_LE16(BT_APPEARANCE_HID_PRESENTATION_REMOTE)),
 };
 
 static const struct bt_data sd[] = {

--- a/applications/gesture_recognition/src/ble/hid/ble_hid.c
+++ b/applications/gesture_recognition/src/ble/hid/ble_hid.c
@@ -14,47 +14,43 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/settings/settings.h>
 
+#include <bluetooth/services/hids.h>
+
 LOG_MODULE_REGISTER(ble_hid);
 
+/* HID keyboard usage codes */
+#define KEY_ARROW_LEFT  0x50
+#define KEY_ARROW_RIGHT 0x4F
+#define KEY_F5          0x3E
+#define KEY_ESC         0x29
 
-#define KEY_ARROW_LEFT (0x50)
-#define KEY_ARROW_RIGHT (0x4F)
-#define KEY_F5 (0x3E)
-#define KEY_ESC (0x29)
+/* Consumer control bit positions (1-byte bitmap) */
+#define KEY_MEDIA_VOLUME_UP   BIT(0)
+#define KEY_MEDIA_VOLUME_DOWN BIT(1)
+#define KEY_MEDIA_MUTE        BIT(2)
+#define KEY_MEDIA_PLAY_PAUSE  BIT(3)
+#define KEY_MEDIA_PREV_TRACK  BIT(4)
+#define KEY_MEDIA_NEXT_TRACK  BIT(5)
 
-#define KEY_MEDIA_VOLUME_UP (1 << 0)
-#define KEY_MEDIA_VOLUME_DOWN (1 << 1)
-#define KEY_MEDIA_MUTE (1 << 2)
-#define KEY_MEDIA_PLAY_PAUSE (1 << 3)
-#define KEY_MEDIA_PREV_TRACK (1 << 4)
-#define KEY_MEDIA_NEXT_TRACK (1 << 5)
+/* Input report indices within the report group */
+#define INPUT_REP_KEYBOARD_IDX 0
+#define INPUT_REP_CONSUMER_IDX 1
 
-/* Require encryption. */
-#define SAMPLE_BT_PERM_READ BT_GATT_PERM_READ_ENCRYPT
-#define SAMPLE_BT_PERM_WRITE BT_GATT_PERM_WRITE_ENCRYPT
+/* Report IDs matching the report map */
+#define INPUT_REP_KEYBOARD_ID 0x01
+#define INPUT_REP_CONSUMER_ID 0x02
 
+/* Report sizes in bytes */
+#define INPUT_REP_KEYBOARD_LEN 8
+#define INPUT_REP_CONSUMER_LEN 1
 
-enum {
-	HIDS_REMOTE_WAKE = BIT(0),
-	HIDS_NORMALLY_CONNECTABLE = BIT(1),
-};
+/* Offset of the 'key' byte within the HID report array */
+#define INPUT_REP_KEYBOARD_KEY_OFFSET 2
+#define INPUT_REP_CONSUMER_KEY_OFFSET 0
 
-struct hids_info {
-	uint16_t version; /* version number of base USB HID Specification */
-	uint8_t code;     /* country HID Device hardware is localized for. */
-	uint8_t flags;
-} __packed;
+#define BASE_USB_HID_SPEC_VERSION 0x0101
 
-struct hids_report {
-	uint8_t id;   /* report id */
-	uint8_t type; /* report type */
-} __packed;
-
-enum {
-	HIDS_INPUT = 0x01,
-	HIDS_OUTPUT = 0x02,
-	HIDS_FEATURE = 0x03,
-};
+BT_HIDS_DEF(hids_obj, INPUT_REP_KEYBOARD_LEN, INPUT_REP_CONSUMER_LEN);
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
@@ -66,33 +62,11 @@ static const struct bt_data ad[] = {
 };
 
 static const struct bt_data sd[] = {
-	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME,
+		sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
-static struct hids_info info = {
-	.version = 0x0000,
-	.code = 0x00,
-	.flags = HIDS_NORMALLY_CONNECTABLE,
-};
-
-static struct hids_report input = {
-	.id = 0x01,
-	.type = HIDS_INPUT,
-};
-
-static struct hids_report input_consumer = {
-	.id = 0x02,
-	.type = HIDS_INPUT,
-};
-
-static bool ble_connected;
-static ble_connection_cb_t user_conn_callback;
-
-static bool ccc_enabled;
-static uint8_t ctrl_point;
-static uint8_t consumer_report;
-
-static uint8_t report_map[] = {
+static const uint8_t report_map[] = {
 	0x05, 0x01, /* Usage Page (Generic Desktop) */
 	0x09, 0x06, /* Usage (Keyboard) */
 	0xA1, 0x01, /* Collection (Application) */
@@ -158,118 +132,27 @@ static uint8_t report_map[] = {
 	0xC0 /* End Collection */
 };
 
-static ssize_t read_info(struct bt_conn *conn,
-			 const struct bt_gatt_attr *attr, void *buf,
-			 uint16_t len, uint16_t offset)
-{
-	return bt_gatt_attr_read(conn, attr, buf, len, offset, attr->user_data,
-				 sizeof(struct hids_info));
-}
+static bool ble_connected;
+static ble_connection_cb_t user_conn_callback;
 
-static ssize_t read_report_map(struct bt_conn *conn,
-			       const struct bt_gatt_attr *attr, void *buf,
-			       uint16_t len, uint16_t offset)
-{
-	return bt_gatt_attr_read(conn, attr, buf, len, offset, report_map,
-				 sizeof(report_map));
-}
-
-static ssize_t read_report(struct bt_conn *conn,
-			    const struct bt_gatt_attr *attr, void *buf,
-			    uint16_t len, uint16_t offset)
-{
-	return bt_gatt_attr_read(conn, attr, buf, len, offset, attr->user_data,
-				 sizeof(struct hids_report));
-}
-
-static void input_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
-{
-	LOG_INF("Input CCCD %s", value == BT_GATT_CCC_NOTIFY ? "enabled" : "disabled");
-	LOG_INF("Input attribute handle: %d", attr->handle);
-
-	ccc_enabled = (value == BT_GATT_CCC_NOTIFY);
-}
-
-static ssize_t read_input_report(struct bt_conn *conn,
-				 const struct bt_gatt_attr *attr, void *buf,
-				 uint16_t len, uint16_t offset)
-{
-	return bt_gatt_attr_read(conn, attr, buf, len, offset, NULL, 0);
-}
-
-static ssize_t write_ctrl_point(struct bt_conn *conn,
-				const struct bt_gatt_attr *attr,
-				const void *buf, uint16_t len, uint16_t offset,
-				uint8_t flags)
-{
-	uint8_t *value = attr->user_data;
-
-	LOG_INF("write_ctrl_point");
-
-	if (offset + len > sizeof(ctrl_point)) {
-		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	}
-
-	memcpy(value + offset, buf, len);
-
-	return len;
-}
-
-static ssize_t read_consumer_report(struct bt_conn *conn,
-				    const struct bt_gatt_attr *attr,
-				    void *buf, uint16_t len, uint16_t offset)
-{
-	return bt_gatt_attr_read(conn, attr, buf, len, offset, NULL, 0);
-}
-
-static void consumer_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
-{
-	LOG_INF("Consumer CCCD %s", value == BT_GATT_CCC_NOTIFY ? "enabled" : "disabled");
-}
-
-BT_GATT_SERVICE_DEFINE(hog_svc,
-		       BT_GATT_PRIMARY_SERVICE(BT_UUID_HIDS),
-		       BT_GATT_CHARACTERISTIC(BT_UUID_HIDS_INFO, BT_GATT_CHRC_READ,
-					      BT_GATT_PERM_READ, read_info, NULL, &info),
-		       BT_GATT_CHARACTERISTIC(BT_UUID_HIDS_REPORT_MAP, BT_GATT_CHRC_READ,
-					      BT_GATT_PERM_READ, read_report_map, NULL, NULL),
-
-		       BT_GATT_CHARACTERISTIC(BT_UUID_HIDS_REPORT,
-					      BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
-					      SAMPLE_BT_PERM_READ,
-					      read_input_report, NULL, NULL),
-		       BT_GATT_CCC(input_ccc_changed,
-				   SAMPLE_BT_PERM_READ | SAMPLE_BT_PERM_WRITE),
-		       BT_GATT_DESCRIPTOR(BT_UUID_HIDS_REPORT_REF, BT_GATT_PERM_READ,
-					  read_report, NULL, &input),
-
-		       BT_GATT_CHARACTERISTIC(BT_UUID_HIDS_REPORT,
-					      BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
-					      SAMPLE_BT_PERM_READ,
-					      read_consumer_report, NULL, &consumer_report),
-		       BT_GATT_CCC(consumer_ccc_changed,
-				   SAMPLE_BT_PERM_READ | SAMPLE_BT_PERM_WRITE),
-		       BT_GATT_DESCRIPTOR(BT_UUID_HIDS_REPORT_REF, BT_GATT_PERM_READ,
-					  read_report, NULL, &input_consumer),
-
-		       BT_GATT_CHARACTERISTIC(BT_UUID_HIDS_CTRL_POINT,
-					      BT_GATT_CHRC_WRITE_WITHOUT_RESP,
-					      BT_GATT_PERM_WRITE,
-					      NULL, write_ctrl_point, &ctrl_point),
-			);
-
-static void connected(struct bt_conn *conn, uint8_t err)
+static void connected(struct bt_conn *conn, uint8_t conn_err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
+	int err;
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	if (err) {
-		LOG_ERR("Failed to connect to %s (%u)", addr, err);
+	if (conn_err) {
+		LOG_ERR("Failed to connect to %s (%u)", addr, conn_err);
 		return;
 	}
 
 	LOG_INF("Connected %s", addr);
+
+	err = bt_hids_connected(&hids_obj, conn);
+	if (err) {
+		LOG_ERR("Failed to notify HIDS about connection (err %d)", err);
+	}
 
 	if (bt_conn_set_security(conn, BT_SECURITY_L2)) {
 		LOG_ERR("Failed to set security");
@@ -291,8 +174,13 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	LOG_INF("Disconnected from %s (reason 0x%02x)", addr, reason);
 
+	err = bt_hids_disconnected(&hids_obj, conn);
+	if (err) {
+		LOG_ERR("Failed to notify HIDS about disconnection (err %d)",
+			err);
+	}
+
 	ble_connected = false;
-	ccc_enabled = false;
 
 	if (user_conn_callback) {
 		user_conn_callback(ble_connected);
@@ -324,7 +212,6 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 		LOG_INF("Security changed: %s level %u", addr, level);
 	} else {
 		LOG_ERR("Security failed: %s level %u err %d", addr, level, err);
-
 		bt_unpair(BT_ID_DEFAULT, BT_ADDR_LE_ANY);
 	}
 }
@@ -334,6 +221,34 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.disconnected = disconnected,
 	.security_changed = security_changed,
 };
+
+static int hids_service_init(void)
+{
+	struct bt_hids_init_param hids_init_param = {0};
+	struct bt_hids_inp_rep *keyboard_rep;
+	struct bt_hids_inp_rep *consumer_rep;
+
+	hids_init_param.rep_map.data = report_map;
+	hids_init_param.rep_map.size = sizeof(report_map);
+
+	hids_init_param.info.bcd_hid = BASE_USB_HID_SPEC_VERSION;
+	hids_init_param.info.b_country_code = 0x00;
+	hids_init_param.info.flags = BT_HIDS_NORMALLY_CONNECTABLE;
+
+	keyboard_rep = &hids_init_param.inp_rep_group_init.reports[INPUT_REP_KEYBOARD_IDX];
+	keyboard_rep->size = INPUT_REP_KEYBOARD_LEN;
+	keyboard_rep->id = INPUT_REP_KEYBOARD_ID;
+	hids_init_param.inp_rep_group_init.cnt++;
+
+	consumer_rep = &hids_init_param.inp_rep_group_init.reports[INPUT_REP_CONSUMER_IDX];
+	consumer_rep->size = INPUT_REP_CONSUMER_LEN;
+	consumer_rep->id = INPUT_REP_CONSUMER_ID;
+	hids_init_param.inp_rep_group_init.cnt++;
+
+	hids_init_param.is_kb = true;
+
+	return bt_hids_init(&hids_obj, &hids_init_param);
+}
 
 static void bt_ready(int err)
 {
@@ -361,6 +276,13 @@ int ble_hid_init(ble_connection_cb_t cb)
 {
 	int err;
 
+	err = hids_service_init();
+
+	if (err) {
+		LOG_ERR("HID Service init failed (err %d)", err);
+		return err;
+	}
+
 	err = bt_enable(bt_ready);
 
 	if (err) {
@@ -375,73 +297,95 @@ int ble_hid_init(ble_connection_cb_t cb)
 
 int ble_hid_send_key(ble_hid_key_t key)
 {
-	int res = -1;
-	uint8_t report[8] = {0};
-	size_t report_len = sizeof(report);
-	int attr_index = 5;
+	int err;
+	uint8_t keyboard_report[INPUT_REP_KEYBOARD_LEN] = {0};
+	uint8_t consumer_report[INPUT_REP_CONSUMER_LEN] = {0};
+	bool is_consumer = false;
 
-	if (!ble_connected || !ccc_enabled) {
-		return -1;
+	if (!ble_connected) {
+		return -ENOTCONN;
 	}
 
+	/* The keyboard report is sent as a single key pressed with modifier key bitmap cleared */
 	switch (key) {
 	case BLE_HID_KEY_ARROW_LEFT:
-		report[2] = KEY_ARROW_LEFT;
+		keyboard_report[INPUT_REP_KEYBOARD_KEY_OFFSET] = KEY_ARROW_LEFT;
 		break;
 	case BLE_HID_KEY_ARROW_RIGHT:
-		report[2] = KEY_ARROW_RIGHT;
+		keyboard_report[INPUT_REP_KEYBOARD_KEY_OFFSET] = KEY_ARROW_RIGHT;
 		break;
 	case BLE_HID_KEY_F5:
-		report[2] = KEY_F5;
+		keyboard_report[INPUT_REP_KEYBOARD_KEY_OFFSET] = KEY_F5;
 		break;
 	case BLE_HID_KEY_ESC:
-		report[2] = KEY_ESC;
+		keyboard_report[INPUT_REP_KEYBOARD_KEY_OFFSET] = KEY_ESC;
 		break;
 	case BLE_HID_KEY_MEDIA_PREV_TRACK:
-		report[0] = KEY_MEDIA_PREV_TRACK;
-		report_len = 2;
-		attr_index = 10;
+		consumer_report[INPUT_REP_CONSUMER_KEY_OFFSET] = KEY_MEDIA_PREV_TRACK;
+		is_consumer = true;
 		break;
 	case BLE_HID_KEY_MEDIA_NEXT_TRACK:
-		report[0] = KEY_MEDIA_NEXT_TRACK;
-		report_len = 2;
-		attr_index = 10;
+		consumer_report[INPUT_REP_CONSUMER_KEY_OFFSET] = KEY_MEDIA_NEXT_TRACK;
+		is_consumer = true;
 		break;
 	case BLE_HID_KEY_MEDIA_MUTE:
-		report[0] = KEY_MEDIA_MUTE;
-		report_len = 2;
-		attr_index = 10;
+		consumer_report[INPUT_REP_CONSUMER_KEY_OFFSET] = KEY_MEDIA_MUTE;
+		is_consumer = true;
 		break;
 	case BLE_HID_KEY_MEDIA_PLAY_PAUSE:
-		report[0] = KEY_MEDIA_PLAY_PAUSE;
-		report_len = 2;
-		attr_index = 10;
+		consumer_report[INPUT_REP_CONSUMER_KEY_OFFSET] = KEY_MEDIA_PLAY_PAUSE;
+		is_consumer = true;
 		break;
 	case BLE_HID_KEY_MEDIA_VOLUME_UP:
-		report[0] = KEY_MEDIA_VOLUME_UP;
-		report_len = 2;
-		attr_index = 10;
+		consumer_report[INPUT_REP_CONSUMER_KEY_OFFSET] = KEY_MEDIA_VOLUME_UP;
+		is_consumer = true;
 		break;
 	case BLE_HID_KEY_MEDIA_VOLUME_DOWN:
-		report[0] = KEY_MEDIA_VOLUME_DOWN;
-		report_len = 2;
-		attr_index = 10;
+		consumer_report[INPUT_REP_CONSUMER_KEY_OFFSET] = KEY_MEDIA_VOLUME_DOWN;
+		is_consumer = true;
 		break;
 	default:
-		return res;
+		return -EINVAL;
 	}
 
-	res = bt_gatt_notify(NULL, &hog_svc.attrs[attr_index], report, report_len);
+	if (is_consumer) {
+		err = bt_hids_inp_rep_send(&hids_obj, NULL,
+					   INPUT_REP_CONSUMER_IDX,
+					   consumer_report,
+					   sizeof(consumer_report), NULL);
+		if (err) {
+			LOG_ERR("Failed to send consumer key (err %d)", err);
+			return err;
+		}
 
-	if (res) {
-		LOG_ERR("Failed to send key, error = %d", res);
-		return res;
+		memset(consumer_report, 0, sizeof(consumer_report));
+		err = bt_hids_inp_rep_send(&hids_obj, NULL,
+					   INPUT_REP_CONSUMER_IDX,
+					   consumer_report,
+					   sizeof(consumer_report), NULL);
+	} else {
+		err = bt_hids_inp_rep_send(&hids_obj, NULL,
+					   INPUT_REP_KEYBOARD_IDX,
+					   keyboard_report,
+					   sizeof(keyboard_report), NULL);
+		if (err) {
+			LOG_ERR("Failed to send keyboard key (err %d)", err);
+			return err;
+		}
+
+		memset(keyboard_report, 0, sizeof(keyboard_report));
+		err = bt_hids_inp_rep_send(&hids_obj, NULL,
+					   INPUT_REP_KEYBOARD_IDX,
+					   keyboard_report,
+					   sizeof(keyboard_report), NULL);
 	}
-	LOG_INF("BLE HID Key %d sent successfully", report[0]);
 
-	/* reset report */
-	memset(report, 0, sizeof(report));
+	if (err) {
+		LOG_ERR("Failed to send key release (err %d)", err);
+		return err;
+	}
 
-	res = bt_gatt_notify(NULL, &hog_svc.attrs[attr_index], report, report_len);
-	return res;
+	LOG_INF("BLE HID key sent successfully");
+
+	return 0;
 }

--- a/doc/links.txt
+++ b/doc/links.txt
@@ -79,6 +79,7 @@
 .. _`Sensor`: https://docs.nordicsemi.com/bundle/ncs-3.3.0-preview2/page/zephyr/hardware/peripherals/sensor/index.html#sensor
 .. _`Nordic UART Service (NUS)`: https://docs.nordicsemi.com/bundle/ncs-3.3.0-preview2/page/nrf/libraries/bluetooth/services/nus.html
 .. _`TensorFlow Lite for Microcontrollers: Hello World`: https://docs.nordicsemi.com/bundle/ncs-3.3.0-preview2/page/zephyr/samples/modules/tflite-micro/hello_world/README.html#tflite-hello-world
+.. _`HID Service`: https://docs.nordicsemi.com/bundle/ncs-3.3.0-preview2/page/nrf/libraries/bluetooth/services/hids.html
 
 .. ### Source: edgeimpulse.com
 


### PR DESCRIPTION
It's been agreed offline, that the application would benefit from using the ready Bluetooth HID Service module from the sdk-nrf repo, which will hide Zephyr Bluetooth API changes (migration will be handled on sdk-nrf level) and ensure quality of the service implementation. At the same time the HID Service API is quite stable, so it shouldn't generate too much maintenance in the add-on.

**Not addressed in this PR**:

- [ ] Restore authentication setting selectively for HIDs, previously removed by https://github.com/nrfconnect/sdk-edge-ai/pull/39