### PR TITLE
doc: Update link to the Nordic Edge AI Lab

### DIFF
--- a/applications/gesture_recognition/README.rst
+++ b/applications/gesture_recognition/README.rst
@@ -30,7 +30,7 @@ Based on accelerometer and gyroscope data, the nRF Edge AI model recognizes eigh
 * No gestures (IDLE)
 * Unknown gesture
 
-The neural network model is trained using the `Nordic Edge AI Lab platform`_.
+The neural network model is trained using the `Nordic Edge AI Lab`_.
 The whole process how to capture data and train the model is described in the `Nordic Edge AI Lab documentation`_.
 You can also see `Gesture recognition use-case demo video`_.
 

--- a/doc/integrations/nrf_edgeai.rst
+++ b/doc/integrations/nrf_edgeai.rst
@@ -114,7 +114,7 @@ The total memory footprint consists of the runtime engine and context, the user-
 The runtime engine and its associated context typically require about 2 kB of FLASH and 0.5–1 kB of SRAM.
 The size of the user-generated model, which is trained for a specific dataset, depends on your selected settings and overall model complexity.
 In most cases, the requirement is between 1 and 10 kB.
-Memory usage for the signal-processing pipeline is determined by the configuration parameters specified in the `Signal Processing Block`_ of `Nordic Edge AI Lab documentation`_.
+Memory usage for the signal-processing pipeline is determined by the configuration parameters specified in the `Signal Processing Block`_ of `Nordic Edge AI Lab Documentation`_.
 
 This variability results from the library including only those algorithms and processing blocks that you explicitly select.
 Unused modules are not included in the deployed solution, which helps ensure that memory is used efficiently and without unnecessary overhead.

--- a/doc/links.txt
+++ b/doc/links.txt
@@ -14,8 +14,7 @@
 .. _`nRF54LM20 DK`: https://www.nordicsemi.com/Products/Development-hardware/nRF54LM20-DK/Hardware-files
 .. _`EdgeAI Inference Runner`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/doc/model_creating_pipeline/run_inference_on_the_desktop.html
 .. _`Signal Processing Block`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/doc/model_creating_pipeline/signal_processing.html
-.. _`Nordic Edge AI Lab platform`: https://ai.lab.nordicsemi.com/
-.. _`Nordic Edge AI Lab`: https://www.nordicsemi.com/Products/Technologies/Edge-AI/Software#infotabs
+.. _`Nordic Edge AI Lab`: https://ai.lab.nordicsemi.com/
 .. _`nRF54LM20B`: https://www.nordicsemi.com/Products/nRF54LM20B
 .. _`Axon NPU`: https://www.nordicsemi.com/Products/Technologies/Edge-AI/Axon-NPU
 .. _`Neuton models`: https://www.nordicsemi.com/Products/Technologies/Edge-AI/Neuton-models
@@ -33,7 +32,7 @@
 .. _`nRF Connect for Visual Studio Code: Thread Viewer`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/reference/ui_panel.html#thread-viewer
 .. _`Nordic central UART sample`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/bluetooth/central_uart/README.html
 .. _`nRF54L15TAG`: https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/boards/nordic/nrf54l15tag/doc/index.html
-.. _`Nordic Edge AI Lab documentation`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/index.html
+.. _`Nordic Edge AI Lab Documentation`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/index.html
 .. _`Nordic Edge AI Lab Quick Start Guide`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/doc/get_started.html
 .. _`Nordic Edge AI Lab Model Creating Pipeline`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/doc/model_creating_pipeline.html
 .. _`Nordic Edge AI Lab Model Dataset Requirements`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/doc/model_creating_pipeline/dataset_requirements.html


### PR DESCRIPTION
The current link doesn't point to the Edge AI Lab page directly