### PR TITLE
applications: ww_kws: Clarify model getter step in README

### DIFF
--- a/applications/ww_kws/README.rst
+++ b/applications/ww_kws/README.rst
@@ -48,7 +48,7 @@ You can replace the bundled models using the `Text to Wake Word Detection <Nordi
       To replace the model used in wakeword detection stage complete the following steps:
 
       1. Replace the files inside :file:`src/ww/nrf_edgeai_generated` directory with files downloaded from `Nordic Edge AI Lab`_.
-      #. Update :c:func:`ww_init` to get a pointer to the proper model instance from generated files.
+      #. In :c:func:`ww_init`, set the ``ww_model`` pointer using the model getter from the generated files.
       #. Adjust the Kconfig options to tune wakeword detection postprocessing to your model.
 
 
@@ -57,7 +57,7 @@ You can replace the bundled models using the `Text to Wake Word Detection <Nordi
       To replace the model used in keyword spotting stage complete the following steps:
 
       1. Replace the files inside :file:`src/kws/nrf_edgeai_generated` directory with files downloaded from `Nordic Edge AI Lab`_.
-      #. Update :c:func:`kws_init` to get a pointer to the proper model instance from generated files.
+      #. In :c:func:`kws_init`, set the ``kws_model`` pointer using the model getter from the generated files.
       #. Update the ``keyword_class`` enumeration and ``keyword_detection_ctxs`` array in the :file:`src/kws/kws.c` file to match keywords spotted by selected model.
       #. Adjust the Kconfig options to tune keyword spotting postprocessing to selected model.
 


### PR DESCRIPTION
The "replace the model" instructions told users to "get a pointer to the proper model instance", which was unclear and did not explain the manual rename required when the generated model getter uses a model-specific name (for example nrf_edgeai_user_model_google_commands) instead of the expected nrf_edgeai_user_model_kws / _wakeword.

Reword both the wakeword and keyword spotting steps to state that the ww_model / kws_model pointer must be set using the model getter provided by the generated files, so the getter name is updated to match the downloaded archive.

Ref: NCSDK-39707