### PR TITLE
ww_kws: add low power configuration - prj_release.conf

### DIFF
--- a/applications/ww_kws/prj_release.conf
+++ b/applications/ww_kws/prj_release.conf
@@ -1,0 +1,67 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# ---------------------------------------------------------------------------
+# Core application dependencies
+# ---------------------------------------------------------------------------
+
+# nRF Edge AI inference runtime and Axon NPU driver
+CONFIG_NRF_EDGEAI=y
+
+# nRF Edge AI dependencies
+CONFIG_NRF_AXON=y
+CONFIG_NEWLIB_LIBC=y
+CONFIG_FPU=y
+
+# Size of interlayer buffer to fit model
+CONFIG_NRF_AXON_INTERLAYER_BUFFER_SIZE=6656
+
+# Size of psum buffer to fit model
+CONFIG_NRF_AXON_PSUM_BUFFER_SIZE=0
+
+# ---------------------------------------------------------------------------
+# Required peripherals
+# ---------------------------------------------------------------------------
+
+# Enable GPIO for LEDs and AUDIO for DMIC
+CONFIG_GPIO=y
+CONFIG_AUDIO=y
+CONFIG_AUDIO_DMIC=y
+CONFIG_SERIAL=y
+CONFIG_UART_ASYNC_API=y
+
+# ---------------------------------------------------------------------------
+# Power management
+# ---------------------------------------------------------------------------
+CONFIG_PM=y
+CONFIG_PM_DEVICE=y
+CONFIG_PM_DEVICE_RUNTIME=y
+
+
+# ---------------------------------------------------------------------------
+# Disable all debug and logging infrastructure
+# ---------------------------------------------------------------------------
+CONFIG_LOG=n
+CONFIG_PRINTK=n
+CONFIG_CONSOLE=n
+CONFIG_UART_CONSOLE=n
+CONFIG_SHELL=n
+CONFIG_BOOT_BANNER=n
+CONFIG_NCS_BOOT_BANNER=n
+CONFIG_ASSERT=n
+CONFIG_DEBUG=n
+
+# ---------------------------------------------------------------------------
+# Library size reduction
+# ---------------------------------------------------------------------------
+CONFIG_CBPRINTF_NANO=y
+
+# ---------------------------------------------------------------------------
+# Compiler and linker optimizations
+# ---------------------------------------------------------------------------
+CONFIG_SPEED_OPTIMIZATIONS=y
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y

--- a/applications/ww_kws/src/control_output.c
+++ b/applications/ww_kws/src/control_output.c
@@ -87,14 +87,20 @@ static void control_output_work_handler(struct k_work *work)
 		buffer_len = strlen(buffer);
 		break;
 
-	case CONTROL_MESSAGE_KW_SPOTTED:
-		buffer = output_buffer;
-		buffer_len = snprintf(output_buffer, sizeof(output_buffer),
-				      messages[message_item.type], message_item.name);
-		__ASSERT(buffer_len >= 0, "Error in snprintf call (%d)", buffer_len);
-		__ASSERT(buffer_len < sizeof(output_buffer), "Output buffer is too small");
+	case CONTROL_MESSAGE_KW_SPOTTED: {
+		int ret = snprintf(output_buffer, sizeof(output_buffer),
+				   messages[message_item.type], message_item.name);
 
+		if (ret < 0) {
+			atomic_set(&uart_busy, false);
+			k_msgq_get(&control_msg_queue, &message_item, K_NO_WAIT);
+			LOG_ERR("snprintf failed (%d)", ret);
+			return;
+		}
+		buffer = output_buffer;
+		buffer_len = MIN((size_t)ret, sizeof(output_buffer) - 1);
 		break;
+	}
 	default:
 		atomic_set(&uart_busy, false);
 		k_msgq_get(&control_msg_queue, &message_item, K_NO_WAIT);


### PR DESCRIPTION
## Motivation

The default `prj.conf` enables the full logging and debug stack which
is unnecessary in a production build and contributes measurable idle
current. This PR adds `prj_release.conf` as a separate build overlay
that targets the lowest practical power consumption for the ww_kws
application running on nRF54LM20.

## Changes

- Disable `LOG`, `PRINTK`, `CONSOLE`, `UART_CONSOLE`, `SHELL`,
  `ASSERT`, and `DEBUG` — removes log buffers, the log thread, and
  the console UART driver initialisation entirely.
- Enable `PM`, `PM_DEVICE`, and `PM_DEVICE_RUNTIME` — UART is
  power-gated between detection events; GPIO domain idles between
  LED blink callbacks.
- Enable `CBPRINTF_NANO` — replaces the ~1 kB floating-point capable
  cbprintf with a minimal variant; safe because no cbprintf callers
  remain after logging is disabled.
- Enable `SPEED_OPTIMIZATIONS`, `LTO`, and
  `ISR_TABLES_LOCAL_DECLARATION` — shorter inference time per audio
  block and no flash lookup on interrupt entry.

## Testing

Built for `nrf54lm20dk/nrf54lm20b/cpuapp` using:
```
west build -b nrf54lm20dk/nrf54lm20b/cpuapp \
  -- -DCONF_FILE=prj_release.conf
```
Wakeword and keyword detection verified functional over VCOM0.
No regression observed against the `prj.conf` debug build.

### Memory

| Region | `prj.conf` | `prj_release.conf` | Δ | % |
|--------|----------:|------------------:|--:|--:|
| FLASH  | 514,760 B | 478,388 B | −36,372 B | −7.1% |
| RAM    |  55,016 B |  51,744 B |  −3,272 B | −5.9% |

### Current consumption

| State | `prj.conf` | `prj_release.conf` | Δ | % |
|-------|----------:|------------------:|--:|--:|
| WW    | 1.10 mA | 0.66 mA | −0.44 mA | −40.0% |
| KWS   | 1.62 mA | 1.21 mA | −0.41 mA | −25.3% |

### Ref: NCSDK-38123