### PR TITLE
Add observability documentation

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Install system dependencies
         run: |
+          sudo apt update
+          sudo apt-get install -y graphviz plantuml
           wget --no-verbose "https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz"
           sudo tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz -C /opt
           echo "/opt/doxygen-${DOXYGEN_VERSION}/bin" >> $GITHUB_PATH

--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -1,0 +1,6 @@
+/* Make PlantUML SVG diagrams responsive.
+ * svg_img format emits <p class="plantuml"><img src="...svg"> */
+p.plantuml > img {
+    max-width: 100%;
+    height: auto;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -55,7 +55,11 @@ extensions = [
     'zephyr.doxyrunner',
     'zephyr.doxybridge',
     'zephyr.external_content',
+    'sphinxcontrib.plantuml',
 ]
+
+plantuml = 'plantuml'
+plantuml_output_format = 'svg_img'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -72,6 +76,7 @@ external_content_contents = [
     (EDGE_AI_BASE, "applications/**/*.rst"),
     (EDGE_AI_BASE, "samples/**/*.rst"),
     (EDGE_AI_BASE, "tests/**/*.rst"),
+    (EDGE_AI_BASE, "lib/**/Kconfig"),
 ]
 
 # -- Options for doxyrunner plugin ---------------------------------------------
@@ -123,7 +128,8 @@ html_extra_path = ['versions.json']
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static'] (currently not in use)
+html_static_path = [str(EDGE_AI_BASE / "doc" / "_static")]
+html_css_files = ['custom.css']
 
 rst_epilog = """
 .. include:: /links.txt

--- a/doc/doxyfile.in
+++ b/doc/doxyfile.in
@@ -2404,6 +2404,8 @@ PREDEFINED             = __DOXYGEN__ \
                          "__syscall=" \
                          "__syscall_inline=" \
                          "__attribute(x)= DOXYGEN=1" \
+                         CONFIG_NRF_EDGEAI_OBSV_METRIC_PROBS_DISTRIBUTION \
+                         CONFIG_NRF_EDGEAI_OBSV_METRIC_TRANSITION_MATRIX \
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/doc/libraries.rst
+++ b/doc/libraries.rst
@@ -12,4 +12,5 @@ Nordic Semiconductor provides libraries and services that are used in samples an
 
    libraries/nrf_edgeai
    libraries/nrf_edgeai_changelog
+   libraries/nrf_edgeai_obsv
    libraries/axon

--- a/doc/libraries/nrf_edgeai.rst
+++ b/doc/libraries/nrf_edgeai.rst
@@ -53,8 +53,10 @@ Once you enable the ``CONFIG_NRF_EDGEAI`` Kconfig option, the build system autom
 
 1. It locates the precompiled static library for your target architecture (for example, ``libnrf_edgeai_cortex-m4.a``).
 #. It includes the header files from the :file:`include/nrf_edgeai/` directory.
-#. It compiles and links your `Nordic Edge AI Lab`_-generated model sources with the your application. (for example, :file:`nrf_edgeai_user_model.c`)
+#. It compiles and links your `Nordic Edge AI Lab`_-generated model sources with your application (for example, :file:`nrf_edgeai_user_model.c`).
 #. It compiles and links your firmware application with the library.
+
+See also :ref:`nrf_edgeai_obsv_lib` for collecting runtime statistics from model output probabilities; it works with any inference engine, including this library, and can upload data to the `Memfault`_ cloud service.
 
 .. _nrf_edgeai_lib_api:
 

--- a/doc/libraries/nrf_edgeai_obsv.rst
+++ b/doc/libraries/nrf_edgeai_obsv.rst
@@ -1,0 +1,575 @@
+.. _nrf_edgeai_obsv_lib:
+
+nRF Edge AI Observability Library
+#################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The Edge AI Observability module tracks how a classification model performs at runtime.
+It collects stats from the model's output probabilities and packages them as metric snapshots that can be sent to a monitoring backend.
+It works with any inference engine that produces a probability vector, including the :ref:`nrf_edgeai_lib`, :ref:`Axon NPU <lib_axon>`, and `Edge Impulse`_ deployments.
+
+Overview
+********
+
+Deployed Edge AI models behave differently in production then in controlled environments.
+Class distributions shift, transitions between predicted labels change over time, and confidence scores drift as conditions change.
+The observability module gives you a structured way to capture these statistics on-device and send them off-device for analysis.
+
+Currently, metrics are driven only by the model output probability vector passed to :c:func:`nrf_edgeai_obsv_update`.
+
+Collected data enables the following:
+
+* Model quality monitoring - Allows tracking whether prediction confidence and class frequencies stay within expected bounds after deployment.
+* Dataset collection guidance - Helps identify which classes are under-represented or confused in the field, and target data collection efforts accordingly.
+* Retraining triggers - Allows detecting distribution shift early and decide when a model update is needed before accuracy degrades noticeably.
+* A/B testing - Allows comparing metric snapshots from devices running different model versions to evaluate improvements in production conditions.
+
+The module is organized as three cooperating layers:
+
+* Core (:file:`lib/nrf_edgeai_obsv/`) - A portable, mutex-free state machine that accumulates metric counters as inference results arrive.
+  It has no Zephyr RTOS dependency and you can use it in bare-metal environments, other RTOSes, or host-side test builds.
+* Zephyr wrapper (:file:`lib/nrf_edgeai_obsv/`) - Wraps the core in a mutex-protected context so that multiple threads can feed inferences and trigger encoding without data races, and integrates the library into the Zephyr build system (CMake, Kconfig, logging).
+* Memfault CDR transport (:file:`lib/nrf_edgeai_obsv_memfault/`) - Encodes the accumulated metric snapshots as a CBOR blob and stages them as a `Memfault Custom Data Recording`_ (CDR) that the Memfault SDK packetizer uploads on the next transport drain cycle.
+  For Memfault Kconfig, keys, and transports in |NCS|, see `Memfault in nRF Connect SDK`_.
+
+.. uml::
+   :caption: High-level data flow from application inference through observability to nRF Cloud and downstream tools.
+
+   skinparam shadowing false
+   skinparam roundcorner 0
+   skinparam backgroundColor #FFFFFF
+   skinparam defaultTextAlignment center
+   skinparam ArrowColor #0077C8
+   skinparam ArrowThickness 1
+   skinparam linetype ortho
+   skinparam componentStyle rectangle
+
+   skinparam component {
+     BackgroundColor #13B6FF
+     BorderColor #13B6FF
+     FontColor #333F48
+   }
+
+   skinparam cloud {
+     BackgroundColor #C1E8FF
+     BorderColor #2149C2
+     FontColor #333F48
+   }
+
+   together {
+     component "Application" as App
+     component "nrf_edgeai_obsv\n(Zephyr wrapper + core)" as Obsv
+     component "Metrics\n(e.g. probability distribution)" as Metrics
+   }
+
+   component "nrf_edgeai_obsv_memfault\n(Memfault CDR transport)" as MfltTransport
+   component "Memfault SDK" as MfltSDK
+   cloud "nRF Cloud\n(Memfault)" as Cloud
+   component "Monitoring tool\n(dashboard / ML pipeline)" as Dashboard
+
+   App -right-> Obsv : inference results\n(class probabilities)
+   Obsv -down-> Metrics : accumulate counters
+   App -down-> MfltTransport : trigger collect
+   MfltTransport -up-> Obsv : encode metrics as CBOR
+   MfltTransport -right-> MfltSDK : stage CDR
+   MfltSDK -right-> Cloud : upload via BLE or HTTP
+   Cloud -right-> Dashboard : fetch CDR\n(REST API)
+
+The following diagram shows the detailed call sequence between the observability layers, the application, and the Memfault SDK.
+
+.. uml::
+   :caption: Call sequence for initialization, inference updates, Memfault collect, and CDR drain.
+
+   skinparam shadowing false
+   skinparam roundcorner 0
+   skinparam backgroundColor #FFFFFF
+   skinparam ArrowColor #0077C8
+   skinparam sequenceArrowThickness 1
+
+   skinparam sequence {
+     DividerBackgroundColor #8DBEFF
+     DividerBorderColor #8DBEFF
+     LifeLineBackgroundColor #13B6FF
+     LifeLineBorderColor #13B6FF
+     ParticipantBackgroundColor #13B6FF
+     ParticipantBorderColor #13B6FF
+     BoxBackgroundColor #C1E8FF
+     BoxBorderColor #C1E8FF
+     GroupBackgroundColor #8DBEFF
+     GroupBorderColor #8DBEFF
+   }
+
+   skinparam note {
+     BackgroundColor #ABCFFF
+     BorderColor #2149C2
+     Shadowing false
+   }
+
+   skinparam participant {
+     Shadowing false
+   }
+
+   participant "Application" as App
+   participant "nrf_edgeai_obsv\n(Zephyr wrapper)" as Obsv
+   participant "nrf_edgeai_obsv_core" as Core
+   participant Metric
+   participant "nrf_edgeai_obsv_memfault" as Mflt
+   participant "Memfault SDK" as SDK
+
+   == Initialization ==
+
+   App -> Obsv : nrf_edgeai_obsv_init(ctx, model)
+   App -> Metric : nrf_edgeai_obsv_metric_tm_create(metric, buf, n)
+   App -> Metric : nrf_edgeai_obsv_metric_pd_create(metric, buf, n)
+   App -> Obsv : nrf_edgeai_obsv_register(ctx, metric, cfg)
+   App -> Mflt : nrf_edgeai_obsv_memfault_init(ctx)
+   Mflt -> SDK : memfault_cdr_register_source()
+
+   == Inference loop ==
+
+   loop every inference
+     App -> Obsv : nrf_edgeai_obsv_update(ctx, probs)
+     Obsv -> Obsv : lock ctx->lock
+     Obsv -> Core : nrf_edgeai_obsv_core_update()
+     Core -> Metric : metric->update(probs, n)
+     Obsv -> Obsv : unlock ctx->lock
+   end
+
+   == Collect (periodic or on demand) ==
+
+   App -> Mflt : nrf_edgeai_obsv_memfault_collect()
+   note right of Mflt : snapshot ctx list under obsv_mflt_lock,\nthen release before encoding
+   Mflt -> Obsv : nrf_edgeai_obsv_encode_list(ctxs, n, buf)
+   loop per context
+     Obsv -> Obsv : lock ctx->lock
+     Obsv -> Core : nrf_edgeai_obsv_core_for_each_metric()
+     Core -> Metric : metric->finalize()
+     Core -> Metric : metric->snapshot()
+     Core -> Obsv : zcbor encode → CBOR blob
+     Obsv -> Obsv : unlock ctx->lock
+   end
+   Mflt -> Mflt : copy blob to staging buffer\nunder obsv_mflt_lock
+
+   == Transport drain ==
+
+   SDK -> Mflt : has_cdr_cb()
+   Mflt --> SDK : metadata (size, mime type)
+   SDK -> Mflt : read_data_cb(offset, len)
+   Mflt --> SDK : CBOR payload bytes
+   SDK -> Mflt : mark_cdr_read_cb()
+   SDK -> SDK : upload via BLE MDS or HTTP
+
+Metrics
+*******
+
+The module exposes model behavior through metrics that are updated on every inference and exported as snapshots.
+Each metric is a self-contained unit with its own storage and callbacks, which means you can mix built-in metrics with your own custom ones.
+The module includes two ready-to-use built-in metrics, and provides an interface for adding your own.
+
+.. _nrf_edgeai_obsv_metrics_built_in:
+
+Built-in metrics
+================
+
+The module provides two built-in metrics that capture different aspects of model behavior over time.
+See the :ref:`nrf_edgeai_obsv_buffer_config` section for the available options.
+
+.. _nrf_edgeai_obsv_metrics_built_in_transition:
+
+Transition matrix
+-----------------
+
+The transition matrix counts how many times the dominant class (argmax of the probability vector) changed from class *i* to class *j* across consecutive calls to :c:func:`nrf_edgeai_obsv_update`.
+The result is a square ``num_classes × num_classes`` matrix of ``uint32_t`` counters stored in row-major order, where row *i* is the previous class and column *j* is the current class.
+
+The following table shows rows for the previous dominant class and columns for the current dominant class:
+
+.. list-table:: Example transition matrix counts (four classes, illustrative)
+   :widths: auto
+   :header-rows: 1
+   :stub-columns: 1
+
+   * -
+     - idle
+     - walk
+     - run
+     - jump
+   * - idle
+     - 0
+     - 38
+     - 3
+     - 1
+   * - walk
+     - 36
+     - 0
+     - 12
+     - 2
+   * - run
+     - 3
+     - 10
+     - 0
+     - 5
+   * - jump
+     - 2
+     - 3
+     - 3
+     - 0
+
+The illustrative counts suggest *walk* as the dominant class, frequent transitions between *idle* and *walk*, and little *jump* activity.
+
+.. _nrf_edgeai_obsv_metrics_built_in_probability:
+
+Probability distribution
+------------------------
+
+The probability distribution metric builds a per-class histogram over the ``[0, 1]`` probability range.
+Each call to :c:func:`nrf_edgeai_obsv_update` function increments one bin per class based on that class's output probability.
+The result is a ``num_classes × bin_num`` matrix of ``uint32_t`` bin counts, where row *i* is the class and each column is a histogram bin.
+
+The following table uses four uniform bins with inner edges at 0.25, 0.50, and 0.75.
+Each row is a class; each column is a probability bin.
+
+.. list-table:: Example per-class probability histogram counts (four classes, four bins, illustrative)
+   :widths: auto
+   :header-rows: 1
+   :stub-columns: 1
+
+   * -
+     - [0, 0.25)
+     - [0.25, 0.50)
+     - [0.50, 0.75)
+     - [0.75, 1.0]
+   * - idle
+     - 85
+     - 22
+     - 14
+     - 20
+   * - walk
+     - 18
+     - 25
+     - 31
+     - 67
+   * - run
+     - 96
+     - 30
+     - 10
+     - 5
+   * - jump
+     - 130
+     - 8
+     - 2
+     - 1
+
+The illustrative counts suggest *walk* is often predicted with high confidence (67 counts in the top bin), a bimodal spread for *idle*, and mostly low confidence for *run* and *jump*, which may indicate confusion between those classes.
+
+.. _nrf_edgeai_obsv_metrics_custom:
+
+Custom metrics
+==============
+
+You can implement additional metrics by filling in an :c:struct:`nrf_edgeai_obsv_metric_t` operation table and registering it with the :c:func:`nrf_edgeai_obsv_register` function.
+A metric consists of five callbacks and a ``priv`` pointer to its own storage:
+
+.. list-table:: Observability metric callbacks
+   :widths: auto
+   :header-rows: 1
+
+   * - Callback
+     - Required
+     - Purpose
+   * - ``init(cfg, priv)``
+     - yes
+     - Zero counters and apply optional configuration.
+   * - ``update(probs, n, priv)``
+     - yes
+     - Consume one inference result.
+   * - ``clear(priv)``
+     - no
+     - Zero counters without touching configuration (called by :c:func:`nrf_edgeai_obsv_reset`). Set to ``NULL`` if reset is a no-op.
+   * - ``finalize(priv)``
+     - no
+     - Compute derived values before a snapshot is taken. Set to ``NULL`` if not needed.
+   * - ``snapshot(out, priv)``
+     - yes
+     - Populate a read-only :c:struct:`nrf_edgeai_obsv_metric_snapshot_t` view. The ``counts`` pointer must remain valid for the lifetime of the metric instance.
+
+The snapshot exposes counters as a flat row-major ``uint32_t`` matrix of ``num_rows × num_cols`` elements.
+Metrics with a single scalar value use ``num_rows = 1, num_cols = 1``.
+
+Custom metric IDs
+-----------------
+
+Choose an ID that does not collide with the built-in values defined in :c:enum:`nrf_edgeai_obsv_metric_id`.
+Using values well above the built-in range (for example, 1000 and above) leaves room for future built-in additions.
+
+.. _nrf_edgeai_obsv_buffer_sizing:
+
+Buffer sizing for CBOR encoding
+-------------------------------
+
+When the Memfault transport (or :c:func:`nrf_edgeai_obsv_encode_list`) serializes all metrics, the encode buffer must be large enough to hold custom metric data in addition to the built-in ones.
+You reserve this space through the ``CONFIG_NRF_EDGEAI_OBSV_EXTRA_ENCODE_BYTES`` Kconfig option (see :ref:`nrf_edgeai_obsv_buffer_config`).
+
+The required value is the sum of ``NRF_EDGEAI_OBSV_ENCODE_METRIC_SIZE(n_rows, n_cols)`` across all custom metrics.
+Because ``NRF_EDGEAI_OBSV_ENCODE_METRIC_SIZE`` is a C preprocessor macro, evaluate it at compile time and write the resulting integer directly in :file:`prj.conf`.
+To catch mismatches at build time, add a ``BUILD_ASSERT`` in your application code:
+
+.. code-block:: c
+
+   BUILD_ASSERT(CONFIG_NRF_EDGEAI_OBSV_EXTRA_ENCODE_BYTES >=
+                NRF_EDGEAI_OBSV_ENCODE_METRIC_SIZE(1, MY_NUM_CLASSES),
+                "EXTRA_ENCODE_BYTES too small for custom metric");
+
+Example custom metric: class frequency counter
+----------------------------------------------
+
+The following example shows a minimal custom metric that counts how often each class is the argmax across all inferences.
+It produces a 1 × ``num_classes`` row of ``uint32_t`` counters, with storage passed through priv to match the built-in metric pattern.
+
+.. code-block:: c
+
+   #include <stdint.h>
+   #include <string.h>
+   #include <nrf_edgeai_obsv/nrf_edgeai_obsv.h>
+   #include <nrf_edgeai_obsv/nrf_edgeai_obsv_metrics.h>
+
+   #define MY_METRIC_ID   1000U
+   #define MY_METRIC_VER  1U
+   #define MY_NUM_CLASSES 4U
+
+
+   static void my_init(const void *cfg, void *priv)
+   {
+       ARG_UNUSED(cfg);
+       memset(priv, 0, MY_NUM_CLASSES * sizeof(uint32_t));
+   }
+
+   static void my_clear(void *priv)
+   {
+       memset(priv, 0, MY_NUM_CLASSES * sizeof(uint32_t));
+   }
+
+   static void my_update(const float *probs, uint16_t n, void *priv)
+   {
+       uint32_t *counts = (uint32_t *)priv;
+       uint16_t argmax = 0;
+
+       /* When probabilities tie for the maximum, the lowest index wins. */
+       for (uint16_t i = 1; i < n; i++) {
+           if (probs[i] > probs[argmax]) {
+               argmax = i;
+           }
+       }
+       counts[argmax]++;
+   }
+
+   static void my_snapshot(nrf_edgeai_obsv_metric_snapshot_t *out, void *priv)
+   {
+       out->metric_id = MY_METRIC_ID;
+       out->version   = MY_METRIC_VER;
+       out->num_rows  = 1U;
+       out->num_cols  = MY_NUM_CLASSES;
+       out->counts    = (uint32_t *)priv;
+   }
+
+   /* buf: at least n_classes * sizeof(uint32_t) bytes, uint32_t-aligned. */
+   void my_metric_create(nrf_edgeai_obsv_metric_t *metric, void *buf, uint16_t n_classes)
+   {
+       ARG_UNUSED(n_classes); /* stored implicitly via MY_NUM_CLASSES in callbacks */
+       *metric = (nrf_edgeai_obsv_metric_t){
+           .init     = my_init,
+           .update   = my_update,
+           .clear    = my_clear,
+           .finalize = NULL,
+           .snapshot = my_snapshot,
+           .priv     = buf,
+       };
+   }
+
+Register it alongside the built-in metrics during initialization:
+
+.. code-block:: c
+
+   static uint32_t my_buf[MY_NUM_CLASSES];
+   static nrf_edgeai_obsv_metric_t my_metric;
+
+   my_metric_create(&my_metric, my_buf, MY_NUM_CLASSES);
+   nrf_edgeai_obsv_init(&obsv_ctx, &model);
+   nrf_edgeai_obsv_register(&obsv_ctx, &my_metric, NULL);
+
+.. _nrf_edgeai_obsv_buffer_config:
+
+Configuration
+*************
+
+To use the observability library, enable the ``CONFIG_NRF_EDGEAI_OBSV`` Kconfig option in your :file:`prj.conf` file.
+Enable at least one metric to start collecting data:
+
+* Built-in metrics:
+
+  * For the :ref:`transition matrix <nrf_edgeai_obsv_metrics_built_in_transition>`, enable
+    ``CONFIG_NRF_EDGEAI_OBSV_METRIC_TRANSITION_MATRIX``.
+  * For the :ref:`probability distribution <nrf_edgeai_obsv_metrics_built_in_probability>`, enable ``CONFIG_NRF_EDGEAI_OBSV_METRIC_PROBS_DISTRIBUTION``, and set the number of histogram bins through ``CONFIG_NRF_EDGEAI_OBSV_PROBS_DISTRIBUTION_BIN_NUM``.
+
+* Custom metrics:
+
+  * If you wish to implement custom metrics, set ``CONFIG_NRF_EDGEAI_OBSV_EXTRA_ENCODE_BYTES`` to reserve buffer space for CBOR encoding.
+    See :ref:`Buffer sizing for CBOR encoding <nrf_edgeai_obsv_buffer_sizing>` for how to calculate the value.
+
+For a full list of available Kconfig options, refer to the following sections:
+
+Core library
+============
+
+.. options-from-kconfig:: /lib/nrf_edgeai_obsv/Kconfig
+   :show-type:
+
+Memfault CDR transport
+======================
+
+The Memfault module registers a CDR source with the Memfault SDK; see `Memfault Custom Data Recording`_ for callback semantics, payload metadata, and upload limits, `Memfault`_ for the vendor platform, and `Memfault in nRF Connect SDK`_ for integration in |NCS|.
+
+.. options-from-kconfig:: /lib/nrf_edgeai_obsv_memfault/Kconfig
+   :show-type:
+
+Usage
+*****
+
+The observability library works with any inference engine that produces a probability vector per inference.
+For a complete example using the nRF Edge AI API, see :ref:`quick_start_nrf_edgeai`.
+
+To integrate the library into your application, complete the following steps:
+
+1. Initialize an observability context with model metadata using the :c:func:`nrf_edgeai_obsv_init` function.
+#. Allocate metric storage and initialize each metric descriptor using the :c:func:`nrf_edgeai_obsv_metric_tm_create` and :c:func:`nrf_edgeai_obsv_metric_pd_create` functions.
+#. Register the metrics with the context using the :c:func:`nrf_edgeai_obsv_register` function.
+#. Bind the Memfault transport once at application startup using the :c:func:`nrf_edgeai_obsv_memfault_init` function.
+#. Call the :c:func:`nrf_edgeai_obsv_update` function after every inference.
+#. Call the :c:func:`nrf_edgeai_obsv_memfault_collect` function periodically, or enable the ``CONFIG_NRF_EDGEAI_OBSV_MEMFAULT_AUTO_COLLECT`` Kconfig option.
+
+The following example shows minimal initialization with both built-in metrics and Memfault upload over Bluetooth using MDS:
+
+.. code-block:: c
+
+   #include <nrf_edgeai_obsv/nrf_edgeai_obsv.h>
+   #include <nrf_edgeai_obsv/nrf_edgeai_obsv_metrics.h>
+   #include <nrf_edgeai_obsv/nrf_edgeai_obsv_memfault.h>
+
+   #define NUM_CLASSES 4
+
+   static nrf_edgeai_obsv_ctx_t obsv_ctx;
+
+   /* uint32_t arrays give natural alignment required by the storage macros. */
+   static uint32_t tm_buf[NRF_EDGEAI_OBSV_TM_STORAGE_BYTES(NUM_CLASSES) / sizeof(uint32_t)];
+   static uint32_t pd_buf[NRF_EDGEAI_OBSV_PD_STORAGE_BYTES(NUM_CLASSES) / sizeof(uint32_t)];
+   static nrf_edgeai_obsv_metric_t tm_metric;
+   static nrf_edgeai_obsv_metric_t pd_metric;
+
+   void observability_init(void)
+   {
+       const nrf_edgeai_obsv_model_info_t model = {
+           .model_id    = 1,
+           .num_classes = NUM_CLASSES,
+           .version     = 1,
+       };
+
+       nrf_edgeai_obsv_init(&obsv_ctx, &model);
+
+       nrf_edgeai_obsv_metric_tm_create(&tm_metric, tm_buf, NUM_CLASSES);
+       nrf_edgeai_obsv_register(&obsv_ctx, &tm_metric, NULL);
+
+       nrf_edgeai_obsv_metric_pd_create(&pd_metric, pd_buf, NUM_CLASSES);
+       nrf_edgeai_obsv_register(&obsv_ctx, &pd_metric, NULL);
+
+       /* Bind the Memfault transport. */
+       nrf_edgeai_obsv_memfault_init(&obsv_ctx);
+   }
+
+   void on_inference_done(const float *probs)
+   {
+       /* Feed inference result to all registered metrics. */
+       nrf_edgeai_obsv_update(&obsv_ctx, probs);
+   }
+
+When ``CONFIG_NRF_EDGEAI_OBSV_MEMFAULT_AUTO_COLLECT`` is disabled, call :c:func:`nrf_edgeai_obsv_memfault_collect` manually at the interval that matches your transport's drain cadence (for example, once per hour for HTTP, or before each Bluetooth LE connection).
+
+When using a custom transport instead of Memfault, use :c:func:`nrf_edgeai_obsv_encode_list` to encode one or more contexts into a caller-supplied buffer in a single CBOR list:
+
+.. code-block:: c
+
+   uint8_t cbor_buf[NRF_EDGEAI_OBSV_ENCODE_LIST_BUF_SIZE(1)];
+   nrf_edgeai_obsv_ctx_t *ctxs[] = {&obsv_ctx};
+
+   size_t len = nrf_edgeai_obsv_encode_list(ctxs, ARRAY_SIZE(ctxs), cbor_buf, sizeof(cbor_buf));
+   if (len > 0) {
+       my_transport_send(cbor_buf, len);
+   }
+
+Thread safety
+=============
+
+The following functions acquire ``ctx->lock`` internally and are safe to call from different threads:
+
+* :c:func:`nrf_edgeai_obsv_update`
+* :c:func:`nrf_edgeai_obsv_encode`
+* :c:func:`nrf_edgeai_obsv_for_each_metric`
+
+The :c:func:`nrf_edgeai_obsv_memfault_collect` function uses two mutexes:
+
+* ``obsv_mflt_lock`` protects the staging buffer and the registered context list.
+* Each ``ctx->lock`` is acquired by :c:func:`nrf_edgeai_obsv_encode_list` during encoding.
+
+To avoid lock inversion, ``obsv_mflt_lock`` is released before encoding begins, so inference is never blocked by an ongoing collect.
+
+Dependencies
+************
+
+Observability core with Zephyr wrapper
+======================================
+
+This module uses the following Zephyr libraries:
+
+* `ZCBOR`_
+
+Memfault CDR transport module
+=============================
+
+This module uses the following |EAI| library:
+
+* :file:`lib/nrf_edgeai_obsv`
+
+This module uses the following Zephyr libraries:
+
+* `Logging`_
+
+This module uses the following |NCS| libraries:
+
+* `Memfault in nRF Connect SDK`_
+
+.. _nrf_edgeai_obsv_lib_api:
+
+API Reference
+*************
+
+Zephyr context
+==============
+
+.. doxygengroup:: nrf_edgeai_obsv
+
+Portable core
+=============
+
+.. doxygengroup:: nrf_edgeai_obsv_core
+
+Metrics
+=======
+
+.. doxygengroup:: nrf_edgeai_obsv_metrics
+
+Memfault CDR transport
+======================
+
+.. doxygengroup:: nrf_edgeai_obsv_memfault

--- a/doc/links.txt
+++ b/doc/links.txt
@@ -32,6 +32,7 @@
 .. _`nRF Connect for Visual Studio Code`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/index.html
 .. _`nRF Connect for Visual Studio Code: Thread Viewer`: https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/reference/ui_panel.html#thread-viewer
 .. _`Nordic central UART sample`: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/samples/bluetooth/central_uart/README.html
+.. _`Memfault in nRF Connect SDK`: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/libraries/debug/memfault_ncs.html
 .. _`nRF54L15TAG`: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/zephyr/boards/nordic/nrf54l15tag/doc/index.html
 .. _`Nordic Edge AI Lab Documentation`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/index.html
 .. _`Nordic Edge AI Lab Quick Start Guide`: https://docs.nordicsemi.com/bundle/edge-ai-lab/page/doc/get_started.html
@@ -79,12 +80,18 @@
 .. _`Simulated sensor driver`: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/drivers/sensor_sim.html
 
 .. _`Logging`: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/zephyr/services/logging/index.html#logging-api
+.. _`ZCBOR`: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/zephyr/services/serialization/cbor.html#cbor-api
 .. _`Power Management`: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/zephyr/services/pm/index.html#power-management
 .. _`Sensor`: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/zephyr/hardware/peripherals/sensor/index.html#sensor
 .. _`Nordic UART Service (NUS)`: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/libraries/bluetooth/services/nus.html
 .. _`TensorFlow Lite for Microcontrollers: Hello World`: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/zephyr/samples/modules/tflite-micro/hello_world/README.html#tflite-hello-world
 .. _`HID Service`: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/libraries/bluetooth/services/hids.html
 .. _`Video`: https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/zephyr/hardware/peripherals/video.html
+
+.. ### Source: memfault.com
+
+.. _`Memfault`: https://memfault.com/
+.. _`Memfault Custom Data Recording`: https://docs.memfault.com/docs/mcu/custom-data-recording
 
 .. ### Source: edgeimpulse.com
 

--- a/doc/quick_start/axon_driver.rst
+++ b/doc/quick_start/axon_driver.rst
@@ -117,3 +117,10 @@ Build your application and flash it to your Nordic device.
 
 Monitor performance metrics like inference time and current consumption to ensure your application meets requirements.
 The direct driver access gives you the control needed to fine-tune performance for demanding embedded AI applications.
+
+Next steps
+**********
+
+See further documentation:
+
+* Add runtime monitoring of model outputs with :ref:`nrf_edgeai_obsv_lib`.

--- a/doc/quick_start/edge_impulse.rst
+++ b/doc/quick_start/edge_impulse.rst
@@ -139,3 +139,4 @@ To work on advanced solutions, see further documentation:
 
 * Explore advanced features - Dive deeper into the `Edge Impulse C++ SDK`_ documentation to discover advanced capabilities like anomaly detection, continuous learning, and custom processing blocks.
 * Direct Axon NPU control - If you use Axon and need lower‑level access to the NPU beyond what |EI| provides, see :ref:`quick_start_axon_driver_app_development` to learn how to implement custom inference pipelines with the Axon driver API.
+* Add runtime monitoring of model outputs with :ref:`nrf_edgeai_obsv_lib`.

--- a/doc/quick_start/nrf_edgeai.rst
+++ b/doc/quick_start/nrf_edgeai.rst
@@ -151,3 +151,4 @@ Next steps
 See further documentation:
 
 * Read through :ref:`nrf_edgeai_lib` to understand more about the library and its capabilities.
+* Add runtime monitoring of model outputs with :ref:`nrf_edgeai_obsv_lib`.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,3 +3,4 @@ sphinx>=7.2,<8.2
 sphinx-ncs-theme<1.1
 sphinx-tabs>=3.4
 sphinx-copybutton
+sphinxcontrib-plantuml>=0.27


### PR DESCRIPTION
Adds Sphinx documentation for the nRF Edge AI Observability library (`nrf_edgeai_obsv`).

Changes:

- **New library page** — `doc/libraries/nrf_edgeai_obsv.rst`: overview, architecture (PlantUML), API usage, Kconfig, Memfault CDR transport, and examples.
- **Navigation** — Entry in `doc/libraries.rst` toctree; cross-links from `nrf_edgeai.rst` and quick-start guides (nRF Edge AI, Axon, Edge Impulse).
- **External links** — Memfault and ZCBOR targets in `doc/links.txt`.
- **Doc build** — PlantUML support (`sphinxcontrib-plantuml`, CI `plantuml` package), `custom.css`, Doxygen `PREDEFINED` for obsv Kconfig symbols, Kconfig pulled into external content.