### PR TITLE
tools: data_forwarder_host: Add sensor data forwarder host GUI

### DIFF
--- a/tools/data_forwarder_host/.gitignore
+++ b/tools/data_forwarder_host/.gitignore
@@ -5,3 +5,13 @@ recordings/
 __pycache__/
 *.py[cod]
 *.egg-info/
+
+# Standalone binary build (PyInstaller) and its isolated build venv
+/build/
+/dist/
+/.build-venv/
+
+# A parent .gitignore ignores `build_*` (meant for build output dirs); that also
+# matches this build SCRIPT by name. It is a tracked source deliverable, so
+# re-include it explicitly.
+!scripts/build_linux_binary.sh

--- a/tools/data_forwarder_host/.gitignore
+++ b/tools/data_forwarder_host/.gitignore
@@ -1,0 +1,7 @@
+# Default recordings output directory (REQ-210/REQ-211)
+recordings/
+
+# Python caches & build artefacts
+__pycache__/
+*.py[cod]
+*.egg-info/

--- a/tools/data_forwarder_host/README.md
+++ b/tools/data_forwarder_host/README.md
@@ -71,6 +71,34 @@ By default, source acquisition (byte reading + COBS/CBOR decode) runs in a
 separate child process so the GUI stays responsive regardless of backend load.
 Set `DFH_SINGLE_PROCESS=1` to fall back to the legacy in-GUI acquisition path.
 
+## Standalone single-file binary (no install on the target)
+
+To run the application on a machine that has **no Python and no dependencies
+installed**, build a single self-contained executable with PyInstaller:
+
+```bash
+./scripts/build_linux_binary.sh
+```
+
+This produces one file, `dist/data-forwarder-host`, that bundles the Python
+interpreter, Qt6 and every dependency. Copy that single file to any reasonably
+recent x86_64 Ubuntu machine and run it directly — nothing has to be installed
+there:
+
+```bash
+./data-forwarder-host
+```
+
+Notes:
+
+- Build on the **oldest** Ubuntu you intend to support: glibc is forward- but
+  not backward-compatible, so a binary built on 22.04 runs on 22.04+, while one
+  built on 24.04 may not run on 22.04.
+- The build is driven by `data_forwarder_host.spec`; `scripts/build_linux_binary.sh`
+  just provisions an isolated build virtualenv (kept out of git) and invokes
+  PyInstaller against that spec.
+- The binary is large (~100 MB) because the whole Qt6 stack is embedded.
+
 ## First-time use
 
 1. Launch the application — it starts blank, with no session open and no tabs.

--- a/tools/data_forwarder_host/README.md
+++ b/tools/data_forwarder_host/README.md
@@ -1,0 +1,135 @@
+<!--
+Copyright (c) 2026 Nordic Semiconductor ASA
+SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+-->
+
+# Data Forwarder Host
+
+`data_forwarder_host` is a cross-platform desktop GUI that receives, visualises,
+records and exports sensor data forwarded from an nRF device over **UART** or
+**BLE NUS** (Nordic UART Service). Frames use the device's COBS + CBOR v1
+framing; multiple capture sessions can run side by side in their own tabs.
+
+The matching device-side firmware is the
+[`data_forwarder` sample](../../samples/data_forwarder) (`edge-ai/samples/data_forwarder`),
+which produces the COBS/CBOR `sensor-data` stream this host decodes. For BLE it
+advertises the Nordic UART Service as `nRF DataFwd`. Without that firmware
+running on a connected device there is no data to receive.
+
+## Requirements
+
+- Python **3.12** or newer.
+- Linux, Windows or macOS.
+- An nRF device running the [`data_forwarder` firmware
+  sample](../../samples/data_forwarder) (`edge-ai/samples/data_forwarder`).
+- For UART sources: permission to access the serial port (on Linux this usually
+  means membership of the `dialout` group).
+
+## Install
+
+> **Ubuntu / Debian:** Qt 6 (PySide6) needs the XCB cursor library at runtime.
+> If the app fails to start with an `xcb` platform-plugin error
+> (`Could not load the Qt platform plugin "xcb"`), install it first:
+>
+> ```bash
+> sudo apt install libxcb-cursor0
+> ```
+>
+> On a minimal install you may also need the other XCB runtime libraries
+> (`libxcb-xinerama0`, `libxkbcommon-x11-0`); these are present on a standard
+> Ubuntu desktop.
+
+From this directory (`data_forwarder_host/`), install the requirements:
+
+```bash
+pip install -r requirements.txt
+```
+
+`requirements.txt` uses `pyproject.toml` as the single source of truth, so the
+dependency list lives in exactly one place. Alternatively, install the package
+directly with pip's editable mode:
+
+```bash
+pip install -e .
+```
+
+PySide6 (Qt 6, with QtCharts) is a base dependency and is always installed — the
+application is GUI-only.
+
+## Run
+
+The application is a pure GUI — there is no command-line interface. Launch it in
+any of these equivalent ways:
+
+```bash
+data-forwarder-host          # console script (installed entry point)
+python -m data_forwarder_host
+python main.py
+```
+
+By default, source acquisition (byte reading + COBS/CBOR decode) runs in a
+separate child process so the GUI stays responsive regardless of backend load.
+Set `DFH_SINGLE_PROCESS=1` to fall back to the legacy in-GUI acquisition path.
+
+## First-time use
+
+1. Launch the application — it starts blank, with no session open and no tabs.
+2. Open `Session → New session…`.
+3. Pick a **data source**: **UART** (live serial device) or **BLE NUS** (Nordic
+   UART Service). For BLE NUS, the dialog scans for advertising devices and
+   lets you pick one to connect to (requires a working Bluetooth adapter). If
+   the BLE stream drops frames or runs slower than expected, see
+   [docs/ble_throughput_tuning.md](docs/ble_throughput_tuning.md) for an
+   ordered, OS-aware speed-up procedure.
+4. Set any other session details, then click **Create session** to open a
+   per-session tab; streaming starts automatically.
+5. Enter a recording **label**, choose an output directory, then press
+   **Record** to capture data. Recordings are buffered in RAM and dumped to
+   a CSV on **Stop**; when the output directory is left blank they are written
+   to `recordings/` next to the package. Each recording writes a `{stem}.csv`
+   data file plus a paired `{stem}.txt` metadata sidecar (host, transport,
+   timing, device session info, channels and errors). A banner shows the last
+   saved CSV with shortcuts to open the file or its containing folder.
+
+The **View** menu toggles the error and log panels, the per-tab visualisation
+panels (Combined View, Individual Channels, Channel ASCII, Decoded Frames),
+the theme (System / Light / Dark) and the log level. Session configuration can
+be saved and reopened via the **Session** menu. Live bandwidth, host metrics
+and First Failure Data Capture (FFDC) details are surfaced on each tab.
+
+## Architecture (short)
+
+The application is strictly layered. The acquisition/transport layers are fully
+**Qt-free** (no PySide6 imports), so they can run inside the headless child
+acquisition process; the data-model, session and GUI layers run in the GUI
+process and use Qt (PySide6 `QObject`/`Signal`):
+
+- `platform/` — *(Qt-free)* OS-specific adapters (serial-port enumeration,
+  access diagnostics).
+- `source/` — *(Qt-free)* byte sources: `uart` (pyserial) and `ble_nus`
+  (BLE NUS, via bleak).
+- `protocol/` — *(Qt-free)* frame decoders (COBS + CBOR v1) and the framing
+  primitives.
+- `pipeline/` — *(Qt-free)* out-of-process acquisition: a `spawn` child process
+  reads the source and decodes frames, while the GUI process drains decoded
+  envelopes over an IPC queue (toggle with `DFH_SINGLE_PROCESS`).
+- `core/` — per-session data model, rolling channel buffers, decimation, the
+  recorder, the CSV writer, the metadata sidecar and the metrics (bandwidth,
+  host, transfer, pipeline). *Uses Qt:* `data_model`, `recorder` and
+  `error_log` are `QObject`s that emit signals to the GUI; the CSV writer,
+  sidecar and the metrics dataclasses are plain Python.
+- `session/` — *(uses Qt)* `ForwardingSession` (source + decoder + I/O),
+  `SessionController` (per-tab façade) and `SessionManager` (app-wide registry).
+- `utils/` — standard paths, logging, version and small helpers (plus one
+  optional Qt-based debug-stream helper).
+- `gui/` — *(uses Qt)* PySide6 main window, menus, dialogs (`gui/dialogs/`) and
+  per-session tab widgets (`gui/widgets/`, including the QtCharts plots).
+
+## License
+
+All files carry the SPDX header:
+
+```
+Copyright (c) 2026 Nordic Semiconductor ASA
+SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+```

--- a/tools/data_forwarder_host/__init__.py
+++ b/tools/data_forwarder_host/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Data Forwarder Host — receives, visualises and exports sensor data from an nRF device."""
+
+__version__ = "0.1.0"
+
+
+def main() -> int:
+    """GUI entry point (re-exported from :mod:`data_forwarder_host.app`)."""
+    from data_forwarder_host.app import main as _main
+
+    return _main()
+
+
+__all__ = ["__version__", "main"]

--- a/tools/data_forwarder_host/__main__.py
+++ b/tools/data_forwarder_host/__main__.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Entry point for ``python -m data_forwarder_host``."""
+
+from __future__ import annotations
+
+import sys
+
+
+def _run() -> int:
+    # Repair sys.path so the ``platform/`` subpackage cannot shadow stdlib when
+    # the package dir is the CWD (e.g. ``python -m`` run from inside it).
+    from data_forwarder_host.utils.syspath import repair_launcher_path
+
+    repair_launcher_path()
+
+    from data_forwarder_host import main
+
+    return main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run())

--- a/tools/data_forwarder_host/app.py
+++ b/tools/data_forwarder_host/app.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Application bootstrap — Settings, AppContext, Application, main().
+
+There is no command-line interface and no headless mode: the application is a
+GUI launched via ``python3 -m data_forwarder_host``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from dataclasses import asdict, dataclass, field
+
+from data_forwarder_host.platform.base import PlatformAdapter
+from data_forwarder_host.platform.factory import detect_platform
+from data_forwarder_host.session.manager import SessionManager
+from data_forwarder_host.utils.logging import configure_logging
+from data_forwarder_host.utils.paths import settings_file
+from data_forwarder_host.utils.version import get_version
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Linux display helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_xauthority() -> str | None:
+    """Return the X authority file path by scanning /proc for a user process
+    that already has XAUTHORITY set (e.g. gnome-shell, gnome-session).
+
+    This is needed in terminals (such as the nRF Connect SDK terminal in VS
+    Code) that inherit DISPLAY from the compositor session but not the
+    per-session XAUTHORITY path.
+    """
+    import glob
+
+    uid = os.getuid()
+    for env_path in glob.iglob("/proc/*/environ"):
+        try:
+            if os.stat(env_path).st_uid != uid:
+                continue
+            with open(env_path, "rb") as fh:
+                for token in fh.read().split(b"\x00"):
+                    if token.startswith(b"XAUTHORITY="):
+                        path = token[11:].decode(errors="replace")
+                        if os.path.isfile(path):
+                            return path
+        except OSError:
+            continue
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Settings:
+    """Persistent application settings.
+
+    Spill thresholds are internal recorder constants and are intentionally NOT
+    represented here.
+    """
+
+    window_geometry_b64: str = ""
+    theme: str = "SYSTEM"
+    plot_window_seconds_default: float = 10.0
+    log_level: str = "INFO"
+
+    def save(self) -> None:
+        try:
+            settings_file().write_text(
+                json.dumps(asdict(self), indent=2, sort_keys=True), encoding="utf-8"
+            )
+        except OSError:
+            log.exception("failed to save settings")
+
+    @classmethod
+    def load(cls) -> "Settings":
+        path = settings_file()
+        if not path.exists():
+            return cls()
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            log.exception("failed to load settings; using defaults")
+            return cls()
+        s = cls()
+        for k, v in data.items():
+            if hasattr(s, k):
+                setattr(s, k, v)
+        return s
+
+
+# ---------------------------------------------------------------------------
+# AppContext
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AppContext:
+    version: str
+    platform: PlatformAdapter
+    settings: Settings
+    session_manager: SessionManager = field(default_factory=SessionManager)
+
+
+# ---------------------------------------------------------------------------
+# Application
+# ---------------------------------------------------------------------------
+
+
+class Application:
+    """Owns the AppContext and the Qt QApplication."""
+
+    def __init__(self, ctx: AppContext) -> None:
+        self.ctx = ctx
+
+    def run(self) -> int:
+        # ── Linux display / platform bootstrap ────────────────────────────
+        # Must happen BEFORE Qt is imported so that dlopen() calls made by the
+        # Qt platform plugins pick up the correct libraries.
+        if sys.platform.startswith("linux"):
+            _sys_lib = "/usr/lib/x86_64-linux-gnu"
+            if os.path.isdir(_sys_lib):
+                _ld = os.environ.get("LD_LIBRARY_PATH", "")
+                if _sys_lib not in _ld.split(":"):
+                    os.environ["LD_LIBRARY_PATH"] = (
+                        f"{_sys_lib}:{_ld}" if _ld else _sys_lib
+                    )
+
+            if os.environ.get("WAYLAND_DISPLAY"):
+                os.environ.setdefault("QT_QPA_PLATFORM", "wayland")
+                _decor_dir = f"{_sys_lib}/libdecor/plugins-1"
+                if os.path.isdir(_decor_dir):
+                    os.environ.setdefault("LIBDECOR_PLUGIN_DIR", _decor_dir)
+            elif os.environ.get("DISPLAY"):
+                if not os.environ.get("XAUTHORITY"):
+                    _xauth = _find_xauthority()
+                    if _xauth:
+                        os.environ["XAUTHORITY"] = _xauth
+                os.environ.setdefault("QT_QPA_PLATFORM", "xcb")
+
+        from PySide6.QtWidgets import QApplication
+
+        from data_forwarder_host.gui.main_window import MainWindow
+        from data_forwarder_host.gui.theme import Theme, apply_theme
+
+        qt_app = QApplication.instance() or QApplication(sys.argv)
+        qt_app.setApplicationName("Data Forwarder")
+        qt_app.setOrganizationName("Nordic Semiconductor")
+        # Force the Fusion style so our explicit light/dark palettes are honoured
+        # consistently across platforms. The native styles (e.g. GTK/Adwaita on
+        # Linux, the Windows style) only partially apply a custom QPalette, which
+        # is what produced the unreadable dark-background / dark-text mix.
+        qt_app.setStyle("Fusion")
+
+        try:
+            theme = Theme[self.ctx.settings.theme]
+        except KeyError:
+            theme = Theme.SYSTEM
+        apply_theme(theme)
+
+        window = MainWindow(self.ctx)
+        window.show()
+        exit_code = qt_app.exec()
+        self.ctx.settings.save()
+        return int(exit_code)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """GUI entry point. Returns a process exit code."""
+    settings = Settings.load()
+    configure_logging(settings.log_level)
+    ctx = AppContext(
+        version=get_version(),
+        platform=detect_platform(),
+        settings=settings,
+    )
+    app = Application(ctx)
+    try:
+        return app.run()
+    except Exception as exc:  # pragma: no cover
+        log.exception("fatal: %s", exc)
+        return 1

--- a/tools/data_forwarder_host/core/__init__.py
+++ b/tools/data_forwarder_host/core/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Per-session core — data model, ring buffers, recorder, error log, event bus."""

--- a/tools/data_forwarder_host/core/bandwidth.py
+++ b/tools/data_forwarder_host/core/bandwidth.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Real-time bandwidth measurement over a trailing time window.
+
+:class:`BandwidthMeter` is a pure, GUI-free accumulator: callers feed it byte
+and message events as they arrive and read back throughput rates computed over a
+configurable trailing window. ``channels/s`` is derived from ``messages/s`` and
+the session's fixed per-message channel count.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class BandwidthSample:
+    """A snapshot of the three throughput rates."""
+
+    bytes_per_second: float
+    messages_per_second: float
+    channels_per_second: float
+
+
+class BandwidthMeter:
+    """Sliding-window throughput meter.
+
+    Events are timestamped via *time_fn* (monotonic seconds by default) and
+    rates are the count within the trailing *window_seconds* divided by the
+    **effective** window, which is the smaller of *window_seconds* and the time
+    elapsed since measurement started. Early on — e.g. 3 s into a 10 s window —
+    the rate is averaged over the 3 s actually observed, not the full 10 s, so
+    a partially-filled window is not under-reported.
+    """
+
+    def __init__(
+        self,
+        window_seconds: float = 1.0,
+        *,
+        time_fn=time.monotonic,
+    ) -> None:
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be positive")
+        self._window = float(window_seconds)
+        self._time_fn = time_fn
+        # Each deque holds (timestamp, value); messages use value == 1.
+        self._byte_events: deque[tuple[float, int]] = deque()
+        self._msg_events: deque[float] = deque()
+        # Time of the first event since the last reset; used to cap the divisor
+        # to the data actually available.
+        self._start_time: float | None = None
+
+    @property
+    def window_seconds(self) -> float:
+        return self._window
+
+    def set_window_seconds(self, window_seconds: float) -> None:
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be positive")
+        self._window = float(window_seconds)
+
+    def add_bytes(self, n: int, *, now: float | None = None) -> None:
+        """Record *n* received bytes at the current (or supplied) time."""
+        if n <= 0:
+            return
+        t = self._time_fn() if now is None else now
+        if self._start_time is None:
+            self._start_time = t
+        self._byte_events.append((t, int(n)))
+
+    def add_message(self, *, now: float | None = None) -> None:
+        """Record one decoded message at the current (or supplied) time."""
+        t = self._time_fn() if now is None else now
+        if self._start_time is None:
+            self._start_time = t
+        self._msg_events.append(t)
+
+    def reset(self) -> None:
+        self._byte_events.clear()
+        self._msg_events.clear()
+        self._start_time = None
+
+    def _evict(self, now: float) -> None:
+        cutoff = now - self._window
+        while self._byte_events and self._byte_events[0][0] < cutoff:
+            self._byte_events.popleft()
+        while self._msg_events and self._msg_events[0] < cutoff:
+            self._msg_events.popleft()
+
+    def _effective_window(self, now: float) -> float:
+        """Return the divisor: ``min(window, available)``.
+
+        ``available`` is the time elapsed since the first recorded event. Until
+        the window has filled, rates are averaged over the data actually seen
+        rather than the full (mostly empty) window. Falls back to the full
+        window when no positive elapsed time exists yet.
+        """
+        if self._start_time is None:
+            return self._window
+        available = now - self._start_time
+        if available <= 0:
+            return self._window
+        return min(self._window, available)
+
+    def bytes_per_second(self, *, now: float | None = None) -> float:
+        t = self._time_fn() if now is None else now
+        self._evict(t)
+        total = sum(v for _, v in self._byte_events)
+        return total / self._effective_window(t)
+
+    def messages_per_second(self, *, now: float | None = None) -> float:
+        t = self._time_fn() if now is None else now
+        self._evict(t)
+        return len(self._msg_events) / self._effective_window(t)
+
+    def channels_per_second(
+        self, channel_count: int, *, now: float | None = None
+    ) -> float:
+        return self.messages_per_second(now=now) * max(0, int(channel_count))
+
+    def sample(
+        self, channel_count: int, *, now: float | None = None
+    ) -> BandwidthSample:
+        t = self._time_fn() if now is None else now
+        return BandwidthSample(
+            bytes_per_second=self.bytes_per_second(now=t),
+            messages_per_second=self.messages_per_second(now=t),
+            channels_per_second=self.channels_per_second(channel_count, now=t),
+        )

--- a/tools/data_forwarder_host/core/channels.py
+++ b/tools/data_forwarder_host/core/channels.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""NumPy ring buffer for one channel of ``(t_host_ms, value)`` samples."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+
+class ChannelBuffer:
+    """Fixed-capacity FIFO ring buffer storing ``(t_host_ms, value)`` pairs.
+
+    Designed for the live-plot use case: the GUI thread reads recent samples
+    via :meth:`snapshot` while the I/O thread appends via :meth:`append`.
+    Appends are O(1); snapshots copy out the contiguous in-order view.
+
+    The buffer is **not** internally synchronised — the owning ``DataModel``
+    runs on the GUI thread and is the sole writer.
+    """
+
+    DEFAULT_SAMPLE_RATE_HINT_HZ = 1000.0
+    SAFETY = 2.0
+
+    def __init__(self, *, plot_window_seconds: float, sample_rate_hint_hz: float | None = None) -> None:
+        if plot_window_seconds <= 0:
+            raise ValueError("plot_window_seconds must be > 0")
+        rate = sample_rate_hint_hz or self.DEFAULT_SAMPLE_RATE_HINT_HZ
+        cap = max(1024, int(math.ceil(plot_window_seconds * rate * self.SAFETY)))
+        self._capacity = cap
+        self._ts = np.zeros(cap, dtype=np.int64)
+        self._val = np.zeros(cap, dtype=np.float64)
+        self._head = 0    # next write index
+        self._size = 0    # current number of valid samples
+
+    @property
+    def capacity(self) -> int:
+        return self._capacity
+
+    @property
+    def size(self) -> int:
+        return self._size
+
+    def resize(self, *, plot_window_seconds: float, sample_rate_hint_hz: float | None = None) -> None:
+        """Reallocate with a new capacity, preserving the most recent samples."""
+        ts, val = self.snapshot()
+        new = ChannelBuffer(
+            plot_window_seconds=plot_window_seconds,
+            sample_rate_hint_hz=sample_rate_hint_hz,
+        )
+        # Replay the most recent samples that fit.
+        n_keep = min(new._capacity, ts.size)
+        if n_keep:
+            new._ts[:n_keep] = ts[-n_keep:]
+            new._val[:n_keep] = val[-n_keep:]
+            new._head = n_keep % new._capacity
+            new._size = n_keep
+        self._capacity = new._capacity
+        self._ts = new._ts
+        self._val = new._val
+        self._head = new._head
+        self._size = new._size
+
+    def append(self, t_host_ms: int, value: float) -> None:
+        self._ts[self._head] = t_host_ms
+        self._val[self._head] = value
+        self._head = (self._head + 1) % self._capacity
+        if self._size < self._capacity:
+            self._size += 1
+
+    def snapshot(self) -> tuple[np.ndarray, np.ndarray]:
+        """Return contiguous ``(ts, val)`` arrays in chronological order."""
+        if self._size == 0:
+            return np.empty(0, dtype=np.int64), np.empty(0, dtype=np.float64)
+        if self._size < self._capacity:
+            return self._ts[: self._size].copy(), self._val[: self._size].copy()
+        # Full ring: unwrap starting from oldest (== head)
+        ts = np.concatenate((self._ts[self._head :], self._ts[: self._head]))
+        val = np.concatenate((self._val[self._head :], self._val[: self._head]))
+        return ts, val
+
+    def latest_window(self, window_ms: int) -> tuple[np.ndarray, np.ndarray]:
+        """Return the most recent samples spanning ``window_ms`` milliseconds."""
+        ts, val = self.snapshot()
+        if ts.size == 0:
+            return ts, val
+        cutoff = int(ts[-1]) - int(window_ms)
+        mask = ts >= cutoff
+        return ts[mask], val[mask]
+
+    def clear(self) -> None:
+        self._head = 0
+        self._size = 0
+
+    def oldest_ts(self) -> int | None:
+        """Timestamp of the oldest retained sample, or ``None`` if empty."""
+        if self._size == 0:
+            return None
+        if self._size < self._capacity:
+            return int(self._ts[0])
+        return int(self._ts[self._head])
+
+    def retain_window(self, window_ms: int) -> None:
+        """Drop samples older than ``window_ms`` before the newest sample.
+
+        Used to cap idle (not-recording) retention to a bounded time span
+        without resizing the ring. Cheap when nothing needs dropping
+        (a single oldest-timestamp check); otherwise rebuilds from the trimmed
+        chronological view.
+        """
+        if window_ms <= 0 or self._size == 0:
+            return
+        oldest = self.oldest_ts()
+        ts, val = self._ts, self._val
+        newest = int(ts[(self._head - 1) % self._capacity])
+        cutoff = newest - int(window_ms)
+        if oldest is None or oldest >= cutoff:
+            return
+        keep_ts, keep_val = self.snapshot()
+        mask = keep_ts >= cutoff
+        keep_ts, keep_val = keep_ts[mask], keep_val[mask]
+        self.clear()
+        n = keep_ts.size
+        if n:
+            self._ts[:n] = keep_ts
+            self._val[:n] = keep_val
+            self._head = n % self._capacity
+            self._size = n

--- a/tools/data_forwarder_host/core/csv_writer.py
+++ b/tools/data_forwarder_host/core/csv_writer.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Fixed CSV output for a finished recording.
+
+A single CSV file in one predefined format:
+
+* Filename: ``{label}_{session}_{utc}.csv`` where ``{label}`` is the
+  user-defined recording label, ``{session}`` is the session tag, and
+  ``{utc}`` is the host UTC timestamp of the recording-start moment with
+  millisecond resolution.
+* Row 1 (header): ``device_time_ms`` followed by the N channel names and a
+  trailing ``label`` column.
+* Rows 2..M (data): the device timestamp in milliseconds followed by the N
+  channel values, in the same column order as the header, and finally the
+  user-defined recording label (constant for every row).
+
+A companion ``{stem}.txt`` sidecar holding human-readable session metadata
+(transport, device, host OS/timestamps, ``session_info``, channel layout and an
+error summary) is written next to the CSV when *metadata_text* is supplied.
+
+There is no append mode and no configurable filename pattern.
+"""
+
+from __future__ import annotations
+
+import csv
+from datetime import datetime, timezone
+from pathlib import Path
+
+from data_forwarder_host.core.recorder import Recording
+
+DEVICE_TIME_COLUMN = "device_time_ms"
+LABEL_COLUMN = "label"
+
+# --- Recording-start timestamp appended to the CSV filename ------------------
+# Edit these two expressions to change the trailing timestamp in CSV filenames.
+# ``CSV_FILENAME_TIMESTAMP_FORMAT`` is a ``strftime`` pattern applied to the
+# host UTC start time; milliseconds and the ``Z`` suffix are appended by
+# ``CSV_FILENAME_TIMESTAMP_SUFFIX`` to keep millisecond resolution. The rendered
+# stamp is human-readable and uses ONLY digits, dashes and underscores (plus a
+# trailing ``Z`` to mark UTC) — no dots, spaces, colons or other special signs,
+# so it stays filesystem-safe across platforms.
+CSV_FILENAME_TIMESTAMP_FORMAT = "%Y-%m-%d_%H-%M-%S"
+CSV_FILENAME_TIMESTAMP_SUFFIX = "_{ms:03d}Z"
+
+
+def format_filename_timestamp(started_utc: str) -> str:
+    """Render *started_utc* (ISO-8601 ``...Z``) as a filesystem-safe stamp.
+
+    Falls back to a sanitised copy of the input if it cannot be parsed, so a
+    filename is always produced.
+    """
+    try:
+        dt = datetime.strptime(started_utc, "%Y-%m-%dT%H:%M:%S.%fZ").replace(
+            tzinfo=timezone.utc
+        )
+    except (ValueError, TypeError):
+        return "".join(c if c.isalnum() else "-" for c in str(started_utc))
+    ms = dt.microsecond // 1000
+    return dt.strftime(CSV_FILENAME_TIMESTAMP_FORMAT) + CSV_FILENAME_TIMESTAMP_SUFFIX.format(ms=ms)
+
+
+def csv_filename(label: str, session_tag: str, started_utc: str) -> str:
+    """Return ``{label}_{session}_{utc}.csv``."""
+    return f"{csv_stem(label, session_tag, started_utc)}.csv"
+
+
+def csv_stem(label: str, session_tag: str, started_utc: str) -> str:
+    """Return the CSV filename stem (no extension): ``{label}_{session}_{utc}``."""
+    return f"{label}_{session_tag}_{format_filename_timestamp(started_utc)}"
+
+
+def unique_csv_path(directory: Path, stem: str) -> Path:
+    """Return a non-colliding ``directory/<stem>.csv`` path.
+
+    If ``<stem>.csv`` does not exist it is returned unchanged; otherwise an
+    incrementing numeric suffix is appended to the stem until a free path is
+    found: ``<stem>_1.csv``, ``<stem>_2.csv``, … An existing file is never
+    overwritten and the user is never prompted.
+    """
+    base = directory / f"{stem}.csv"
+    if not base.exists():
+        return base
+    n = 1
+    while True:
+        candidate = directory / f"{stem}_{n}.csv"
+        if not candidate.exists():
+            return candidate
+        n += 1
+
+
+def write_recording_csv(recording: Recording, *, label: str, output_dir: str | Path,
+                        metadata_text: str | None = None) -> Path:
+    """Write *recording* to ``{label}_{session}_{utc}.csv`` under *output_dir*.
+
+    Returns the path of the written file. Raises ``ValueError`` if *label* is
+    empty (the Record action must be gated on a defined label). When
+    *metadata_text* is given, a ``{stem}.txt`` metadata sidecar is written next
+    to the CSV.
+
+    This is the blocking convenience wrapper; the GUI uses :class:`RecordingCsvDump`
+    directly so the dump can be driven incrementally off the recording-stop event
+    without freezing the event loop.
+    """
+    return RecordingCsvDump(
+        recording, label=label, output_dir=output_dir, metadata_text=metadata_text
+    ).run_to_completion()
+
+
+class RecordingCsvDump:
+    """Incremental writer for a finished recording's CSV.
+
+    The whole capture is RAM/spill-buffered while recording; at *stop* it must
+    be flushed to a single CSV. For large recordings that flush can take long
+    enough to freeze the GUI if done in one blocking call, so this class writes
+    the file in bounded **chunks**: each :meth:`step` writes at most
+    ``chunk_rows`` rows and returns whether more remain, letting a caller yield
+    to the Qt event loop (or another thread) between chunks while a progress bar
+    tracks :attr:`rows_written` against :attr:`total_rows`.
+
+    The produced file is byte-for-byte identical to the one-shot writer.
+
+    :raises ValueError: if *label* is empty (Record is gated on a label).
+    """
+
+    def __init__(
+        self,
+        recording: Recording,
+        *,
+        label: str,
+        output_dir: str | Path,
+        chunk_rows: int = 4096,
+        metadata_text: str | None = None,
+    ) -> None:
+        if not label or not label.strip():
+            raise ValueError("a recording label is required to write the CSV file")
+        self._row_label = label.strip()
+        out_dir = Path(output_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        stem = csv_stem(self._row_label, recording.session_tag, recording.started_utc)
+        self.path: Path = unique_csv_path(out_dir, stem)
+        self._metadata_text = metadata_text
+        self._channel_names = list(recording.channel_names)
+        self._rows = recording.storage.iter_rows()
+        self._chunk_rows = max(1, int(chunk_rows))
+        # Best-effort total for the progress bar: known for RAM storage, None
+        # (indeterminate) once capture has spilled to disk shards.
+        count = getattr(recording.storage, "row_count", None)
+        self.total_rows: int | None = int(count) if count is not None else None
+        self.rows_written: int = 0
+        self._fh = None
+        self._writer = None
+        self._done = False
+
+    @property
+    def done(self) -> bool:
+        return self._done
+
+    def step(self) -> bool:
+        """Write at most one chunk of rows; return *True* while rows remain.
+
+        Opens the file and writes the header on the first call. On the final
+        call (or on error) the file handle is closed. Returns *False* once the
+        whole recording has been written.
+        """
+        if self._done:
+            return False
+        if self._fh is None:
+            self._fh = self.path.open("w", newline="", encoding="utf-8")
+            self._writer = csv.writer(self._fh)
+            self._writer.writerow([DEVICE_TIME_COLUMN, *self._channel_names, LABEL_COLUMN])
+        try:
+            for _ in range(self._chunk_rows):
+                _t_host_ms, t_device_ms, _seq, _lbl, channels = next(self._rows)
+                device_time = "" if t_device_ms is None else t_device_ms
+                # The trailing label column is the user-defined recording label,
+                # identical on every row (the device's per-row ``lbl`` is ignored).
+                self._writer.writerow([device_time, *channels, self._row_label])
+                self.rows_written += 1
+            return True
+        except StopIteration:
+            self._write_metadata_sidecar()
+            self._close()
+            return False
+        except Exception:
+            self._close()
+            raise
+
+    def run_to_completion(self) -> Path:
+        """Drive :meth:`step` until the whole recording is written; return the path."""
+        while self.step():
+            pass
+        return self.path
+
+    @property
+    def metadata_path(self) -> Path:
+        """Path of the ``{stem}.txt`` metadata sidecar paired with the CSV."""
+        return self.path.with_suffix(".txt")
+
+    def _write_metadata_sidecar(self) -> None:
+        """Write the metadata sidecar next to the CSV (best-effort).
+
+        The sidecar shares the CSV's base name with a ``.txt`` extension. A
+        failure to write it must not abort an otherwise successful CSV dump, so
+        any error is swallowed (the CSV is the primary artefact).
+        """
+        if not self._metadata_text:
+            return
+        try:
+            self.metadata_path.write_text(self._metadata_text, encoding="utf-8")
+        except Exception:
+            pass
+
+    def _close(self) -> None:
+        if self._fh is not None:
+            self._fh.close()
+            self._fh = None
+            self._writer = None
+        self._done = True

--- a/tools/data_forwarder_host/core/data_model.py
+++ b/tools/data_forwarder_host/core/data_model.py
@@ -1,0 +1,350 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Per-session GUI-side data model — rolling buffers + redraw coalescer."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+from PySide6.QtCore import QObject, QTimer, Signal
+
+from data_forwarder_host.core.channels import ChannelBuffer
+from data_forwarder_host.core.error_log import ErrorCategory, ErrorLog
+from data_forwarder_host.core.playout import PlayoutClock
+from data_forwarder_host.protocol.base import DecodedMessage
+from data_forwarder_host.utils.slow_span import slow_span_fn
+
+_REDRAW_HZ = 30
+_REDRAW_INTERVAL_MS = int(1000 / _REDRAW_HZ)
+
+# When no recording is in progress there is no need to keep accumulating live
+# samples beyond what the plot shows; idle retention is capped at this many
+# seconds (or the plot window, whichever is larger).
+_IDLE_RETENTION_FLOOR_SECONDS = 100.0
+
+
+class DataModel(QObject):
+    """Per-session rolling buffers; lives on the GUI thread.
+
+    Channels are discovered hybrid-style:
+      * if a ``session_info`` message contains channel names, those win;
+      * otherwise the count is locked from the first ``sensor_data`` message;
+      * subsequent count mismatches are surfaced via :class:`ErrorLog`.
+    """
+
+    channels_changed = Signal()                 # ()
+    data_appended = Signal(int)                 # (samples added since last tick)
+    session_info = Signal(dict)                 # (raw session-info dict)
+    cleared = Signal()
+    recording_marker_changed = Signal()         # recording start/stop markers moved/cleared
+
+    def __init__(
+        self,
+        *,
+        plot_window_seconds: float,
+        error_log: ErrorLog,
+        parent: QObject | None = None,
+        time_fn: Callable[[], float] | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._plot_window_seconds = plot_window_seconds
+        self._error_log = error_log
+        # Smooth wall-clock-to-device-time playout for the chart right edge so
+        # the view scrolls continuously even when samples arrive late/in bursts;
+        # late points fill in as the playout position passes their device ts
+        # (the time source is injectable for deterministic playout).
+        self._time_fn: Callable[[], float] = time_fn or time.monotonic
+        self._playout = PlayoutClock()
+        self._channel_names: tuple[str, ...] = ()
+        self._channels_locked: bool = False
+        self._buffers: list[ChannelBuffer] = []
+        self._pending_added: int = 0
+        self._recording: bool = False
+
+        # Recording markers: device timestamps for the vertical lines drawn on
+        # the charts where recording began and ended. The start marker sits just
+        # before the first recorded sample (after the last non-recorded one) and
+        # PERSISTS after recording stops; the stop marker is fixed at the last
+        # recorded sample when recording ends.
+        self._last_appended_ts: int | None = None
+        self._awaiting_first_recorded: bool = False
+        self._recording_start_marker_ms: int | None = None
+        self._recording_stop_marker_ms: int | None = None
+
+        self._timer = QTimer(self)
+        self._timer.setInterval(_REDRAW_INTERVAL_MS)
+        self._timer.timeout.connect(self._tick)
+        self._timer.start()
+
+    # ------------------------------------------------------------------
+    # Public
+    # ------------------------------------------------------------------
+
+    @property
+    def plot_window_seconds(self) -> float:
+        return self._plot_window_seconds
+
+    @property
+    def channel_names(self) -> tuple[str, ...]:
+        return self._channel_names
+
+    @property
+    def channel_count(self) -> int:
+        return len(self._buffers)
+
+    @property
+    def max_buffer_size(self) -> int:
+        """Largest current per-channel sample count (diagnostics)."""
+        return max((b.size for b in self._buffers), default=0)
+
+    def buffer(self, index: int) -> ChannelBuffer:
+        return self._buffers[index]
+
+    @property
+    def recording_start_marker_ms(self) -> int | None:
+        """Device timestamp of the recording-start marker, or ``None``."""
+        return self._recording_start_marker_ms
+
+    @property
+    def recording_stop_marker_ms(self) -> int | None:
+        """Device timestamp of the recording-stop marker, or ``None``."""
+        return self._recording_stop_marker_ms
+
+    def begin_recording_marker(self) -> None:
+        """Arm the start marker for a new recording, clearing prior markers.
+
+        The next recorded sample fixes the new start moment. Any markers from a
+        previous recording are cleared so only the current capture is shown.
+        """
+        self._awaiting_first_recorded = True
+        changed = False
+        if self._recording_start_marker_ms is not None:
+            self._recording_start_marker_ms = None
+            changed = True
+        if self._recording_stop_marker_ms is not None:
+            self._recording_stop_marker_ms = None
+            changed = True
+        if changed:
+            self.recording_marker_changed.emit()
+
+    def end_recording_marker(self) -> None:
+        """Fix the stop marker at the last recorded sample on a normal stop.
+
+        The start marker is left in place so both the begin and end of the
+        recording stay visible on the charts.
+        """
+        self._awaiting_first_recorded = False
+        stop = self._last_appended_ts
+        if stop is not None and stop != self._recording_stop_marker_ms:
+            self._recording_stop_marker_ms = stop
+            self.recording_marker_changed.emit()
+
+    def clear_recording_markers(self) -> None:
+        """Remove both recording markers (e.g. when a recording is cancelled)."""
+        self._awaiting_first_recorded = False
+        changed = False
+        if self._recording_start_marker_ms is not None:
+            self._recording_start_marker_ms = None
+            changed = True
+        if self._recording_stop_marker_ms is not None:
+            self._recording_stop_marker_ms = None
+            changed = True
+        if changed:
+            self.recording_marker_changed.emit()
+
+    def set_plot_window_seconds(self, seconds: float) -> None:
+        if seconds <= 0 or seconds == self._plot_window_seconds:
+            return
+        self._plot_window_seconds = seconds
+        for b in self._buffers:
+            b.resize(plot_window_seconds=seconds)
+
+    def set_recording(self, recording: bool) -> None:
+        """Track recording state so idle retention can be capped."""
+        self._recording = bool(recording)
+
+    def playout_position_ms(self) -> float | None:
+        """Smoothed device-time right edge for the charts, or ``None`` if idle.
+
+        Returns the :class:`PlayoutClock` position — which advances
+        continuously at the low-pass-filtered device rate and trails the newest
+        received timestamp by a small de-jitter delay — so the chart right edge
+        scrolls smoothly. Before any data has been seen it returns ``None`` and
+        callers fall back to their data-derived range.
+        """
+        if not self._playout.is_initialized:
+            return None
+        return self._playout.position_ms(self._time_fn())
+
+    def visible_x_window_ms(self) -> tuple[float, float] | None:
+        """Shared rolling X window ``(lo_ms, hi_ms)`` for every chart.
+
+        All charts — the combined overlay and each per-channel chart — must show
+        the **same** X range so a given horizontal position maps to the same
+        time across them. That range is computed once here: the right edge
+        follows the smoothed playout clock, falling back to the newest
+        appended device timestamp; the left edge is exactly one plot window
+        behind it. Returns ``None`` before any data has been seen, so callers can
+        keep their previous range until the stream starts.
+        """
+        right = self.playout_position_ms()
+        if right is None:
+            right = self._last_appended_ts
+        if right is None:
+            return None
+        window_ms = self._plot_window_seconds * 1000.0
+        return (float(right) - window_ms, float(right))
+
+    def clear(self) -> None:
+        for b in self._buffers:
+            b.clear()
+        self._pending_added = 0
+        self._last_appended_ts = None
+        self._playout.reset()
+        self._awaiting_first_recorded = False
+        self._recording_start_marker_ms = None
+        self._recording_stop_marker_ms = None
+        self.cleared.emit()
+        self.recording_marker_changed.emit()
+
+    def reset(self) -> None:
+        self._buffers = []
+        self._channel_names = ()
+        self._channels_locked = False
+        self._pending_added = 0
+        self._last_appended_ts = None
+        self._playout.reset()
+        self._awaiting_first_recorded = False
+        self._recording_start_marker_ms = None
+        self._recording_stop_marker_ms = None
+        self.channels_changed.emit()
+        self.cleared.emit()
+        self.recording_marker_changed.emit()
+
+    # ------------------------------------------------------------------
+    # Slot
+    # ------------------------------------------------------------------
+
+    @slow_span_fn("data_model.on_message")
+    def on_message(self, msg: DecodedMessage) -> None:
+        if msg.kind == "session_info":
+            self._handle_session_info(msg.raw)
+            return
+        if msg.kind != "sensor_data" or msg.channels is None:
+            return
+
+        n = len(msg.channels)
+        if not self._channels_locked:
+            self._lock_channels(n)
+
+        if n != len(self._buffers):
+            self._error_log.add(
+                ErrorCategory.CHANNEL_MISMATCH,
+                f"expected {len(self._buffers)} channels, got {n}",
+                seq=msg.seq,
+            )
+            return
+
+        # X axis uses device timestamp when present; fall back to host time.
+        t_ms = msg.t_device_ms if msg.t_device_ms is not None else msg.t_host_ms
+        # Fix the recording-start marker on the first sample recorded after
+        # recording began: place it just before this sample but after the last
+        # non-recorded one (midpoint), so the vertical line sits between them.
+        if self._awaiting_first_recorded:
+            if self._last_appended_ts is not None and self._last_appended_ts < t_ms:
+                self._recording_start_marker_ms = (self._last_appended_ts + t_ms) // 2
+            else:
+                self._recording_start_marker_ms = t_ms
+            self._awaiting_first_recorded = False
+            self.recording_marker_changed.emit()
+        for i, v in enumerate(msg.channels):
+            self._buffers[i].append(t_ms, v)
+        self._last_appended_ts = t_ms
+        # Feed the smoothed playout clock the newest device timestamp so the
+        # chart right edge can advance continuously between arrivals.
+        self._playout.observe(float(t_ms), self._time_fn())
+        self._pending_added += 1
+
+    def on_messages(self, messages) -> None:
+        """Ingest a batch of decoded messages in one call.
+
+        When the source runs out-of-process frames arrive batched,
+        so the GUI thread pays a single hand-off per batch instead of per frame.
+        This simply applies the per-message :meth:`on_message` logic to each item
+        in order; the 30 Hz coalesced redraw still collapses the whole
+        batch into one repaint.
+        """
+        for msg in messages:
+            self.on_message(msg)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _handle_session_info(self, raw: dict[str, Any]) -> None:
+        # Look for channel names in common spots.
+        names = None
+        for key in ("channels", "channel_names", "ch"):
+            v = raw.get(key)
+            if isinstance(v, (list, tuple)) and all(isinstance(s, str) for s in v):
+                names = tuple(v)
+                break
+            if isinstance(v, dict):
+                items = v.get("names") if isinstance(v.get("names"), (list, tuple)) else None
+                if items and all(isinstance(s, str) for s in items):
+                    names = tuple(items)
+                    break
+
+        # The device wire format (see samples/data_forwarder/cddl) nests the
+        # channel names under the payload key "d" as "ch_n" (with channel count
+        # in "ch"). Accept that, plus the generic "channels" spelling.
+        d = raw.get("d") if isinstance(raw.get("d"), dict) else {}
+        if names is None and isinstance(d, dict):
+            for key in ("ch_n", "channel_names", "channels"):
+                v = d.get(key)
+                if isinstance(v, (list, tuple)) and v and all(isinstance(s, str) for s in v):
+                    names = tuple(v)
+                    break
+
+        if names is not None:
+            self._set_channel_names(names)
+            self._channels_locked = True
+
+        self.session_info.emit(raw)
+
+    def _lock_channels(self, n: int) -> None:
+        if self._channel_names and len(self._channel_names) == n:
+            names = self._channel_names
+        elif self._channel_names:
+            # Pre-existing names had the wrong count — fall back to inferred.
+            names = tuple(f"ch{i}" for i in range(n))
+        else:
+            names = tuple(f"ch{i}" for i in range(n))
+        self._set_channel_names(names)
+        self._channels_locked = True
+
+    def _set_channel_names(self, names: tuple[str, ...]) -> None:
+        if names == self._channel_names and len(self._buffers) == len(names):
+            return
+        self._channel_names = names
+        self._buffers = [
+            ChannelBuffer(plot_window_seconds=self._plot_window_seconds) for _ in names
+        ]
+        self.channels_changed.emit()
+
+    @slow_span_fn("data_model._tick")
+    def _tick(self) -> None:
+        # While idle (not recording), cap how much history the live buffers keep
+        # so nothing accumulates needlessly between recordings.
+        if not self._recording and self._buffers:
+            cap_ms = int(
+                max(_IDLE_RETENTION_FLOOR_SECONDS, self._plot_window_seconds) * 1000
+            )
+            for b in self._buffers:
+                b.retain_window(cap_ms)
+        if self._pending_added == 0:
+            return
+        added, self._pending_added = self._pending_added, 0
+        self.data_appended.emit(added)

--- a/tools/data_forwarder_host/core/decimation.py
+++ b/tools/data_forwarder_host/core/decimation.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Pure, Qt-free render-time decimation for live charts.
+
+The live charts must redraw in time proportional to the number of points they
+put *on screen*, not the number of samples buffered. This module provides a
+single pure function, :func:`decimate_minmax`, that reduces a channel's
+``(ts, val)`` samples to a bounded number of points using **min/max bucketing**.
+
+Why min/max (and not stride / every-Nth sampling): stride sampling can step over
+a transient spike entirely, hiding it. Min/max bucketing splits the input into a
+fixed number of contiguous, x-ordered buckets and, for each bucket, emits *both*
+the minimum and the maximum sample (in x order). Peaks and dips therefore always
+survive, while the on-screen point count stays bounded.
+
+Contract
+--------
+``decimate_minmax(ts, val, target_buckets=DEFAULT_TARGET_BUCKETS) -> (ts, val)``
+
+* Inputs: two equal-length sequences (lists or NumPy arrays) — ``ts`` (x, must be
+  non-decreasing) and ``val`` (y).
+* Output length is bounded: ``len(out) <= 2 * target_buckets`` for any input.
+* If ``len(ts) <= 2 * target_buckets`` the input is returned unchanged (passthrough).
+* Output x order is preserved (non-decreasing); the function is deterministic.
+* No Qt import — the GUI widgets call this; they do not implement downsampling.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# Default number of horizontal buckets. Each bucket can emit up to two points
+# (its min and its max), so the on-screen point count per channel is capped at
+# ``2 * DEFAULT_TARGET_BUCKETS`` (≈2000) regardless of how many samples are
+# buffered. Tuned for smooth interaction on a typical desktop display.
+DEFAULT_TARGET_BUCKETS = 1000
+
+
+def decimate_minmax(
+    ts: np.ndarray,
+    val: np.ndarray,
+    target_buckets: int = DEFAULT_TARGET_BUCKETS,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Reduce ``(ts, val)`` to a bounded set of points via min/max bucketing.
+
+    Args:
+        ts: x values (timestamps), non-decreasing, length ``n``.
+        val: y values, length ``n``.
+        target_buckets: number of horizontal buckets; output is capped at
+            ``2 * target_buckets`` points. Must be >= 1.
+
+    Returns:
+        ``(ts_out, val_out)`` NumPy arrays. When ``n <= 2 * target_buckets`` the
+        input values are returned unchanged (as arrays).
+
+    Raises:
+        ValueError: if ``target_buckets < 1`` or the inputs differ in length.
+    """
+    if target_buckets < 1:
+        raise ValueError("target_buckets must be >= 1")
+
+    ts_arr = np.asarray(ts)
+    val_arr = np.asarray(val)
+    if ts_arr.shape[0] != val_arr.shape[0]:
+        raise ValueError("ts and val must have the same length")
+
+    n = ts_arr.shape[0]
+    cap = 2 * target_buckets
+    # Passthrough: already small enough that decimation would not reduce it.
+    if n <= cap:
+        return ts_arr.copy(), val_arr.copy()
+
+    # Contiguous, x-ordered bucket boundaries over the sample index range. Using
+    # index boundaries (rather than time boundaries) keeps each bucket non-empty
+    # and the work O(n) with no dependence on the time distribution.
+    edges = np.linspace(0, n, target_buckets + 1).astype(np.int64)
+
+    # Keep only non-empty buckets. Because the buckets partition ``[0, n)`` into
+    # contiguous index ranges, dropping the zero-width ones leaves a set of
+    # strictly increasing segment starts that still cover every sample — exactly
+    # what ``np.*.reduceat`` needs.
+    starts = edges[:-1]
+    ends = edges[1:]
+    starts = starts[starts < ends]
+    sizes = np.diff(np.append(starts, n))
+
+    # Per-bucket min/max VALUES via segmented reductions (fully vectorised; no
+    # Python-level loop over buckets — this is the live-redraw hot path).
+    seg_min = np.minimum.reduceat(val_arr, starts)
+    seg_max = np.maximum.reduceat(val_arr, starts)
+
+    # Per-bucket FIRST index achieving that min/max, matching ``np.argmin`` /
+    # ``np.argmax`` semantics. For each sample, take its own index where it ties
+    # the bucket extreme and ``n`` otherwise, then reduce with ``minimum`` to get
+    # the earliest qualifying index in the bucket.
+    idx = np.arange(n, dtype=np.int64)
+    min_exp = np.repeat(seg_min, sizes)
+    max_exp = np.repeat(seg_max, sizes)
+    cand_min = np.where(val_arr == min_exp, idx, n)
+    cand_max = np.where(val_arr == max_exp, idx, n)
+    i_min = np.minimum.reduceat(cand_min, starts)
+    i_max = np.minimum.reduceat(cand_max, starts)
+
+    # Emit the earlier-indexed extreme first so the x-order stays non-decreasing;
+    # collapse to a single point where the bucket's min and max coincide.
+    lo = np.minimum(i_min, i_max)
+    hi = np.maximum(i_min, i_max)
+    same = i_min == i_max
+    keep = np.empty(2 * lo.shape[0], dtype=np.int64)
+    keep[0::2] = lo
+    keep[1::2] = hi
+    mask = np.ones(keep.shape[0], dtype=bool)
+    mask[1::2] = ~same
+    keep = keep[mask]
+    return ts_arr[keep], val_arr[keep]

--- a/tools/data_forwarder_host/core/error_log.py
+++ b/tools/data_forwarder_host/core/error_log.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Per-session error journal.
+
+The single, structured journal of per-session abnormalities. Decoder, recorder
+and source wrapper all funnel events here, and the GUI ``ErrorPanel`` binds to
+this object.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import Counter, deque
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Any
+
+from PySide6.QtCore import QObject, QTimer, Signal
+
+from data_forwarder_host.session.states import SessionState
+from data_forwarder_host.utils.timeutil import utc_iso8601_now
+
+
+class ErrorCategory(Enum):
+    COBS = auto()
+    CRC = auto()
+    MALFORMED = auto()
+    CBOR = auto()
+    CHANNEL_MISMATCH = auto()
+    SESSION_INFO_INVALID = auto()
+    SESSION_INFO_MISMATCH = auto()
+    SENSOR_DATA_INVALID = auto()
+    RECORDER_OVERFLOW = auto()
+    PRODUCER_DROP = auto()
+    PRODUCER_DROP_TOTAL = auto()
+    TRANSPORT = auto()
+
+
+@dataclass(frozen=True)
+class ErrorEvent:
+    t_host_utc: str
+    category: ErrorCategory
+    session_state: SessionState
+    detail: str
+    context: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ErrorSummary:
+    total_messages: int
+    counts: dict[ErrorCategory, int]
+    percentages: dict[ErrorCategory, float]
+    incomplete: bool
+
+
+_MAX_EVENTS = 10_000
+_SUMMARY_RATE_MS = 1000
+
+
+class ErrorLog(QObject):
+    """Per-session event journal with throttled (1 Hz) summary signal."""
+
+    event_added = Signal(object)        # ErrorEvent
+    summary_changed = Signal(object)    # ErrorSummary
+    cleared = Signal()                  # emitted when all events are purged
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._lock = threading.RLock()
+        self._events: deque[ErrorEvent] = deque(maxlen=_MAX_EVENTS)
+        self._counts: Counter[ErrorCategory] = Counter()
+        self._state_provider: Callable[[], SessionState] | None = None
+        self._total_messages: int = 0
+        self._dirty: bool = False
+
+        # Throttle summary emissions to ~1 Hz.
+        self._timer = QTimer(self)
+        self._timer.setInterval(_SUMMARY_RATE_MS)
+        self._timer.timeout.connect(self._maybe_emit_summary)
+        self._timer.start()
+
+    # ------------------------------------------------------------------
+    # Wiring
+    # ------------------------------------------------------------------
+
+    def bind_state_provider(self, provider: Callable[[], SessionState]) -> None:
+        """Provide a callable returning the current ``SessionState``."""
+        self._state_provider = provider
+
+    def note_message(self) -> None:
+        """Count one successfully delivered application message.
+
+        Used as the denominator for ``percentages`` in :class:`ErrorSummary`.
+        """
+        with self._lock:
+            self._total_messages += 1
+            self._dirty = True
+
+    # ------------------------------------------------------------------
+    # Mutators
+    # ------------------------------------------------------------------
+
+    def add(self, category: ErrorCategory, detail: str, **context: Any) -> None:
+        state = self._state_provider() if self._state_provider else SessionState.CONFIGURED
+        evt = ErrorEvent(
+            t_host_utc=utc_iso8601_now(),
+            category=category,
+            session_state=state,
+            detail=detail,
+            context=dict(context),
+        )
+        with self._lock:
+            self._events.append(evt)
+            self._counts[category] += 1
+            self._dirty = True
+        self.event_added.emit(evt)
+
+    def add_bulk(
+        self, category: ErrorCategory, count: int, detail: str, **context: Any
+    ) -> None:
+        """Record *count* occurrences of *category* as a single coalesced event.
+
+        A transport flood can confirm thousands of losses in one go; emitting an
+        individual :class:`ErrorEvent` per occurrence would itself stall the GUI
+        (one signal emission and one widget append each). This appends a single
+        summary event, advances the category count by *count* in one step, and
+        emits :attr:`event_added` exactly once — keeping the running totals
+        accurate while the per-event cost stays O(1) regardless of *count*.
+        """
+        count = int(count)
+        if count <= 0:
+            return
+        state = self._state_provider() if self._state_provider else SessionState.CONFIGURED
+        evt = ErrorEvent(
+            t_host_utc=utc_iso8601_now(),
+            category=category,
+            session_state=state,
+            detail=detail,
+            context={**context, "count": count},
+        )
+        with self._lock:
+            self._events.append(evt)
+            self._counts[category] += count
+            self._dirty = True
+        self.event_added.emit(evt)
+
+    def set_count(self, category: ErrorCategory, count: int) -> None:
+        """Force the running count for *category* to an absolute value.
+
+        Used for cumulative producer-side metrics such as the ``dr`` drop
+        count, where the device reports a running total rather than discrete
+        events. No :class:`ErrorEvent` is appended.
+        """
+        count = max(0, int(count))
+        with self._lock:
+            if self._counts.get(category, 0) == count:
+                return
+            self._counts[category] = count
+            self._dirty = True
+
+    def clear(self) -> None:
+        with self._lock:
+            self._events.clear()
+            self._counts.clear()
+            self._total_messages = 0
+            # Mark clean so the 1-Hz timer doesn't re-emit a stale dirty flush.
+            self._dirty = False
+        # Notify GUI immediately — don't wait for the next timer tick.
+        self.cleared.emit()
+        self.summary_changed.emit(self.summary())
+
+    # ------------------------------------------------------------------
+    # Read-only
+    # ------------------------------------------------------------------
+
+    def events(self) -> Sequence[ErrorEvent]:
+        with self._lock:
+            return list(self._events)
+
+    def summary(self) -> ErrorSummary:
+        with self._lock:
+            total = self._total_messages
+            denom = total + self._counts.get(ErrorCategory.RECORDER_OVERFLOW, 0)
+            counts = {c: self._counts.get(c, 0) for c in ErrorCategory}
+            percentages = {
+                c: (100.0 * counts[c] / denom) if denom else 0.0 for c in ErrorCategory
+            }
+            incomplete = counts[ErrorCategory.RECORDER_OVERFLOW] > 0
+            return ErrorSummary(
+                total_messages=total,
+                counts=counts,
+                percentages=percentages,
+                incomplete=incomplete,
+            )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _maybe_emit_summary(self) -> None:
+        with self._lock:
+            if not self._dirty:
+                return
+            self._dirty = False
+        self.summary_changed.emit(self.summary())

--- a/tools/data_forwarder_host/core/eventbus.py
+++ b/tools/data_forwarder_host/core/eventbus.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Tiny app-wide publish/subscribe bus (thread-safe, callback-based)."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from typing import Any
+
+Callback = Callable[..., None]
+
+
+class EventBus:
+    """A minimal topic-based pub/sub bus.
+
+    Subscribers are invoked synchronously from the publishing thread; cross-
+    thread delivery is the responsibility of the subscriber (use Qt signals or
+    similar). Useful for app-wide notifications that do not warrant a dedicated
+    Qt signal/slot wiring (e.g. settings changes).
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._subs: dict[str, list[Callback]] = {}
+
+    def subscribe(self, topic: str, callback: Callback) -> Callable[[], None]:
+        with self._lock:
+            self._subs.setdefault(topic, []).append(callback)
+
+        def _unsubscribe() -> None:
+            with self._lock:
+                lst = self._subs.get(topic, [])
+                if callback in lst:
+                    lst.remove(callback)
+
+        return _unsubscribe
+
+    def publish(self, topic: str, *args: Any, **kwargs: Any) -> None:
+        with self._lock:
+            subscribers = list(self._subs.get(topic, ()))
+        for cb in subscribers:
+            try:
+                cb(*args, **kwargs)
+            except Exception:  # pragma: no cover — never crash publisher
+                import logging
+                logging.getLogger(__name__).exception("subscriber failed on topic %s", topic)

--- a/tools/data_forwarder_host/core/ffdc.py
+++ b/tools/data_forwarder_host/core/ffdc.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""First Failure Data Capture (FFDC) report building.
+
+When a decode failure first occurs the decoder attaches diagnostic context to
+the :class:`~data_forwarder_host.core.error_log.ErrorEvent` (the offending
+bytestream, what was expected vs. what actually arrived, and a Python
+traceback where one exists). This module turns the per-session error journal
+into a structured, GUI-free FFDC report: for each error *category* it keeps the
+**first** occurrence (the classic "first failure" capture) and renders the
+diagnostics into labelled, individually-focusable panels.
+
+Kept free of Qt so it is isolated; the GUI ``FfdcDialog`` only lays the
+resulting :class:`FfdcEntry`/:class:`FfdcPanel` objects out as collapsible
+sections.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # avoid importing Qt-bound types at runtime
+    from data_forwarder_host.core.error_log import ErrorEvent
+
+_HEX_BYTES_PER_ROW = 16
+
+
+@dataclass(frozen=True)
+class FfdcPanel:
+    """One focusable view within a single failure capture."""
+
+    title: str
+    text: str
+
+
+@dataclass(frozen=True)
+class FfdcEntry:
+    """The first captured occurrence of one error category."""
+
+    category: str
+    timestamp: str
+    detail: str
+    panels: list[FfdcPanel]
+
+
+def hexdump(data: bytes, *, bytes_per_row: int = _HEX_BYTES_PER_ROW) -> str:
+    """Render *data* as an offset/hex/ascii hexdump (one row per 16 bytes)."""
+    if not data:
+        return "(empty)"
+    rows: list[str] = []
+    for off in range(0, len(data), bytes_per_row):
+        chunk = data[off : off + bytes_per_row]
+        hex_part = " ".join(f"{b:02x}" for b in chunk)
+        hex_part = hex_part.ljust(bytes_per_row * 3 - 1)
+        rows.append(f"{off:08x}  {hex_part}  {ascii_view(chunk)}")
+    return "\n".join(rows)
+
+
+def ascii_view(data: bytes) -> str:
+    """Return a printable-ASCII view of *data* (non-printables shown as ``.``)."""
+    return "".join(chr(b) if 0x20 <= b < 0x7F else "." for b in data)
+
+
+def _coerce_bytes(value: object) -> bytes | None:
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    return None
+
+
+def _build_panels(detail: str, context: dict) -> list[FfdcPanel]:
+    panels: list[FfdcPanel] = []
+
+    # Python error trace, when the failure carried an exception.
+    tb = context.get("traceback")
+    if isinstance(tb, str) and tb.strip() and tb.strip() != "NoneType: None":
+        panels.append(FfdcPanel("Python error trace", tb.rstrip()))
+
+    # Real issue analysis: expected vs. what actually arrived.
+    expected = context.get("expected")
+    actual = context.get("actual")
+    if expected is not None or actual is not None:
+        panels.append(
+            FfdcPanel(
+                "Expected vs. actual",
+                f"Detail:   {detail}\n"
+                f"Expected: {expected if expected is not None else '(n/a)'}\n"
+                f"Actual:   {actual if actual is not None else '(n/a)'}",
+            )
+        )
+
+    # The offending bytestream, in hex + ascii.
+    raw = _coerce_bytes(context.get("raw"))
+    if raw is not None:
+        raw_len = context.get("raw_len", len(raw))
+        truncated = isinstance(raw_len, int) and raw_len > len(raw)
+        suffix = (
+            f"\n... ({raw_len - len(raw)} more byte(s) not captured)"
+            if truncated
+            else ""
+        )
+        panels.append(
+            FfdcPanel("Bytestream — hex", hexdump(raw) + suffix)
+        )
+        panels.append(
+            FfdcPanel("Bytestream — ASCII", ascii_view(raw) + suffix)
+        )
+
+    return panels
+
+
+def build_ffdc(events: Sequence[ErrorEvent]) -> list[FfdcEntry]:
+    """Return one :class:`FfdcEntry` per category, for its first occurrence.
+
+    Categories appear in the order their first failure was observed. Each entry
+    exposes a list of :class:`FfdcPanel` views (Python trace, expected/actual,
+    bytestream hex/ascii) so the UI can let the user focus on one at a time.
+    """
+    entries: list[FfdcEntry] = []
+    seen: set[str] = set()
+    for evt in events:
+        name = evt.category.name
+        if name in seen:
+            continue
+        seen.add(name)
+        entries.append(
+            FfdcEntry(
+                category=name,
+                timestamp=evt.t_host_utc,
+                detail=evt.detail,
+                panels=_build_panels(evt.detail, dict(evt.context)),
+            )
+        )
+    return entries

--- a/tools/data_forwarder_host/core/host_metrics.py
+++ b/tools/data_forwarder_host/core/host_metrics.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Host-machine resource sampling (CPU / RAM) for the status bar.
+
+The sampling and formatting logic lives here, free of any Qt dependency, so it
+can be exercised in isolation. The GUI layer (a status-bar label) only owns a
+timer that periodically calls :func:`sample_host_metrics` and renders the result
+with :func:`format_host_metrics`.
+
+``psutil`` is imported lazily inside :func:`sample_host_metrics` so importing
+this module never hard-fails if the dependency is missing, and so callers can
+inject a fake implementation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+_UNITS = ("B", "KB", "MB", "GB", "TB")
+
+
+def _fmt_size(n: float) -> str:
+    """Render a byte count as a compact human-readable string."""
+    size = float(n)
+    for unit in _UNITS:
+        if size < 1024.0 or unit == _UNITS[-1]:
+            if unit == "B":
+                return f"{int(size)} {unit}"
+            return f"{size:.1f} {unit}"
+        size /= 1024.0
+    return f"{size:.1f} {_UNITS[-1]}"  # pragma: no cover - unreachable
+
+
+@dataclass(frozen=True)
+class HostMetrics:
+    """A point-in-time snapshot of host resource usage.
+
+    ``cpu_percent`` and ``ram_percent`` are host-wide 0..100 figures spanning
+    all cores / total physical memory. ``process_cpu_percent`` and
+    ``process_rss_bytes`` describe *this* application process, so the user can
+    see the tool's own footprint. ``process_cpu_percent`` is normalised to the
+    whole machine (divided by the logical-CPU count), so 100 % would mean the
+    app is saturating every core, keeping it comparable with ``cpu_percent``.
+    """
+
+    cpu_percent: float
+    ram_percent: float
+    ram_used_bytes: int
+    ram_total_bytes: int
+    process_cpu_percent: float
+    process_rss_bytes: int
+
+
+def _app_memory_bytes(proc: Any) -> int:
+    """Application memory that matches what a system monitor reports.
+
+    GNOME System Monitor (via libgtop) shows a process's memory as its
+    *resident* set minus *shared* pages — i.e. the memory private to this
+    process, excluding shared library/framework pages mapped into every
+    process. We mirror that exact formula (``rss - shared``) so the figure
+    lines up with what the user sees in the system monitor, rather than the
+    raw RSS (which over-counts shared pages) or smaps-derived USS (which is
+    computed differently and diverges by tens of MB).
+    """
+    mi = proc.memory_info()
+    rss = int(mi.rss)
+    shared = int(getattr(mi, "shared", 0) or 0)
+    return max(rss - shared, 0)
+
+
+def sample_host_metrics(*, _psutil: Any = None, _proc: Any = None) -> HostMetrics:
+    """Sample current host and application CPU and memory usage.
+
+    Both the host (``cpu_percent``) and the application (``process_cpu_percent``)
+    CPU figures are measured non-blockingly (``interval=None``): they report
+    utilisation since the previous call, so the very first call after process
+    start returns ``0.0``. Callers should prime them once and then poll on a
+    timer.
+
+    The application :class:`psutil.Process` handle is cached at module scope so
+    successive calls share the same object; ``Process.cpu_percent`` only yields
+    a real figure when called repeatedly on the *same* handle (a fresh handle
+    always reports 0 %). The ``_psutil`` / ``_proc`` parameters exist only for
+    dependency injection.
+    """
+    if _psutil is None:
+        import psutil  # noqa: PLC0415 - lazy so the module imports without psutil
+
+        _psutil = psutil
+    if _proc is not None:
+        proc = _proc
+    else:
+        proc = _get_default_process(_psutil)
+    vm = _psutil.virtual_memory()
+    ncpu = _psutil.cpu_count() or 1
+    return HostMetrics(
+        cpu_percent=float(_psutil.cpu_percent(interval=None)),
+        ram_percent=float(vm.percent),
+        ram_used_bytes=int(vm.used),
+        ram_total_bytes=int(vm.total),
+        process_cpu_percent=float(proc.cpu_percent(interval=None)) / ncpu,
+        process_rss_bytes=_app_memory_bytes(proc),
+    )
+
+
+_DEFAULT_PROCESS: Any = None
+
+
+def _get_default_process(psutil_mod: Any) -> Any:
+    """Return a cached :class:`psutil.Process` for this application."""
+    global _DEFAULT_PROCESS
+    if _DEFAULT_PROCESS is None:
+        _DEFAULT_PROCESS = psutil_mod.Process()
+        # Prime per-process CPU accounting so the first real sample is non-zero.
+        try:
+            _DEFAULT_PROCESS.cpu_percent(interval=None)
+        except Exception:  # noqa: BLE001 - priming must never raise
+            pass
+    return _DEFAULT_PROCESS
+
+
+
+def _app_ram_percent(m: "HostMetrics") -> float:
+    """Application memory as a percentage of total physical RAM."""
+    if m.ram_total_bytes <= 0:
+        return 0.0
+    return m.process_rss_bytes / m.ram_total_bytes * 100.0
+
+
+def format_host_metrics(m: HostMetrics) -> str:
+    """Render a one-line status-bar summary of host + application usage."""
+    return (
+        f"Host: CPU {m.cpu_percent:.2f}%  RAM {m.ram_percent:.2f}%   "
+        f"App: CPU {m.process_cpu_percent:.2f}%  "
+        f"RAM {_fmt_size(m.process_rss_bytes)} ({_app_ram_percent(m):.2f}%)"
+    )
+
+
+def format_host_metrics_tooltip(m: HostMetrics) -> str:
+    """Render a multi-line tooltip with the same figures, spelled out."""
+    return (
+        "Resource usage\n"
+        f"Host CPU (all cores): {m.cpu_percent:.2f}%\n"
+        f"Host RAM: {m.ram_percent:.2f}%  "
+        f"({_fmt_size(m.ram_used_bytes)} used of {_fmt_size(m.ram_total_bytes)})\n"
+        f"This application CPU: {m.process_cpu_percent:.2f}% of total machine\n"
+        f"This application RAM: {_fmt_size(m.process_rss_bytes)} resident "
+        f"({_app_ram_percent(m):.2f}% of total RAM)"
+    )

--- a/tools/data_forwarder_host/core/metadata.py
+++ b/tools/data_forwarder_host/core/metadata.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Sidecar session-metadata dump written next to each recording CSV.
+
+When a recording is saved as ``{stem}.csv`` a human-readable companion file
+``{stem}.txt`` is written with the same base name. It captures everything about
+the capture that the CSV rows themselves do not carry: the transport used, the
+device that produced the data (serial port / BLE name + address), the host OS
+and host timestamps, the device-reported ``session_info`` envelope, the channel
+layout and a short error/loss summary.
+
+The file is plain ``key: value`` lines grouped under ``[Section]`` headers so it
+is both easy to read and trivial to parse back if needed.
+"""
+
+from __future__ import annotations
+
+import platform
+import socket
+import sys
+from typing import TYPE_CHECKING, Any
+
+from data_forwarder_host.core.error_log import ErrorCategory
+from data_forwarder_host.utils.timeutil import utc_iso8601_now
+
+if TYPE_CHECKING:  # pragma: no cover - import for typing only
+    from data_forwarder_host.core.recorder import Recording
+
+
+def _transport_details(kind: str, params: dict[str, Any]) -> list[tuple[str, str]]:
+    """Return ordered ``(label, value)`` rows describing the device endpoint."""
+    kind = (kind or "").lower()
+    if kind == "uart":
+        return [
+            ("transport", "UART / serial"),
+            ("serial_port", str(params.get("port", "") or "(unknown)")),
+            ("baudrate", str(params.get("baudrate", 115200))),
+        ]
+    if kind == "ble":
+        return [
+            ("transport", "BLE (Nordic UART Service)"),
+            ("device_name", str(params.get("name", "") or "(unknown)")),
+            ("device_address", str(params.get("address", "") or "(unknown)")),
+        ]
+    return [("transport", kind or "(unknown)")]
+
+
+def _session_info_rows(session_info: dict[str, Any] | None) -> list[tuple[str, str]]:
+    """Flatten the device ``session_info`` ('si') envelope into rows."""
+    if not isinstance(session_info, dict):
+        return [("session_info", "(not received)")]
+    payload = session_info.get("d")
+    if not isinstance(payload, dict):
+        return [("session_info", "(malformed)")]
+    rows: list[tuple[str, str]] = []
+    labels = {
+        "name": "device_reported_name",
+        "sid": "session_id",
+        "hz": "sampling_rate_hz",
+        "st": "device_start_time",
+        "ch": "channel_count",
+        "dr": "producer_drop_count",
+    }
+    for key, label in labels.items():
+        if key in payload:
+            rows.append((label, str(payload[key])))
+    ch_n = payload.get("ch_n")
+    if isinstance(ch_n, (list, tuple)) and ch_n:
+        rows.append(("channels", ", ".join(str(c) for c in ch_n)))
+    # Surface any remaining unknown fields verbatim so nothing is silently lost.
+    for key, value in payload.items():
+        if key not in labels and key != "ch_n":
+            rows.append((f"si_{key}", str(value)))
+    return rows
+
+
+def _error_rows(recording: "Recording") -> list[tuple[str, str]]:
+    summary = recording.error_summary
+    rows: list[tuple[str, str]] = [
+        ("total_messages", str(summary.total_messages)),
+        ("incomplete", "yes" if recording.incomplete else "no"),
+    ]
+    for category in ErrorCategory:
+        count = summary.counts.get(category, 0)
+        if count:
+            rows.append((category.name.lower(), str(count)))
+    return rows
+
+
+def build_metadata_text(
+    recording: "Recording",
+    *,
+    label: str,
+    source_kind: str,
+    source_params: dict[str, Any],
+    source_description: str,
+    protocol_description: str,
+    csv_filename: str | None = None,
+) -> str:
+    """Render the sidecar metadata text for a finished *recording*."""
+    row_count = getattr(recording.storage, "row_count", None)
+
+    sections: list[tuple[str, list[tuple[str, str]]]] = []
+
+    recording_rows: list[tuple[str, str]] = [
+        ("label", label),
+        ("session_tag", recording.session_tag),
+    ]
+    if csv_filename:
+        recording_rows.append(("csv_file", csv_filename))
+    recording_rows.append(("data_rows", str(row_count) if row_count is not None else "(unknown)"))
+    sections.append(("Recording", recording_rows))
+
+    sections.append((
+        "Host",
+        [
+            ("written_utc", utc_iso8601_now()),
+            ("os", platform.platform()),
+            ("os_system", platform.system()),
+            ("os_release", platform.release()),
+            ("os_version", platform.version()),
+            ("machine", platform.machine()),
+            ("hostname", socket.gethostname()),
+            ("python", sys.version.split()[0]),
+        ],
+    ))
+
+    transport_rows = _transport_details(source_kind, source_params)
+    transport_rows.append(("source", source_description))
+    transport_rows.append(("protocol", protocol_description))
+    sections.append(("Transport", transport_rows))
+
+    sections.append((
+        "Timing",
+        [
+            ("started_utc", recording.started_utc),
+            ("stopped_utc", recording.stopped_utc),
+        ],
+    ))
+
+    sections.append(("Device session_info", _session_info_rows(recording.session_info)))
+    sections.append(("Channels", [
+        ("count", str(len(recording.channel_names))),
+        ("names", ", ".join(recording.channel_names) if recording.channel_names else "(none)"),
+    ]))
+    sections.append(("Errors", _error_rows(recording)))
+
+    lines: list[str] = []
+    for i, (title, rows) in enumerate(sections):
+        if i:
+            lines.append("")
+        lines.append(f"[{title}]")
+        width = max((len(k) for k, _ in rows), default=0)
+        for key, value in rows:
+            lines.append(f"{key.ljust(width)} : {value}")
+    return "\n".join(lines) + "\n"

--- a/tools/data_forwarder_host/core/pipeline_metrics.py
+++ b/tools/data_forwarder_host/core/pipeline_metrics.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Pure per-stage host pipeline metrics and bottleneck detection.
+
+The host data path is a chain of stages — source (wire) → decode → in-flight
+gate → plot buffer → recorder — each with an input rate, an output rate, a
+bounded queue, and a running drop count. This module models a snapshot of that
+chain as plain, immutable data so the GUI can *visualise* where throughput is
+lost without any stage having to know about the others.
+
+Everything here is pure: callers feed in already-measured numbers (from the
+existing :mod:`bandwidth`, :mod:`transfer_stats`, queue ``maxsize``/``qsize``
+and drop counters) and read back derived utilisation and a bottleneck verdict.
+No Qt, no I/O, no global state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+def _clamp01(value: float) -> float:
+    if value < 0.0:
+        return 0.0
+    if value > 1.0:
+        return 1.0
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class StageMetrics:
+    """Measured state of a single pipeline stage.
+
+    Rates are in items per second; queue figures are item counts; ``drops_total``
+    is a monotonic running total of items the stage has discarded.
+    """
+
+    name: str
+    in_rate: float = 0.0
+    out_rate: float = 0.0
+    queue_depth: int = 0
+    queue_capacity: int = 0
+    drops_total: int = 0
+    #: Name of the OS process this stage runs in (e.g. the acquisition child vs
+    #: the GUI process), used to box stages by process in the flow view.
+    #: Empty means "unattributed" and is treated as its own group.
+    process: str = ""
+
+    @property
+    def utilization(self) -> float:
+        """Queue fill fraction in ``[0, 1]`` (``0`` when the stage is unbounded)."""
+        if self.queue_capacity <= 0:
+            return 0.0
+        return _clamp01(self.queue_depth / self.queue_capacity)
+
+    @property
+    def throughput_ratio(self) -> float:
+        """``out_rate / in_rate`` in ``[0, 1]``; ``1`` when nothing is arriving.
+
+        A value below 1 means the stage is emitting slower than it receives, i.e.
+        it is shedding or backing up work.
+        """
+        if self.in_rate <= 0.0:
+            return 1.0
+        return _clamp01(self.out_rate / self.in_rate)
+
+    @property
+    def is_dropping(self) -> bool:
+        """``True`` if this stage has discarded any items."""
+        return self.drops_total > 0
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineSnapshot:
+    """An ordered, time-stamped snapshot of every stage in the pipeline."""
+
+    stages: tuple[StageMetrics, ...] = field(default_factory=tuple)
+    wall_time_s: float = 0.0
+
+    def __post_init__(self) -> None:
+        # Normalise any sequence to an immutable tuple, preserving order.
+        object.__setattr__(self, "stages", tuple(self.stages))
+
+    def stage(self, name: str) -> StageMetrics | None:
+        """Return the stage with *name*, or ``None`` if absent."""
+        for st in self.stages:
+            if st.name == name:
+                return st
+        return None
+
+    @property
+    def total_drops(self) -> int:
+        """Total frames dropped across every stage in the pipeline."""
+        return sum(st.drops_total for st in self.stages)
+
+
+def per_stage_drop_totals(snapshot: PipelineSnapshot) -> tuple[tuple[str, int], ...]:
+    """Per-stage drop totals for the Error & Loss Analysis summary.
+
+    Returns ``(stage_name, drops_total)`` for every stage in pipeline order, so
+    the Error & Loss Analysis section can list dropped frames **by the same
+    stage** the pipeline diagram shows them on. Because both the table and the
+    pipeline widget read these totals from the identical snapshot, the figures
+    are guaranteed to agree — dropping is acceptable, but it is always reported,
+    and always attributed to the stage that did it.
+    """
+    return tuple((st.name, st.drops_total) for st in snapshot.stages)
+
+
+def group_stages_by_process(
+    snapshot: PipelineSnapshot,
+) -> tuple[tuple[str, tuple[int, ...]], ...]:
+    """Group the snapshot's stages into contiguous runs by owning process.
+
+    Returns one ``(process_name, stage_indices)`` entry per maximal run of
+    adjacent stages that share a ``process`` tag, in pipeline order. This lets
+    the flow view draw a single labelled boundary around each process's stages
+    without owning any of the grouping logic. Pure and deterministic so the
+    mapping can be computed without the widget; an empty tag is reported as its own
+    ``"?"`` group rather than being silently merged.
+    """
+    groups: list[tuple[str, list[int]]] = []
+    for i, st in enumerate(snapshot.stages):
+        proc = st.process or "?"
+        if groups and groups[-1][0] == proc:
+            groups[-1][1].append(i)
+        else:
+            groups.append((proc, [i]))
+    return tuple((proc, tuple(idxs)) for proc, idxs in groups)
+
+
+
+
+#: A stage is considered "pressured" once its queue is at least this full.
+BOTTLENECK_UTILIZATION_THRESHOLD: float = 0.8
+
+
+def build_host_pipeline_snapshot(
+    *,
+    message_rate: float,
+    dropped_frames: int,
+    gate_capacity: int,
+    model_queue_depth: int,
+    recording: bool,
+    recorder_queue_depth: int = 0,
+    device_rate: float = 0.0,
+    producer_drops: int = 0,
+    transport_kind: str = "",
+    transport_loss: int = 0,
+    recorder_overflow: int = 0,
+    wall_time_s: float = 0.0,
+) -> PipelineSnapshot:
+    """Assemble the host data-path snapshot from already-measured numbers.
+
+    The chain is Device → Wire → Decode → Gate → Plot Buffer → Recorder. The Device
+    stage represents the sensor board producing samples: its rate is the device's
+    reported frame rate and its drops are samples the device discarded before
+    they reached the host. The remaining stages carry the measured host
+    message rate; the gate holds the overload drop count and its bounded
+    capacity, and the plot buffer/recorder show their current backlog. Pure: no Qt, no
+    I/O — callers feed in the measurements and read back the structure.
+
+    When *transport_kind* is ``"ble"`` an extra **Host BT** stage is inserted
+    between Device and Wire to represent the host OS Bluetooth stack (controller
+    → kernel HCI driver → BlueZ/WinRT/CoreBluetooth → bleak) — the part of the
+    path that produces the frames the application first sees, but which is
+    otherwise invisible. Its input rate is the device's produced rate and its
+    output rate is the rate actually received, so a shortfall (host-stack
+    coalescing/dropping notifications under load) is visible as a rate shrink.
+
+    Its drop counter is the confirmed ``sensor_data`` sequence-gap loss
+    (*transport_loss*) **net of the device's own producer drops**
+    (*producer_drops*) **and the GUI inbox's consumer-side overflow drops**
+    (*recorder_overflow*): ``max(0, transport_loss - producer_drops -
+    recorder_overflow)``. The device advances the sequence number even for
+    frames it drops internally, and a frame the GUI inbox dropped to stay
+    responsive was already delivered by the host Bluetooth stack — so each such
+    frame also appears to the host as a missing sequence number and would
+    otherwise be counted twice — once on its own stage (Device producer drop or
+    RECORDER_OVERFLOW) and again on Host BT (sequence gap). Subtracting both
+    leaves only the loss that the link itself introduced (over-the-air plus
+    host-stack loss), so the Host BT stage no longer mirrors the Device drop
+    count or absorbs consumer-side drops. For non-BLE
+    transports the stage is omitted, because there is no host Bluetooth layer in
+    the path. The host cannot be queried for richer per-driver health portably,
+    so these already-measured rates and the inferred loss are the cross-platform
+    signal.
+    """
+    rec_rate = message_rate if recording else 0.0
+    # Process attribution for the grouped flow view: the Device is the
+    # external sensor board; the optional Host BT stage is the host OS Bluetooth
+    # stack; the Wire + Decode stages run in the acquisition child process that
+    # pulls and decodes frames; the Gate, Plot Buffer and Recorder live in the GUI
+    # process that renders and records them.
+    host_bt_stages: tuple[StageMetrics, ...] = ()
+    if transport_kind == "ble":
+        # Confirmed sequence-gap loss net of the device's own producer drops AND
+        # the GUI inbox's consumer-side overflow drops: a frame the device
+        # dropped internally still advances the sequence number, and a frame the
+        # GUI inbox dropped to stay responsive was already delivered by the host
+        # Bluetooth stack — both surface as host-side sequence gaps. Counting
+        # either here as well as on its own stage (Device producer drop /
+        # RECORDER_OVERFLOW) would double-report it and wrongly blame Host BT, so
+        # both are subtracted.
+        host_bt_loss = transport_loss - producer_drops - recorder_overflow
+        if host_bt_loss < 0:
+            host_bt_loss = 0
+        host_bt_stages = (
+            StageMetrics(
+                name="Host BT",
+                in_rate=device_rate,
+                out_rate=message_rate,
+                drops_total=host_bt_loss,
+                process="Host",
+            ),
+        )
+    stages = (
+        StageMetrics(
+            name="Device",
+            in_rate=device_rate,
+            out_rate=device_rate,
+            drops_total=producer_drops,
+            process="Device",
+        ),
+        *host_bt_stages,
+        StageMetrics(
+            name="Wire", in_rate=message_rate, out_rate=message_rate,
+            process="Acquisition",
+        ),
+        StageMetrics(
+            name="Decode", in_rate=message_rate, out_rate=message_rate,
+            process="Acquisition",
+        ),
+        StageMetrics(
+            name="Gate",
+            in_rate=message_rate,
+            out_rate=message_rate,
+            queue_capacity=gate_capacity,
+            drops_total=dropped_frames,
+            process="GUI",
+        ),
+        StageMetrics(
+            name="Plot Buffer",
+            in_rate=message_rate,
+            out_rate=message_rate,
+            queue_depth=model_queue_depth,
+            process="GUI",
+        ),
+        StageMetrics(
+            name="Recorder",
+            in_rate=rec_rate,
+            out_rate=rec_rate,
+            queue_depth=recorder_queue_depth if recording else 0,
+            process="GUI",
+        ),
+    )
+    return PipelineSnapshot(stages=stages, wall_time_s=wall_time_s)
+
+
+def detect_bottleneck(snapshot: PipelineSnapshot) -> StageMetrics | None:
+    """Return the limiting stage in *snapshot*, or ``None`` if all are healthy.
+
+    A stage is a bottleneck candidate if it is actively dropping items or its
+    queue utilisation is at or above :data:`BOTTLENECK_UTILIZATION_THRESHOLD`.
+    Among candidates, the one with the highest utilisation wins; ties break
+    toward the stage with more accumulated drops, then earliest in pipeline
+    order (the upstream-most constraint). With no candidate, ``None`` is
+    returned. Deterministic and side-effect free.
+    """
+    best: StageMetrics | None = None
+    best_key: tuple[float, int] | None = None
+    for st in snapshot.stages:
+        if not (st.is_dropping or st.utilization >= BOTTLENECK_UTILIZATION_THRESHOLD):
+            continue
+        key = (st.utilization, st.drops_total)
+        if best_key is None or key > best_key:
+            best = st
+            best_key = key
+    return best

--- a/tools/data_forwarder_host/core/playout.py
+++ b/tools/data_forwarder_host/core/playout.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Smoothed wall-clock-to-device-time playout clock for live charts.
+
+:class:`PlayoutClock` is a pure, GUI-free state machine that decides *where the
+right edge of a live chart should be* at any wall-clock moment. Instead of
+snapping the view to the newest sample as it arrives — which makes the chart
+stutter when data comes in bursts or late — the clock advances a **device-time
+playout position** continuously, at a low-pass-filtered estimate of how fast the
+device timeline is advancing (device-milliseconds per wall-second).
+
+The position trails the newest received device timestamp by a small de-jitter
+*delay* (so late samples have time to arrive before their slot scrolls into
+view), is nudged toward that target with a gentle proportional *catch-up* (so
+device-timer drift is absorbed smoothly rather than in steps), and is clamped so
+it never runs ahead of the newest received timestamp (the chart never shows
+future/unreceived data) nor falls more than *max_lag* behind it (after a long
+stall it jumps forward to within the cap instead of crawling). The position is
+monotonic non-decreasing.
+
+The clock is deterministic: every method takes the current wall time as an
+argument, so callers inject ``time.monotonic()`` (or a fake clock for determinism).
+This module imports no Qt and holds no global state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: Target lag (device-ms) the playout position trails the newest timestamp by,
+#: giving jittered/late samples time to arrive before their slot scrolls in.
+DEFAULT_DELAY_MS: float = 150.0
+
+#: Hard cap (device-ms) on how far the position may fall behind the newest
+#: timestamp. After a long stall the position jumps forward to within this cap
+#: rather than crawling. Must be >= ``DEFAULT_DELAY_MS``.
+DEFAULT_MAX_LAG_MS: float = 1000.0
+
+#: EWMA smoothing factor (0 < alpha <= 1) for the device-rate estimate. Smaller
+#: means heavier low-pass filtering, so speed changes are applied more gradually.
+DEFAULT_RATE_ALPHA: float = 0.1
+
+#: Proportional gain (0 < k <= 1) for nudging the position toward its target lag.
+DEFAULT_CATCHUP_GAIN: float = 0.1
+
+#: Initial device-rate estimate (device-ms per wall-second) before any rate has
+#: been measured: assume the device clock runs at real time (1000 ms/s).
+DEFAULT_RATE_MS_PER_S: float = 1000.0
+
+#: Outlier-rejection band: an instantaneous rate sample is folded into the EWMA
+#: only if it lies within ``[1/BAND, BAND]`` of the current estimate, so a
+#: burst of buffered samples delivered at once does not yank the speed estimate.
+_RATE_OUTLIER_BAND: float = 10.0
+
+
+@dataclass(frozen=True, slots=True)
+class PlayoutConfig:
+    """Tunable constants for a :class:`PlayoutClock` (all device-ms / unitless)."""
+
+    delay_ms: float = DEFAULT_DELAY_MS
+    max_lag_ms: float = DEFAULT_MAX_LAG_MS
+    rate_alpha: float = DEFAULT_RATE_ALPHA
+    catchup_gain: float = DEFAULT_CATCHUP_GAIN
+    initial_rate_ms_per_s: float = DEFAULT_RATE_MS_PER_S
+
+    def __post_init__(self) -> None:
+        if not 0.0 < self.rate_alpha <= 1.0:
+            raise ValueError("rate_alpha must be in (0, 1]")
+        if not 0.0 < self.catchup_gain <= 1.0:
+            raise ValueError("catchup_gain must be in (0, 1]")
+        if self.delay_ms < 0.0:
+            raise ValueError("delay_ms must be >= 0")
+        if self.max_lag_ms < self.delay_ms:
+            raise ValueError("max_lag_ms must be >= delay_ms")
+        if self.initial_rate_ms_per_s <= 0.0:
+            raise ValueError("initial_rate_ms_per_s must be > 0")
+
+
+class PlayoutClock:
+    """Maps wall-clock time to a smoothed device-time playout position.
+
+    Feed the clock the newest device timestamp seen so far via :meth:`observe`
+    (typically once per ingest batch), then read :meth:`position_ms` on every
+    redraw tick. The returned position advances smoothly between observations at
+    the filtered device rate and is clamped to ``[newest - max_lag, newest]``.
+    """
+
+    def __init__(self, config: PlayoutConfig | None = None) -> None:
+        self._cfg = config or PlayoutConfig()
+        self._reset_state()
+
+    # -- lifecycle ---------------------------------------------------------
+    def _reset_state(self) -> None:
+        self._initialized = False
+        self._position_ms = 0.0
+        self._newest_ts = 0.0
+        self._rate_ms_per_s = self._cfg.initial_rate_ms_per_s
+        self._last_now_s = 0.0
+        self._obs_ts = 0.0
+        self._obs_now_s = 0.0
+
+    def reset(self) -> None:
+        """Return the clock to its uninitialised state (e.g. on new session)."""
+        self._reset_state()
+
+    @property
+    def is_initialized(self) -> bool:
+        """``True`` once the first :meth:`observe` has seeded the clock."""
+        return self._initialized
+
+    @property
+    def rate_ms_per_s(self) -> float:
+        """Current low-pass-filtered device rate (device-ms per wall-second)."""
+        return self._rate_ms_per_s
+
+    @property
+    def newest_ts_ms(self) -> float:
+        """The newest device timestamp observed so far (device-ms)."""
+        return self._newest_ts
+
+    # -- inputs ------------------------------------------------------------
+    def observe(self, newest_device_ts_ms: float, now_s: float) -> None:
+        """Record the newest device timestamp seen at wall time *now_s*.
+
+        Updates the low-pass device-rate estimate from the progress made since
+        the previous observation. Stalls (no new device progress) and outlier
+        bursts do not perturb the rate estimate.
+        """
+        if not self._initialized:
+            self._initialized = True
+            self._newest_ts = float(newest_device_ts_ms)
+            # Start already trailing by the target delay so we begin de-jittered.
+            self._position_ms = self._newest_ts - self._cfg.delay_ms
+            self._last_now_s = float(now_s)
+            self._obs_ts = float(newest_device_ts_ms)
+            self._obs_now_s = float(now_s)
+            return
+
+        dt = float(now_s) - self._obs_now_s
+        d_ts = float(newest_device_ts_ms) - self._obs_ts
+        if dt > 0.0 and d_ts > 0.0:
+            inst_rate = d_ts / dt
+            lo = self._rate_ms_per_s / _RATE_OUTLIER_BAND
+            hi = self._rate_ms_per_s * _RATE_OUTLIER_BAND
+            if lo <= inst_rate <= hi:
+                a = self._cfg.rate_alpha
+                self._rate_ms_per_s = (1.0 - a) * self._rate_ms_per_s + a * inst_rate
+            self._obs_ts = float(newest_device_ts_ms)
+            self._obs_now_s = float(now_s)
+        elif d_ts > 0.0:
+            # Progress with non-positive dt (same wall instant): advance anchor
+            # without a rate sample.
+            self._obs_ts = float(newest_device_ts_ms)
+            self._obs_now_s = float(now_s)
+
+        if newest_device_ts_ms > self._newest_ts:
+            self._newest_ts = float(newest_device_ts_ms)
+
+    # -- output ------------------------------------------------------------
+    def position_ms(self, now_s: float) -> float:
+        """Return the playout position (device-ms) at wall time *now_s*.
+
+        Advances the position by the filtered rate over the elapsed wall time
+        plus a gentle catch-up toward ``newest - delay``, then clamps it to
+        never exceed ``newest`` nor trail it by more than ``max_lag``, and keeps
+        it monotonic non-decreasing.
+        """
+        if not self._initialized:
+            return 0.0
+
+        dt = float(now_s) - self._last_now_s
+        if dt <= 0.0:
+            # No wall time has elapsed (e.g. a second widget reads the same tick,
+            # or the clock went backwards): the position is unchanged. This keeps
+            # repeated same-instant reads idempotent and the result monotonic.
+            return self._position_ms
+
+        base_advance = self._rate_ms_per_s * dt
+        target = self._newest_ts - self._cfg.delay_ms
+        error = target - (self._position_ms + base_advance)
+        catchup = self._cfg.catchup_gain * error
+        new_pos = self._position_ms + base_advance + catchup
+
+        # Never show future/unreceived data.
+        if new_pos > self._newest_ts:
+            new_pos = self._newest_ts
+        # Bound how far we trail: jump forward to the cap after a long stall.
+        min_pos = self._newest_ts - self._cfg.max_lag_ms
+        if new_pos < min_pos:
+            new_pos = min_pos
+        # Monotonic non-decreasing.
+        if new_pos < self._position_ms:
+            new_pos = self._position_ms
+
+        self._position_ms = new_pos
+        self._last_now_s = float(now_s)
+        return self._position_ms
+
+    def lag_ms(self, now_s: float) -> float:
+        """Current gap (device-ms) between the newest timestamp and the position."""
+        return self._newest_ts - self.position_ms(now_s)

--- a/tools/data_forwarder_host/core/recorder.py
+++ b/tools/data_forwarder_host/core/recorder.py
@@ -1,0 +1,493 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Recorder — RAM-first capture with transparent spill-to-disk shards.
+
+Buffering is gated on recording: nothing is accumulated unless a
+recording is active. When the RAM buffer grows past internal thresholds, the
+recorder transparently activates ``.npy`` shard storage so capture continues
+uninterrupted. The internal queue is bounded; on overflow capture
+continues and a single ``RECORDER_OVERFLOW`` event is surfaced.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import shutil
+import threading
+import time
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+import numpy as np
+from PySide6.QtCore import QObject, QTimer, Signal
+
+from data_forwarder_host.core.error_log import ErrorCategory, ErrorLog, ErrorSummary
+from data_forwarder_host.protocol.base import DecodedMessage
+from data_forwarder_host.utils.paths import app_cache_dir
+from data_forwarder_host.utils.timeutil import utc_iso8601_now
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Storage interfaces
+# ---------------------------------------------------------------------------
+
+Row = tuple[int, int | None, int | None, str | None, tuple[float, ...]]
+
+
+class RecordingStorage(Protocol):
+    def iter_rows(self) -> Iterable[Row]:
+        """Yields ``(t_host_ms, t_device_ms, seq, label, channels)``."""
+
+
+@dataclass(frozen=True)
+class Recording:
+    session_tag: str
+    started_utc: str
+    stopped_utc: str
+    session_info: dict[str, Any] | None
+    channel_names: tuple[str, ...]
+    storage: RecordingStorage
+    error_summary: ErrorSummary
+    incomplete: bool
+
+
+# ---------------------------------------------------------------------------
+# Storage backends
+# ---------------------------------------------------------------------------
+
+
+class RAMStorage:
+    """All rows kept in process memory."""
+
+    def __init__(self) -> None:
+        self._rows: list[Row] = []
+        self._bytes_estimate: int = 0
+
+    def append(self, row: Row) -> None:
+        self._rows.append(row)
+        # Rough estimate: 8B per float channel + ~32B fixed.
+        self._bytes_estimate += 32 + 8 * len(row[4])
+
+    def extend(self, rows: Iterable[Row]) -> None:
+        for r in rows:
+            self.append(r)
+
+    @property
+    def size_bytes(self) -> int:
+        return self._bytes_estimate
+
+    @property
+    def row_count(self) -> int:
+        return len(self._rows)
+
+    def iter_rows(self) -> Iterator[Row]:
+        yield from self._rows
+
+
+class SpillStorage:
+    """Append-only ``.npy`` shards under ``<user_cache_dir>/spill/<id>/``.
+
+    This is an internal scratch area (not the user's CSV output directory).
+    """
+
+    SHARD_BYTES = 32 * 1024 * 1024  # ~32 MB
+
+    def __init__(self, session_id: str, channel_count: int) -> None:
+        self._root = app_cache_dir() / "spill" / session_id
+        self._root.mkdir(parents=True, exist_ok=True)
+        self._channel_count = channel_count
+        self._shard_idx = 0
+        self._shard_rows: list[Row] = []
+        self._shard_bytes = 0
+        self._sealed_shards: list[Path] = []
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    def append(self, row: Row) -> None:
+        self._shard_rows.append(row)
+        self._shard_bytes += 32 + 8 * len(row[4])
+        if self._shard_bytes >= self.SHARD_BYTES:
+            self._flush_shard()
+
+    def extend(self, rows: Iterable[Row]) -> None:
+        for r in rows:
+            self.append(r)
+
+    def seal(self) -> None:
+        if self._shard_rows:
+            self._flush_shard()
+
+    def cleanup(self) -> None:
+        try:
+            shutil.rmtree(self._root, ignore_errors=True)
+        except Exception:
+            log.exception("failed to remove spill directory %s", self._root)
+
+    def iter_rows(self) -> Iterator[Row]:
+        for shard in self._sealed_shards:
+            try:
+                arr = np.load(shard, allow_pickle=True)
+            except Exception:
+                log.exception("failed to read shard %s", shard)
+                continue
+            for entry in arr:
+                yield (
+                    int(entry["t_host_ms"]),
+                    None if entry["t_device_ms"] < 0 else int(entry["t_device_ms"]),
+                    None if entry["seq"] < 0 else int(entry["seq"]),
+                    None if entry["label"] == "" else str(entry["label"]),
+                    tuple(float(v) for v in entry["channels"]),
+                )
+        # Any unflushed tail kept in RAM
+        for row in self._shard_rows:
+            yield row
+
+    def _flush_shard(self) -> None:
+        if not self._shard_rows:
+            return
+        dtype = np.dtype([
+            ("t_host_ms", np.int64),
+            ("t_device_ms", np.int64),
+            ("seq", np.int64),
+            ("label", "U64"),
+            ("channels", np.float64, (self._channel_count,)),
+        ])
+        arr = np.empty(len(self._shard_rows), dtype=dtype)
+        for i, (t, td, seq, lbl, ch) in enumerate(self._shard_rows):
+            arr[i]["t_host_ms"] = t
+            arr[i]["t_device_ms"] = td if td is not None else -1
+            arr[i]["seq"] = seq if seq is not None else -1
+            arr[i]["label"] = lbl or ""
+            if len(ch) == self._channel_count:
+                arr[i]["channels"] = ch
+            else:
+                # Channel count mismatch — pad/truncate.
+                padded = list(ch) + [0.0] * self._channel_count
+                arr[i]["channels"] = padded[: self._channel_count]
+        path = self._root / f"shard_{self._shard_idx:06d}.npy"
+        try:
+            np.save(path, arr, allow_pickle=False)
+            self._sealed_shards.append(path)
+        except Exception:
+            log.exception("failed to write shard %s", path)
+        self._shard_idx += 1
+        self._shard_rows = []
+        self._shard_bytes = 0
+
+
+# ---------------------------------------------------------------------------
+# Recorder
+# ---------------------------------------------------------------------------
+
+
+class Recorder(QObject):
+    """Records ``sensor_data`` messages from a single session.
+
+    RAM-first; spills to disk shards when either internal threshold is exceeded
+    (256 MB OR 10 minutes — whichever comes first). These thresholds are fixed
+    internal constants and are NOT user-configurable.
+    """
+
+    started = Signal()
+    stopped = Signal(object)            # Recording
+
+    SPILL_BYTES = 256 * 1024 * 1024
+    SPILL_SECONDS = 10 * 60
+    QUEUE_BOUND = 4096
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        session_tag: str,
+        error_log: ErrorLog,
+        parent: QObject | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._session_id = session_id
+        self._session_tag = session_tag
+        self._error_log = error_log
+
+        self._recording: bool = False
+        self._started_utc: str | None = None
+        self._session_info: dict[str, Any] | None = None
+        self._channel_names: tuple[str, ...] = ()
+        self._channel_count: int = 0
+        self._t_started_monotonic: float = 0.0
+        self._overflow_emitted: bool = False
+
+        self._ram: RAMStorage | None = None
+        self._spill: SpillStorage | None = None
+        self._using_spill: bool = False
+
+        self._queue: queue.Queue[Row | None] = queue.Queue(maxsize=self.QUEUE_BOUND)
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._lock = threading.RLock()
+
+        self._current: Recording | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def is_recording(self) -> bool:
+        return self._recording
+
+    @property
+    def using_spill(self) -> bool:
+        """True once capture has switched from RAM to on-disk spill shards."""
+        return self._using_spill
+
+    @property
+    def buffered_rows(self) -> int:
+        """Rows currently held in RAM (0 once spilling has freed them)."""
+        with self._lock:
+            return self._ram.row_count if self._ram is not None else 0
+
+    @property
+    def buffered_bytes(self) -> int:
+        """Estimated RAM bytes currently held (0 once spilling has freed them)."""
+        with self._lock:
+            return self._ram.size_bytes if self._ram is not None else 0
+
+    def elapsed_seconds(self) -> float | None:
+        """Return seconds since this recording started, or *None* if not recording."""
+        if not self._recording:
+            return None
+        return time.monotonic() - self._t_started_monotonic
+
+    def current(self) -> Recording | None:
+        return self._current
+
+    def set_session_info(self, info: dict[str, Any], channel_names: tuple[str, ...]) -> None:
+        with self._lock:
+            self._session_info = info
+            if channel_names:
+                self._channel_names = channel_names
+
+    def start(self, *, channel_names: tuple[str, ...]) -> None:
+        with self._lock:
+            if self._recording:
+                return
+            self._recording = True
+            self._overflow_emitted = False
+            self._started_utc = utc_iso8601_now()
+            self._t_started_monotonic = time.monotonic()
+            self._channel_names = channel_names or self._channel_names
+            self._channel_count = len(self._channel_names) if self._channel_names else 0
+            self._ram = RAMStorage()
+            self._spill = None
+            self._using_spill = False
+            self._stop_event.clear()
+            # Drain anything left over from a previous run.
+            try:
+                while True:
+                    self._queue.get_nowait()
+            except queue.Empty:
+                pass
+            self._thread = threading.Thread(
+                target=self._writer_loop, name=f"recorder-{self._session_id}", daemon=True
+            )
+            self._thread.start()
+        self.started.emit()
+
+    def stop(self) -> Recording:
+        with self._lock:
+            if not self._recording:
+                if self._current is not None:
+                    return self._current
+                raise RuntimeError("recorder is not running")
+            self._recording = False
+
+        # Signal writer thread to drain and exit.
+        self._queue.put(None)
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+
+        with self._lock:
+            if self._spill is not None:
+                self._spill.seal()
+            storage: RecordingStorage
+            if self._using_spill and self._spill is not None:
+                storage = self._spill
+            else:
+                storage = self._ram if self._ram is not None else RAMStorage()
+
+            # If recording started before any channel metadata was known (e.g.
+            # the v1-style "Record" begins streaming and capture in one click,
+            # before the device's session_info arrives), infer the channel
+            # names from the first captured row so the CSV header always matches
+            # the data width. Without this the header collapses to just the
+            # device-time column.
+            channel_names = self._channel_names
+            if not channel_names:
+                for row in storage.iter_rows():
+                    n = len(row[4])
+                    if n:
+                        channel_names = tuple(f"ch{i}" for i in range(n))
+                    break
+
+            summary = self._error_log.summary()
+            rec = Recording(
+                session_tag=self._session_tag,
+                started_utc=self._started_utc or utc_iso8601_now(),
+                stopped_utc=utc_iso8601_now(),
+                session_info=self._session_info,
+                channel_names=channel_names,
+                storage=storage,
+                error_summary=summary,
+                incomplete=summary.incomplete,
+            )
+            self._current = rec
+        self.stopped.emit(rec)
+        return rec
+
+    def cleanup_spill(self) -> None:
+        """Delete the on-disk spill folder. Caller must confirm with the user."""
+        with self._lock:
+            if self._spill is not None:
+                self._spill.cleanup()
+                self._spill = None
+            self._current = None
+
+    # ------------------------------------------------------------------
+    # Hot path (gated on recording)
+    # ------------------------------------------------------------------
+
+    def on_message(self, msg: DecodedMessage) -> None:
+        # Buffering is gated on recording: while not recording, nothing is
+        # accumulated (live plots/stats may still update elsewhere).
+        if not self._recording or msg.kind != "sensor_data" or msg.channels is None:
+            return
+        row: Row = (msg.t_host_ms, msg.t_device_ms, msg.seq, msg.label, msg.channels)
+        try:
+            self._queue.put_nowait(row)
+        except queue.Full:
+            # Bounded queue overflow: keep capturing (drop the oldest queued row
+            # to make room) and surface a single RECORDER_OVERFLOW event.
+            try:
+                self._queue.get_nowait()
+            except queue.Empty:
+                pass
+            try:
+                self._queue.put_nowait(row)
+            except queue.Full:
+                pass
+            if not self._overflow_emitted:
+                self._overflow_emitted = True
+                self._error_log.add(
+                    ErrorCategory.RECORDER_OVERFLOW,
+                    "recorder queue overflow; writer falling behind",
+                )
+
+    # ------------------------------------------------------------------
+    # Writer thread
+    # ------------------------------------------------------------------
+
+    def _writer_loop(self) -> None:
+        while True:
+            item = self._queue.get()
+            if item is None:
+                return
+            with self._lock:
+                if self._using_spill:
+                    # Once spilling, rows go to disk shards only. RAM was freed
+                    # in _begin_spill so the in-process object count (and the
+                    # cyclic-GC scan cost) stops growing during long recordings.
+                    if self._spill is not None:
+                        self._spill.append(item)
+                    continue
+                if self._ram is None:
+                    continue
+                self._ram.append(item)
+                if self._should_spill():
+                    self._begin_spill()
+
+    def _should_spill(self) -> bool:
+        if self._ram is None:
+            return False
+        if self._ram.size_bytes >= self.SPILL_BYTES:
+            return True
+        elapsed = time.monotonic() - self._t_started_monotonic
+        return elapsed >= self.SPILL_SECONDS
+
+    def _begin_spill(self) -> None:
+        if self._channel_count == 0 and self._ram is not None and self._ram.row_count:
+            # Infer channel count from the first row.
+            for row in self._ram.iter_rows():
+                self._channel_count = len(row[4])
+                break
+        self._spill = SpillStorage(self._session_id, max(self._channel_count, 1))
+        self._using_spill = True
+        if self._ram is not None:
+            self._spill.extend(self._ram.iter_rows())
+            # Release the RAM rows now that they live in the spill shards.
+            # Keeping them would let the list of tuples grow for the whole
+            # recording, driving unbounded memory use and ever-worsening
+            # cyclic-GC pauses that stall the entire GUI event loop.
+            self._ram = None
+
+
+# ---------------------------------------------------------------------------
+# Non-blocking recording-stop CSV dump
+# ---------------------------------------------------------------------------
+
+
+class CsvDumpJob(QObject):
+    """Drive a chunked CSV dump from the Qt event loop without blocking it.
+
+    Writing a finished recording to CSV happens at the recording-stop event. For
+    a large capture that write can take long enough to freeze the GUI if done in
+    one blocking call, so this job advances a :class:`RecordingCsvDump`-style
+    *dump* one bounded chunk per zero-delay timer tick: between ticks the event
+    loop is free to paint (the saving progress bar) and service input, so the UI
+    stays responsive while the file is written. ``progress`` reports
+    ``(rows_written, total)`` after every chunk (``total`` is ``-1`` when the
+    recording spilled to disk and the row count is not known up-front);
+    ``finished`` carries the written path and ``failed`` an error message.
+
+    The *dump* only needs ``step() -> bool``, ``rows_written``, ``total_rows``
+    and ``path`` — :class:`~data_forwarder_host.core.csv_writer.RecordingCsvDump`
+    satisfies this.
+    """
+
+    progress = Signal(int, int)   # rows_written, total (-1 if unknown)
+    finished = Signal(str)        # written CSV path
+    failed = Signal(str)          # error message
+
+    def __init__(self, dump: Any, *, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._dump = dump
+        self._timer = QTimer(self)
+        self._timer.setInterval(0)  # fire as soon as the event loop is idle
+        self._timer.timeout.connect(self._tick)
+
+    def start(self) -> None:
+        """Begin writing; chunks are processed on subsequent event-loop ticks."""
+        self._timer.start()
+
+    def cancel(self) -> None:
+        """Stop processing further chunks (the partial file is left in place)."""
+        self._timer.stop()
+
+    def _tick(self) -> None:
+        try:
+            more = self._dump.step()
+        except Exception as exc:  # noqa: BLE001 — surfaced to the GUI verbatim
+            self._timer.stop()
+            log.exception("recording CSV dump failed")
+            self.failed.emit(str(exc))
+            return
+        total = self._dump.total_rows if self._dump.total_rows is not None else -1
+        self.progress.emit(self._dump.rows_written, total)
+        if not more:
+            self._timer.stop()
+            self.finished.emit(str(self._dump.path))

--- a/tools/data_forwarder_host/core/sequence_tracker.py
+++ b/tools/data_forwarder_host/core/sequence_tracker.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Transport message-loss detector based on ``sensor_data`` sequence numbers.
+
+Each ``sensor_data`` message carries a monotonically increasing sequence number
+(wire path ``d/seq``). A perfect link delivers consecutive sequence numbers; a
+*gap* means one or more messages did not arrive — yet. Because the transport may
+reorder or briefly delay frames, a gap is **not** reported immediately: every
+missing sequence number is held for a configurable grace period — the **loss
+confirmation window** — and only counted as a transport loss if it has not
+arrived by the time that window elapses. If the missing number turns up within
+the window, its pending record is cleared and no loss is reported.
+
+The tracker is pure Python (no Qt) and its clock is injectable, so the policy is
+fully deterministic.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+# Guard against pathological re-baselines (counter reset, reconnect, device
+# restart). A jump larger than this in either direction is treated as a stream
+# discontinuity rather than millions of "missing" sequence numbers.
+_MAX_GAP = 100_000
+
+# Hard cap on the number of individually tracked pending (missing) sequence
+# numbers. This bounds both memory and the per-confirmation work no matter how
+# fast or how lossy the link is: a sustained flood with massive drops can no
+# longer grow ``_pending`` without limit (the historical cause of an unbounded
+# memory climb → OOM) nor make any single ``observe()`` iterate an arbitrarily
+# large gap (the historical cause of multi-second GUI-thread stalls). Once the
+# cap is reached, further missing numbers in the current burst are not tracked
+# individually; under that much loss they are reported in aggregate instead.
+_MAX_PENDING = 8_192
+
+
+class SequenceGapTracker:
+    """Detect missing ``sensor_data`` sequence numbers with a confirmation delay.
+
+    :param window_seconds: the loss confirmation window — how long a missing
+        sequence number is awaited before it is confirmed lost.
+    :param on_loss: called with the sorted list of sequence numbers confirmed
+        lost, once per sweep that confirms at least one loss.
+    :param time_fn: monotonic clock (seconds); injectable for determinism.
+    """
+
+    def __init__(
+        self,
+        *,
+        window_seconds: float,
+        on_loss: Callable[[list[int]], None],
+        time_fn: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be positive")
+        self._window = float(window_seconds)
+        self._on_loss = on_loss
+        self._time_fn = time_fn
+        self._expected: int | None = None
+        # Missing sequence number -> monotonic deadline by which it must arrive.
+        self._pending: dict[int, float] = {}
+        # Smallest deadline currently in ``_pending`` (or None when empty). Used
+        # to make the per-message sweep O(1) in the common case: if nothing is
+        # yet due, ``sweep()`` returns immediately instead of scanning/sorting
+        # the whole pending set on every single arriving frame. It is only ever
+        # a *lower bound* on the true minimum (recovery may remove the holder),
+        # which is safe — a stale-low value costs at most one extra bounded scan
+        # that then self-corrects, and it can never cause a due loss to be
+        # missed. Aggregate counts of losses that exceeded the tracking cap.
+        self._min_deadline: float | None = None
+        self._untracked_losses: int = 0
+
+    @property
+    def window_seconds(self) -> float:
+        return self._window
+
+    @property
+    def pending_count(self) -> int:
+        """Number of sequence numbers currently awaiting confirmation."""
+        return len(self._pending)
+
+    @property
+    def untracked_loss_count(self) -> int:
+        """Losses that exceeded the tracking cap and were counted in aggregate.
+
+        Under extreme, sustained loss the individually tracked pending set is
+        capped (see ``_MAX_PENDING``); any further missing numbers in such a
+        burst are not tracked one-by-one but accumulate here so the magnitude of
+        the loss is still observable without unbounded memory or CPU.
+        """
+        return self._untracked_losses
+
+    def set_window_seconds(self, window_seconds: float) -> None:
+        """Change the loss confirmation window (applies to future deadlines)."""
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be positive")
+        self._window = float(window_seconds)
+
+    def reset(self) -> None:
+        """Forget all state (e.g. when a new stream starts)."""
+        self._expected = None
+        self._pending.clear()
+        self._min_deadline = None
+        self._untracked_losses = 0
+
+    def observe(self, seq: int, *, now: float | None = None) -> int:
+        """Record an arrived sequence number; return losses confirmed in this call.
+
+        Recovers any matching pending number (a late/out-of-order arrival), then
+        records newly missing numbers for any forward gap, and finally sweeps
+        expired pending numbers.
+
+        The amount of work done here is bounded regardless of how large a gap is
+        or how many numbers are already pending: a forward gap adds at most
+        ``_MAX_PENDING`` tracked entries (any excess is counted in aggregate),
+        and the trailing sweep is O(1) until something is actually due.
+        """
+        t = self._time_fn() if now is None else now
+        seq = int(seq)
+
+        # A late/out-of-order arrival of a number we were waiting for: recovered.
+        # (We intentionally do not refresh ``_min_deadline`` here; it stays a
+        # safe lower bound, see the field comment.)
+        self._pending.pop(seq, None)
+
+        if self._expected is None:
+            self._expected = seq + 1
+            return self.sweep(now=t)
+
+        gap = seq - self._expected
+        if gap == 0:
+            self._expected = seq + 1
+        elif 0 < gap <= _MAX_GAP:
+            # Every integer in [expected, seq) is missing — await each, but only
+            # up to the tracking cap so a huge gap can neither iterate without
+            # bound nor grow ``_pending`` without bound. In a forward gap none of
+            # these numbers can already be pending, so no membership check.
+            deadline = t + self._window
+            room = _MAX_PENDING - len(self._pending)
+            track_until = self._expected + room if room > 0 else self._expected
+            if track_until > seq:
+                track_until = seq
+            for missing in range(self._expected, track_until):
+                self._pending[missing] = deadline
+            if self._min_deadline is None and self._pending:
+                self._min_deadline = deadline
+            # Numbers we had no room to track are, under this much loss, almost
+            # certainly genuine losses; record their magnitude in aggregate.
+            self._untracked_losses += seq - track_until
+            self._expected = seq + 1
+        elif gap > _MAX_GAP or -gap > _MAX_GAP:
+            # Implausible jump in either direction: treat as a stream
+            # discontinuity (reset/reconnect), re-baseline without confirming
+            # spurious losses across the boundary.
+            self._pending.clear()
+            self._min_deadline = None
+            self._expected = seq + 1
+        # else: small backwards step (seq < expected) that was not pending —
+        # a duplicate or an already-confirmed loss; ignore.
+
+        return self.sweep(now=t)
+
+    def sweep(self, *, now: float | None = None) -> int:
+        """Confirm and report any pending numbers whose window has elapsed.
+
+        Returns the number of losses confirmed. Safe to call on a timer so that
+        losses are confirmed even while no new messages arrive.
+
+        Fast path: when nothing is pending, or the earliest deadline is still in
+        the future, this returns in O(1) without scanning the pending set — so
+        calling it on every arriving frame (as ``observe`` does) is cheap. The
+        bounded scan/sort runs only at the moments a confirmation is actually
+        due, and over at most ``_MAX_PENDING`` entries.
+        """
+        t = self._time_fn() if now is None else now
+        if not self._pending:
+            self._min_deadline = None
+            return 0
+        if self._min_deadline is not None and t < self._min_deadline:
+            return 0
+        due = sorted(s for s, deadline in self._pending.items() if deadline <= t)
+        if not due:
+            # ``_min_deadline`` was a stale lower bound; recompute and bail.
+            self._min_deadline = min(self._pending.values())
+            return 0
+        for s in due:
+            del self._pending[s]
+        self._min_deadline = min(self._pending.values()) if self._pending else None
+        self._on_loss(due)
+        return len(due)

--- a/tools/data_forwarder_host/core/transfer_stats.py
+++ b/tools/data_forwarder_host/core/transfer_stats.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Pure derivation of received-frame categories for the bandwidth details view.
+
+The decoder reports raw counters (:class:`DecodeStats`); this module turns them
+into the human-facing reception categories shown in the bandwidth details
+sub-window: how many frames were received in total, how many decoded
+without issues, and the per-reason breakdown of the rest (including frames that
+arrived but were incomplete/corrupted). Kept GUI-free so it is isolated from the GUI.
+"""
+
+from __future__ import annotations
+
+from data_forwarder_host.protocol.base import DecodeStats
+
+
+def received_frame_breakdown(stats: DecodeStats) -> list[tuple[str, int]]:
+    """Return ordered ``(label, count)`` reception categories from *stats*.
+
+    * ``Received (all frames)`` — every frame seen, good or bad
+      (``frames_ok + frames_bad``).
+    * ``Decoded OK (no issues)`` — fully decoded frames (``frames_ok``).
+    * ``Received with issues`` — frames that arrived but failed decoding
+      (``frames_bad``); these are the incomplete/corrupted ones.
+    * Per-reason rows for the failures: COBS, CRC, malformed, CBOR.
+    """
+    received_all = stats.frames_ok + stats.frames_bad
+    return [
+        ("Received (all frames)", received_all),
+        ("Decoded OK (no issues)", stats.frames_ok),
+        ("Received with issues", stats.frames_bad),
+        ("  COBS framing errors", stats.cobs_errors),
+        ("  CRC errors", stats.crc_errors),
+        ("  Malformed frames", stats.malformed),
+        ("  CBOR decode errors", stats.cbor_errors),
+    ]
+
+
+def received_bytes_breakdown(stats: DecodeStats) -> list[tuple[str, int]]:
+    """Return ordered ``(label, bytes)`` reception categories from *stats*.
+
+    Mirrors :func:`received_frame_breakdown` but reports the real number of
+    bytes seen per category rather than the frame counts. For decoded
+    frames this is the COBS-decoded frame length; for COBS failures it is the
+    length of the raw on-wire chunk that could not be decoded.
+    """
+    return [
+        ("Received (all frames)", stats.bytes_ok + stats.bytes_bad),
+        ("Decoded OK (no issues)", stats.bytes_ok),
+        ("Received with issues", stats.bytes_bad),
+        ("  COBS framing errors", stats.bytes_cobs),
+        ("  CRC errors", stats.bytes_crc),
+        ("  Malformed frames", stats.bytes_malformed),
+        ("  CBOR decode errors", stats.bytes_cbor),
+    ]
+
+
+def byte_baseline(stats: DecodeStats) -> dict[str, int]:
+    """Capture per-category byte totals as a reset baseline.
+
+    The byte analogue of :func:`baseline_counts`; subtract from a later
+    :func:`received_bytes_breakdown` to obtain "since reset" byte deltas.
+    """
+    return {label: count for label, count in received_bytes_breakdown(stats)}
+
+
+def bytes_breakdown_since(
+    stats: DecodeStats, baseline: dict[str, int]
+) -> list[tuple[str, int, int]]:
+    """Return ordered ``(label, total_bytes, since_reset_bytes)`` rows.
+
+    The byte analogue of :func:`breakdown_since`: ``since_reset_bytes`` is
+    ``total_bytes - baseline[label]`` (never negative); an empty baseline yields
+    ``since_reset_bytes == total_bytes``.
+    """
+    return [
+        (label, total, max(0, total - baseline.get(label, 0)))
+        for label, total in received_bytes_breakdown(stats)
+    ]
+
+
+def baseline_counts(stats: DecodeStats) -> dict[str, int]:
+    """Capture the current per-category counts as a reset baseline.
+
+    The returned mapping is keyed by the same labels as
+    :func:`received_frame_breakdown`, so it can be subtracted from a later
+    breakdown to obtain "since reset" deltas.
+    """
+    return {label: count for label, count in received_frame_breakdown(stats)}
+
+
+def breakdown_since(
+    stats: DecodeStats, baseline: dict[str, int]
+) -> list[tuple[str, int, int]]:
+    """Return ordered ``(label, total, since_reset)`` rows.
+
+    ``total`` is the session-cumulative count; ``since_reset`` is
+    ``total - baseline[label]`` (never negative), i.e. how many of each
+    category were received since the window-scoped counter was last reset. A
+    missing baseline key counts as zero, so an empty baseline yields
+    ``since_reset == total``.
+    """
+    return [
+        (label, total, max(0, total - baseline.get(label, 0)))
+        for label, total in received_frame_breakdown(stats)
+    ]

--- a/tools/data_forwarder_host/data_forwarder_host.spec
+++ b/tools/data_forwarder_host/data_forwarder_host.spec
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+# PyInstaller spec for the Data Forwarder Host standalone binary.
+#
+# Produces ONE self-contained executable that bundles the CPython interpreter,
+# every third-party dependency (PySide6/Qt6 incl. QtCharts, numpy, bleak,
+# pyserial, cbor2, cobs, psutil, platformdirs) and the application package.
+# The end user runs a single file; nothing has to be installed.
+#
+# Build with:
+#     pyinstaller data_forwarder_host.spec
+#
+# (Normally driven by scripts/build_linux_binary.sh, which provisions an
+# isolated venv with the runtime deps + PyInstaller first.)
+
+import os
+import sys
+
+from PyInstaller.utils.hooks import collect_all, collect_submodules
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+# The package import name ``data_forwarder_host`` maps to *this* directory, so
+# its PARENT (``tools/``) must be importable for ``import data_forwarder_host``
+# to resolve. ``SPECPATH`` is the directory containing this spec file.
+#
+# IMPORTANT: only the PARENT (``tools/``) goes on ``pathex`` — never this package
+# directory itself. Putting the package dir on the search path makes PyInstaller
+# collect the package's internal subpackages (``platform``, ``core``, ``gui`` …)
+# *also* as top-level modules, so a bare stdlib ``import platform`` (reached via
+# ``uuid``) would resolve to ``data_forwarder_host/platform`` and explode with
+# ``module 'platform' has no attribute 'system'``. Keeping only ``tools/`` on the
+# path means the subpackages are reachable solely as ``data_forwarder_host.*``.
+PKG_DIR = os.path.abspath(SPECPATH)
+TOOLS_DIR = os.path.dirname(PKG_DIR)
+ENTRY = os.path.join(PKG_DIR, "scripts", "freeze_entry.py")
+
+# ---------------------------------------------------------------------------
+# Dependency collection
+# ---------------------------------------------------------------------------
+hiddenimports: list[str] = []
+datas: list = []
+binaries: list = []
+
+# Some dependencies pick their OS backend dynamically, so PyInstaller's static
+# import analysis misses it: bleak loads the BlueZ/D-Bus stack on Linux, and
+# pyserial imports its platform-specific port-listing module
+# (serial.tools.list_ports_linux/osx/windows) by name. collect_all pulls in each
+# package's code + data + every submodule so the frozen binary is complete.
+for pkg in ("bleak", "serial"):
+    b, d, h = collect_all(pkg)
+    binaries += b
+    datas += d
+    hiddenimports += h
+
+# The acquisition child is launched by `spawn`, which imports the target by
+# dotted path. Make sure every app submodule is present even if a future lazy
+# import hides one from static analysis.
+hiddenimports += collect_submodules("data_forwarder_host")
+
+# PySide6/Qt is handled by PyInstaller's bundled hooks (they include QtCharts as
+# long as it is imported, which it is). No manual Qt plugin wrangling needed.
+
+block_cipher = None
+
+a = Analysis(
+    [ENTRY],
+    pathex=[TOOLS_DIR],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    # Trim large, unused Qt modules to keep the binary smaller. The app only
+    # uses QtWidgets/QtGui/QtCore/QtCharts.
+    excludes=[
+        "PySide6.QtWebEngineCore",
+        "PySide6.QtWebEngineWidgets",
+        "PySide6.QtWebEngineQuick",
+        "PySide6.Qt3DCore",
+        "PySide6.Qt3DRender",
+        "PySide6.QtMultimedia",
+        "PySide6.QtMultimediaWidgets",
+        "PySide6.QtQuick3D",
+        "PySide6.QtDesigner",
+        "PySide6.QtPdf",
+        "tkinter",
+    ],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name="data-forwarder-host",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,  # GUI app: no console window
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/tools/data_forwarder_host/docs/ble_throughput_tuning.md
+++ b/tools/data_forwarder_host/docs/ble_throughput_tuning.md
@@ -1,0 +1,382 @@
+<!--
+Copyright (c) 2026 Nordic Semiconductor ASA
+SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+-->
+
+# BLE throughput: why it varies and how to make it faster
+
+You opened this guide because the live BLE stream is dropping frames or running
+slower than you expect. This document explains **what actually limits BLE
+throughput** for the `data_forwarder_host` tool, and gives you an **ordered,
+do-this-next procedure** to get more out of the link.
+
+Read §1 to understand the tested baseline and why your numbers may differ, skim
+§2–§3 for the data path and the levers, then follow §4 step by step. §5 lists
+the firmware-side changes for when the host is exhausted.
+
+> ## OS applicability — read this first
+>
+> The concepts (§1–§3, §5) are **OS-independent**. The hands-on host commands in
+> §4 are **not**, because each operating system exposes the Bluetooth stack
+> differently. Every host step is tagged with the OS it applies to:
+>
+> | Tag | Platform | Status in this tool |
+> |-----|----------|---------------------|
+> | **[Linux]**   | Linux / BlueZ        | ✅ Supported and validated (tested on Ubuntu). Most tunable from the host. |
+> | **[macOS]**   | macOS / CoreBluetooth | ⚠️ **Should run but not validated** (untested). The OS auto-negotiates aggressively, so almost nothing is user-tunable. |
+> | **[Windows]** | Windows / WinRT       | ⚠️ **Should run but not validated** (untested). Like macOS, no host-side throughput knobs apply. Notes are included so you know what *would* apply, but treat them as untested. |
+>
+> If a step is not tagged for your OS, it does not apply to you — skip to the
+> next one. When the host platform offers no knob (macOS, and most of Windows),
+> the only remaining wins are **firmware-side (§5)**.
+
+## 1. The tested baseline (and why yours may be slower)
+
+The default device acquisition this tool is validated against is **500 frames
+per second, 10 channels per frame** — i.e. **500 BLE notifications/s**, each
+carrying one CBOR `sensor-data` sample. That is the number the pipeline, the
+decoder and the Host BT stage were sized and tested for.
+
+**This is a reference point, not a guarantee.** The *actual* throughput you see
+depends on a stack of factors that are mostly **outside the host application's
+control**, because they live in the Bluetooth controllers and the radio
+environment. In rough order of real-world impact:
+
+1. **Connection interval.** The single biggest lever. A short interval
+   (7.5–15 ms) gives many connection events per second; a long one (30–50 ms)
+   starves a 500 Hz stream and forces many notifications into each event, which
+   the controller then coalesces or drops. The **peripheral's preferred
+   interval usually wins**, so this is often a firmware question (§5.1).
+
+2. **Other Bluetooth activity on the same adapter.** This is the effect you may
+   have observed. A single Bluetooth controller **time-division-multiplexes all
+   of its links** — there is one radio. If the host already has another BLE
+   connection, a Classic-BT transfer, A2DP audio, or even an HID mouse/keyboard
+   active on the same adapter, those links **steal connection events and airtime
+   from your stream**, so its effective rate drops. Disconnect or move competing
+   peripherals to a different adapter when you need full bandwidth.
+
+3. **Wi-Fi / 2.4 GHz coexistence.** Most laptops use a **combo Wi-Fi+BT chip
+   that shares one antenna and radio**. When Wi-Fi is busy, the chip's
+   coexistence arbitration **blanks BLE** during Wi-Fi slots — delaying or
+   dropping connection events even with no other BT device in sight. Heavy Wi-Fi
+   traffic, a nearby microwave oven, Zigbee, or other BLE/2.4 GHz devices all
+   eat into your effective throughput. Using a **dedicated USB BLE dongle** (a
+   separate radio) sidesteps most of this.
+
+4. **Signal margin / distance.** Weak signal → more link-layer retransmissions →
+   lower *effective* throughput even though the nominal rate is unchanged. Keep
+   the device close and in line of sight while tuning.
+
+5. **Negotiated radio parameters — PHY, Data Length, ATT MTU.** If the link
+   comes up at 1M PHY, 27-byte packets, or the 23-byte minimum MTU, each ~90 B
+   frame is fragmented across several packets/notifications and the per-packet
+   overhead multiplies. These are controller-negotiated (§3).
+
+6. **Host-side delivery cost.** The OS Bluetooth stack must hand all 500
+   notifications/s up to the application. On Linux the delivery path matters
+   (D-Bus vs. a dedicated socket — the app already picks the fast one, §3.1); a
+   slow/old USB controller, USB power-saving (autosuspend), or a CPU-starved
+   host can also coalesce or drop notifications.
+
+The takeaway: **a clean radio environment and a dedicated adapter matter as much
+as any setting.** Before blaming the firmware, eliminate competing BT links and
+Wi-Fi contention, then work through §4.
+
+## 2. How the data path works
+
+The host is a BLE **central**. It scans, connects to the device-side
+`samples/data_forwarder` peripheral, and subscribes to **notifications** on the
+Nordic UART Service (NUS) **TX** characteristic. Each notification payload is a
+COBS/CBOR frame, decoded by the same pipeline the UART source uses.
+
+The path has more layers than it looks:
+
+```
+[Device radio] → [Host BT stack] → [bleak] → [decode] → [pipeline]
+   firmware       controller +      Python     COBS/      IoWorker
+                  kernel HCI +       async      CBOR
+                  BlueZ/WinRT/CB
+```
+
+The easily-overlooked layer is the **Host BT stack** between the device
+radiating a frame and `bleak` handing over bytes. When that stack is busy
+(multiple connections, Wi-Fi coexistence, a competing transfer — see §1), it
+coalesces or drops notifications. The bandwidth-details pipeline therefore shows
+a dedicated **Host BT** stage:
+
+* its **input rate** is the device's produced frame rate (sampling Hz) and its
+  **output rate** is the rate the app actually receives — a host-stack shortfall
+  shows up as a produced-vs-received rate shrink;
+* its **drop counter** is the confirmed transport loss: the `sensor_data`
+  **sequence-gap** losses detected by `core/sequence_tracker.py` (frames the
+  device sent that never arrived). These are over-the-air *plus* host-stack
+  losses, distinct from the device's own reported drops.
+
+The bottleneck detector flags this stage when it is the limiter, so a losing
+host link points you at the host Bluetooth side rather than the sensor board.
+
+## 3. The workload, the levers, and who owns each one
+
+Each sample is a CBOR `sensor-data` map, COBS-framed, with an optional CRC-16
+trailer (see `cddl/data_forwarder.cddl`):
+
+```
+sensor-data = { "seq": uint32, "ts": uint32, "lbl": uint8, "val": [10 × float32] }
+```
+
+Rough on-wire size per frame:
+
+| Part                                   | Bytes (approx.) |
+|----------------------------------------|-----------------|
+| 10 channels × float32 values           | 40              |
+| CBOR keys + `seq`/`ts`/`lbl` + headers | ~25–35          |
+| COBS framing + delimiter               | ~2              |
+| CRC-16 trailer (if enabled)            | 2               |
+| **Total per frame**                    | **~80–95**      |
+
+At 500 Hz that is **~40–47 KB/s ≈ 320–380 kbps of application payload**. The
+link is *not* limited by raw radio bandwidth so much as by **per-packet and
+per-event overhead**. The biggest wins therefore come from sending **fewer,
+larger packets per second** — not a "faster radio" alone.
+
+The classic levers, and **who controls each** (which tells you where the change
+must be made):
+
+| Lever | Effect | Owner | Settable from the host app? |
+|-------|--------|-------|-----------------------------|
+| **Data Length Extension (27 → 251 B)** | One LL packet carries up to 251 B, so a ~90 B notification rides in **one** PDU instead of 4–5. | Controller, both ends; auto-negotiated. | **No** — not exposed by `bleak`/BlueZ. |
+| **2M PHY** | Doubles symbol rate (1 → 2 Msym/s); higher ceiling, shorter air-time. | Controller, both ends; central requests it. | **No** — automatic if both controllers + the OS stack support it. |
+| **ATT MTU (23 → 247 B)** | Largest single notification payload (MTU − 3). At 247 a ~90 B frame fits in one notification; at 23 it fragments. | Negotiated at connect. | **No** — the app can only **read** `client.mtu_size`; it is auto-maxed on macOS/Windows. |
+| **Connection interval** | Shorter interval → far more connection events/s → far more notifications/s. **The single biggest non-firmware lever.** | Central proposes; **peripheral's preferred params usually win**. | **No** — no portable `bleak` API; OS/firmware config only. |
+| **TX power (dBm)** | More signal margin → fewer retransmits at range. Helps *reliability*, not the ceiling. | Controller/adapter, both ends. | **No** — not exposed by `bleak`. |
+
+**Key point:** none of these are settable from portable Python — they are
+negotiated in the controllers. The app's job is to (a) make sure the OS stack
+actually *uses* the big ones and (b) consume 500 notifications/s efficiently.
+Everything the app *can* do is already done (§3.1).
+
+### 3.1 What the host application already does for you
+
+* **[Linux] Prefers BlueZ `AcquireNotify`.** `bleak` can deliver notifications
+  either via D-Bus `PropertiesChanged` signals (the default) or via a dedicated
+  SEQPACKET socket (`AcquireNotify`). At 500 notifications/s the D-Bus path is a
+  real bottleneck and a source of coalesced/dropped frames. The source passes
+  `bluez={"use_start_notify": False}` to select `AcquireNotify`, falling back
+  automatically when unsupported. The argument is inert on macOS/Windows, so it
+  is cross-platform safe.
+* **[All] Logs the negotiated ATT MTU** (`client.mtu_size`) after connect, so
+  you can confirm the link came up with a large MTU rather than silently at 23.
+* **[All] Surfaces the Host BT stage** in the pipeline (§2) so transport loss is
+  attributed to the host side, not the device.
+
+Because the app's levers are already pulled, the procedure below is about
+**radio hygiene, OS configuration, and finally firmware.**
+
+## 4. Speed-up procedure (do this in order)
+
+Work top to bottom. Re-measure after each step (via the **Host BT** pipeline
+stage, and on Linux with `btmon`).
+
+### 4.1 [All] Remove competing radio load first — free and high-impact
+
+Before touching any setting, clean up the environment (this is the most common
+real-world fix; see §1, points 2–3):
+
+* **Disconnect other Bluetooth devices** from the same adapter — other BLE
+  peripherals, BT audio (A2DP), BT mice/keyboards. They share one radio with
+  your stream.
+* **Reduce 2.4 GHz contention** — pause large Wi-Fi transfers, move away from
+  busy access points / microwaves, or prefer a **5 GHz** Wi-Fi network so the
+  combo chip's coexistence logic stops blanking BLE.
+* **Use a dedicated USB BLE dongle** instead of the built-in combo Wi-Fi+BT
+  chip when you can — a separate radio avoids Wi-Fi coexistence entirely.
+* **Move the device closer / into line of sight** to cut retransmissions.
+
+Reconnect and re-measure. If the Host BT stage now shows no drops, you are done.
+
+### 4.2 [Linux/macOS] Measure what the link actually negotiated
+
+Knowing which lever is limiting you avoids guesswork.
+
+**[Linux]** capture the negotiation with `btmon`:
+
+```bash
+sudo btmon > btmon.log
+# now connect with the tool, wait a few seconds, then Ctrl-C
+grep -iE "Connection interval|Max TX octets|Max RX octets|PHY:" btmon.log
+```
+
+Interpret it:
+
+| What you see | Meaning |
+|--------------|---------|
+| `TX PHY: LE 2M` / `RX PHY: LE 2M` | ✅ 2M PHY active. |
+| `Max TX octets: 251` / `Max RX octets: 251` | ✅ DLE active. |
+| `Connection interval: 7.50–15.00 msec` | ✅ Short interval — good for 500 Hz. |
+| `Connection interval: 30–50 msec` | ❌ **Almost always the bottleneck** at 500 Hz. |
+
+**[macOS]** there is no `btmon`. Use the **PacketLogger** tool from Apple's
+*Additional Tools for Xcode* to capture an HCI trace, or rely on the tool's own
+**Host BT** pipeline stage and the logged ATT MTU. macOS negotiates 2M PHY, DLE
+and a large MTU automatically, so the only realistic limiter you can see is the
+connection interval — which on macOS you cannot change from the host (go to
+§5.1).
+
+**[Windows]** *(not validated)* the equivalent capture is a **Bluetooth
+ETW/Btvs** trace via the Windows Driver Kit, but this path is untested for
+this tool.
+
+If PHY shows `LE 1M` or DLE octets are 27, your **adapter or OS stack is the
+limiter** — see §4.5. If the interval is 30–50 ms, continue with §4.3.
+
+### 4.3 [Linux] Shorten the connection interval from the host
+
+A 45 ms interval gives only ~22 connection events/s — fragile at 500 Hz. Lower
+BlueZ's proposed defaults **before connecting** (root; values reset on reboot):
+
+```bash
+# units of 1.25 ms → 6 = 7.5 ms, 12 = 15 ms. Replace hci0 with your adapter.
+echo 6  | sudo tee /sys/kernel/debug/bluetooth/hci0/conn_min_interval
+echo 12 | sudo tee /sys/kernel/debug/bluetooth/hci0/conn_max_interval
+cat /sys/kernel/debug/bluetooth/hci0/conn_min_interval   # expect 6
+cat /sys/kernel/debug/bluetooth/hci0/conn_max_interval   # expect 12
+```
+
+Reconnect and re-check `btmon`. **Two outcomes:**
+
+* Interval drops to ~7.5–15 ms → done, throughput should rise sharply.
+* Interval springs back to ~30–50 ms → the **device's preferred parameters are
+  overriding you** (the central only *proposes*). Go to §5.1 (firmware).
+
+> **If `tee` fails with `Operation not permitted` even under `sudo`:** the kernel
+> is in **lockdown** mode (triggered by Secure Boot), which forbids debugfs
+> writes:
+> ```bash
+> cat /sys/kernel/security/lockdown   # "[integrity]"/"[confidentiality]" = locked
+> mokutil --sb-state                  # "SecureBoot enabled" = the cause
+> ```
+> Disable Secure Boot in UEFI to lift lockdown — but if the device is requesting
+> 30–50 ms anyway (very common), the host setting is overridden regardless, so
+> prefer the firmware fix in §5.1.
+
+**[macOS] / [Windows]** there is no supported host-side knob for the connection
+interval; the firmware must request a short one (§5.1).
+
+### 4.4 [Linux/macOS] Confirm the device is not requesting a long interval
+
+**[Linux]** look for a **Connection Parameter Update Request** from the
+peripheral:
+
+```bash
+grep -iA4 "Connection Parameter" btmon.log
+```
+
+If you see `Min: 24 / Max: 40` (= 30–50 ms), the firmware is asking for a long
+interval and the OS honours it. No host setting beats this — the fix is §5.1.
+(On macOS the same is true; you just confirm it from a PacketLogger trace.)
+
+### 4.5 [Linux/macOS] Verify the adapter and stack can do 2M PHY + DLE
+
+If §4.2 showed `LE 1M` or 27-byte octets, the adapter or stack is the cap:
+
+```bash
+bluetoothctl --version     # [Linux] prefer a recent BlueZ (5.50+)
+hciconfig                  # [Linux] confirm the adapter is present and UP
+```
+
+Use a modern USB controller that supports **2M PHY + DLE + a small connection
+interval**; an old dongle caps throughput regardless of every other setting. On
+macOS the built-in controller already supports these — there is nothing to
+configure.
+
+### 4.6 [All] Re-measure with the pipeline
+
+Run a session and watch the **Host BT** stage:
+
+* **No drops, produced ≈ received** → the host side is optimal; for more, go to
+  §5.
+* **Drops / rate shrink persist** → the bottleneck has moved to the device or
+  the air; the highest-impact next step is sample batching (§5.2).
+
+## 5. Going further: firmware (+ matching host) changes
+
+When the host is exhausted — or your OS offers no knob (macOS, Windows) — these
+raise throughput further but require a **firmware change** (sometimes plus a
+matching host decoder change). Ordered by typical payoff.
+
+### 5.1 Shorten the connection interval in firmware (highest-impact, do first)
+
+Make the peripheral request a 7.5–15 ms interval so the link no longer falls
+back to 30–50 ms. In the device `prj.conf`:
+
+```ini
+CONFIG_BT_PERIPHERAL_PREF_MIN_INT=6     # 6 × 1.25 ms = 7.5 ms
+CONFIG_BT_PERIPHERAL_PREF_MAX_INT=12    # 12 × 1.25 ms = 15 ms
+CONFIG_BT_PERIPHERAL_PREF_LATENCY=0
+CONFIG_BT_PERIPHERAL_PREF_TIMEOUT=400   # 4 s supervision timeout
+```
+
+or call it explicitly after connect:
+
+```c
+struct bt_le_conn_param param = BT_LE_CONN_PARAM_INIT(6, 12, 0, 400);
+bt_conn_le_param_update(conn, &param);
+```
+
+Reflash, reconnect, and confirm the interval dropped to ~7.5–15 ms.
+
+### 5.2 Batch multiple samples per notification (biggest end-to-end win)
+
+Instead of one CBOR frame per sample (500 notifications/s), pack N samples into
+one notification (e.g. 5 → 100 notifications/s). This amortises every
+per-packet/per-notification overhead on both ends — usually the single largest
+end-to-end improvement. Requires a device-side framing change and a host-side
+decoder that iterates samples within a frame.
+
+### 5.3 Switch the high-rate stream to an L2CAP CoC
+
+A connection-oriented channel has lower per-packet overhead and built-in flow
+control versus GATT notifications. Requires a new device-side transport and a
+host-side L2CAP client; note `bleak` does not currently expose L2CAP CoC, so the
+host would need a BlueZ-specific socket path.
+
+### 5.4 Explicitly drive 2M PHY + DLE from the device
+
+Call `bt_conn_le_phy_update()` and `bt_conn_le_data_len_update()` right after
+connect so the link does not rely on automatic negotiation timing. (The
+`samples/data_forwarder` sample should enable the buffers —
+`CONFIG_BT_L2CAP_TX_MTU=247`, `CONFIG_BT_BUF_ACL_RX_SIZE=251` — so this just
+forces the update early.)
+
+### 5.5 Compress the payload
+
+Use int16 fixed-point instead of float32, or delta-encode samples, to roughly
+halve bytes/sample. A device encoder + host decoder change.
+
+### 5.6 Tune device TX power for range
+
+Match TX power to the deployment range to cut retransmissions and improve
+*effective* throughput at the edge of range.
+
+## 6. Quick reference
+
+| Symptom (from the pipeline / a trace) | Fix | Where |
+|---------------------------------------|-----|-------|
+| Throughput drops when another BT/Wi-Fi transfer is active | Free the radio: disconnect peers, cut 2.4 GHz load, use a dedicated dongle | §4.1 |
+| Notifications coalesced/dropped on Linux | `AcquireNotify` | Host app (already done) |
+| `Connection interval: 30–50 msec`, Linux host | Lower `conn_min/max_interval` | §4.3 |
+| Interval bounces back; device requests 30–50 ms (any OS) | Lower peripheral preferred interval | §5.1 |
+| `LE 1M` PHY or 27-byte octets | Modern adapter + recent stack | §4.5 |
+| Still notification-bound after interval fix | Batch N samples/notification | §5.2 |
+| Want lower per-packet overhead + flow control | L2CAP CoC | §5.3 |
+| Bytes/sample too high | Compress payload (int16/delta) | §5.5 |
+| Drops only at range | Raise device TX power | §5.6 |
+
+**Bottom line:** the tool is validated at **500 frames/s × 10 channels**, but
+real throughput is dominated by things the host app cannot set — the
+**connection interval**, **competing BT/Wi-Fi activity on the same radio**, and
+**signal quality**. First clean up the radio environment (§4.1); on **Linux**
+try the connection-interval change (§4.3); on **macOS/Windows**, or when the
+device overrides the host, shorten the interval in **firmware (§5.1)**. After
+that, **sample batching (§5.2)** is the biggest remaining win.

--- a/tools/data_forwarder_host/gui/__init__.py
+++ b/tools/data_forwarder_host/gui/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""PySide6 GUI — main window, dialogs, per-session tab."""

--- a/tools/data_forwarder_host/gui/ble_live_scanner.py
+++ b/tools/data_forwarder_host/gui/ble_live_scanner.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Continuous (live) BLE scanner that streams device detections to the GUI.
+
+Unlike the one-shot :meth:`BleNusSource.discover` (which waits a fixed timeout
+and returns the whole batch at once), :class:`BleLiveScanner` starts a
+``bleak`` scanner and reports every advertisement as it arrives via Qt signals.
+The New Session dialog uses it so the device list fills in *as the window is
+open* — devices appear within a fraction of a second and there is no Refresh
+button or fixed scan wait.
+
+The scanner runs its own asyncio event loop on a worker :class:`QThread`; the
+signals are delivered to the GUI thread (queued connections), so widget updates
+happen on the main thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from PySide6.QtCore import QObject, Signal
+
+
+class BleLiveScanner(QObject):
+    """Run a continuous BLE scan, emitting one signal per detection/state.
+
+    Signals (delivered on the GUI thread when connected from it):
+    - ``device_found(SourceInfo)`` — a device advertisement was seen;
+    - ``state_changed(str)`` — ``"on"`` once scanning started, ``"off"`` when no
+      usable Bluetooth backend is available, ``"unknown"`` if it cannot tell.
+    """
+
+    device_found = Signal(object)
+    state_changed = Signal(str)
+
+    #: Hard cap (seconds) on a single ``bleak`` start/stop call, so a wedged
+    #: Bluetooth backend can never hang the worker thread forever — which, on
+    #: dialog teardown, would otherwise abort the process with
+    #: "QThread: Destroyed while thread is still running".
+    _BLEAK_OP_TIMEOUT = 5.0
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._stop_evt: asyncio.Event | None = None
+        # Set from the GUI thread the instant a stop is requested. Read by the
+        # scan coroutine so a stop that races *ahead* of loop/event creation is
+        # never lost (otherwise the coroutine would block forever and its thread
+        # could not be joined on teardown).
+        self._stop_requested = False
+
+    # -- worker-thread entry point -----------------------------------------
+
+    def run(self) -> None:
+        """Event-loop body; invoke from a worker ``QThread.started`` signal."""
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        try:
+            self._loop.run_until_complete(self._scan())
+        except Exception:  # noqa: BLE001 - never let the worker thread die noisily
+            pass
+        finally:
+            try:
+                self._loop.close()
+            finally:
+                asyncio.set_event_loop(None)
+
+    async def _scan(self) -> None:
+        try:
+            from bleak import BleakScanner
+        except ImportError:
+            self.state_changed.emit("unknown")
+            return
+
+        from data_forwarder_host.source.ble_nus import (
+            _NO_BLUETOOTH_BACKEND_MSG,
+            BleNusSource,
+            _describe_scan_failure,
+        )
+
+        self._stop_evt = asyncio.Event()
+        # A stop may already have been requested before the event existed.
+        if self._stop_requested:
+            return
+
+        def _on_detect(device: Any, adv: Any) -> None:
+            try:
+                info = BleNusSource._info_from_advertisement(
+                    str(getattr(device, "address", "") or ""), device, adv
+                )
+            except Exception:  # noqa: BLE001 - a single bad advert must not stop the scan
+                return
+            self.device_found.emit(info)
+
+        scanner = BleakScanner(detection_callback=_on_detect)
+        try:
+            await asyncio.wait_for(scanner.start(), timeout=self._BLEAK_OP_TIMEOUT)
+        except asyncio.TimeoutError:
+            self.state_changed.emit("unknown")
+            return
+        except Exception as exc:  # noqa: BLE001 - classified for the UI below
+            reason = _describe_scan_failure(exc)
+            self.state_changed.emit(
+                "off" if reason == _NO_BLUETOOTH_BACKEND_MSG else "unknown"
+            )
+            return
+
+        # If a stop landed during start(), tear the scanner down at once.
+        if self._stop_requested:
+            await self._safe_stop_scanner(scanner)
+            return
+
+        self.state_changed.emit("on")
+        try:
+            await self._stop_evt.wait()
+        finally:
+            await self._safe_stop_scanner(scanner)
+
+    @staticmethod
+    async def _safe_stop_scanner(scanner: Any) -> None:
+        """Stop *scanner* without ever blocking the worker thread indefinitely."""
+        try:
+            await asyncio.wait_for(
+                scanner.stop(), timeout=BleLiveScanner._BLEAK_OP_TIMEOUT
+            )
+        except Exception:  # noqa: BLE001 - best-effort teardown (incl. timeout)
+            pass
+
+    # -- GUI-thread control -------------------------------------------------
+
+    def stop(self) -> None:
+        """Ask the scan loop to stop; safe to call from the GUI thread."""
+        self._stop_requested = True
+        loop = self._loop
+        stop_evt = self._stop_evt
+        if loop is not None and stop_evt is not None:
+            try:
+                loop.call_soon_threadsafe(stop_evt.set)
+            except RuntimeError:
+                # Loop already closed/stopped — nothing left to wake.
+                pass

--- a/tools/data_forwarder_host/gui/dialogs/__init__.py
+++ b/tools/data_forwarder_host/gui/dialogs/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Modal dialogs (new session, sink config, about)."""

--- a/tools/data_forwarder_host/gui/dialogs/about_dialog.py
+++ b/tools/data_forwarder_host/gui/dialogs/about_dialog.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""About dialog."""
+
+from __future__ import annotations
+
+from PySide6.QtWidgets import QDialog, QDialogButtonBox, QLabel, QVBoxLayout
+
+from data_forwarder_host.utils.logging import log_user_action
+from data_forwarder_host.utils.version import get_version
+
+
+class AboutDialog(QDialog):
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("About Data Forwarder")
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel(f"<b>Data Forwarder Host</b><br>v{get_version()}"))
+        layout.addWidget(QLabel(
+            "Copyright © 2026 Nordic Semiconductor ASA<br>"
+            "License: LicenseRef-Nordic-5-Clause"
+        ))
+        bb = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok)
+        bb.accepted.connect(self._on_ok)
+        layout.addWidget(bb)
+
+    def _on_ok(self) -> None:
+        log_user_action("Clicked OK in the About dialog")
+        self.accept()
+
+    def closeEvent(self, event) -> None:  # noqa: N802 (Qt naming)
+        log_user_action("Closed the About dialog")
+        super().closeEvent(event)

--- a/tools/data_forwarder_host/gui/dialogs/new_session_dialog.py
+++ b/tools/data_forwarder_host/gui/dialogs/new_session_dialog.py
@@ -1,0 +1,1517 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""New-session dialog — builds a validated :class:`SessionConfig`.
+
+The user chooses and configures a single data source (UART or BLE NUS) and
+defines the recording ``label`` and per-session output directory. There is no
+protocol selection (the single COBS/CBOR v1 protocol is fixed) and no sink
+configuration (output is a single CSV file).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from PySide6.QtCore import Qt, QThread, QTimer, Signal
+from PySide6.QtGui import QBrush, QColor
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QInputDialog,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QSpinBox,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from data_forwarder_host.gui.scan_worker import ScanWorker
+from data_forwarder_host.platform.base import PlatformAdapter
+from data_forwarder_host.session.config import ConfigError, SessionConfig, SourceSpec
+from data_forwarder_host.source import SOURCE_KINDS, source_for_kind
+from data_forwarder_host.source.base import ConfigField, RoleMode
+from data_forwarder_host.source.ble_nus import DEFAULT_DEVICE_NAME
+from data_forwarder_host.utils.logging import log_user_action
+
+# Default source kind: BLE NUS is preselected when the dialog opens.
+DEFAULT_SOURCE_KIND = "ble"
+
+# Process-wide registry of scan threads that did not finish within the join
+# timeout on dialog teardown. Holding a Python reference here keeps the QThread
+# (and its scanner) alive until it actually finishes, so it is never garbage-
+# collected or destroyed while still running — which would abort the process.
+_PENDING_SCAN_THREADS: set[QThread] = set()
+
+
+def _detach_running_scan_thread(thread: QThread, scanner: Any) -> None:
+    """Keep a still-running scan thread alive until it finishes, then delete it.
+
+    Called when ``QThread.wait`` times out. Destroying a running ``QThread``
+    aborts the process, so instead we retain references and schedule deletion
+    via the thread's ``finished`` signal.
+    """
+    _PENDING_SCAN_THREADS.add(thread)
+
+    def _cleanup() -> None:
+        _PENDING_SCAN_THREADS.discard(thread)
+        try:
+            thread.deleteLater()
+        except RuntimeError:
+            pass
+        if scanner is not None:
+            try:
+                scanner.deleteLater()
+            except RuntimeError:
+                pass
+
+    try:
+        thread.finished.connect(_cleanup)
+    except RuntimeError:
+        pass
+
+
+# How often the live BLE device list is repainted from coalesced detections.
+# A fixed 1 s cadence keeps rows from toggling/re-sorting several times a second.
+_DEVICE_REFRESH_MS = 1000
+
+# Default bandwidth-averaging window for a new session (seconds). Independent of
+# the plot window; adjustable later from the session window.
+DEFAULT_BANDWIDTH_WINDOW_SECONDS = 1.0
+
+# Hint shown next to a disabled OK button until a usable data source is ready.
+_HINT_PICK_KIND = "Pick a data source."
+_HINT_BLE_SELECT = "Choose a data source: select a Bluetooth device from the list."
+_HINT_BLE_CONNECTING = (
+    "Press Connect to connect to the selected device. "
+    "Create session enables once connected."
+)
+
+
+def compute_ok_state(
+    kind: str,
+    *,
+    ble_selected: bool = False,
+    ble_connected: bool = False,
+) -> tuple[bool, str]:
+    """Decide whether OK is enabled, and the hint to show while it is not.
+
+    Pure (no Qt) so the gating policy is isolated. For BLE the user must
+    select a device *and* the connection attempted in the dialog must have
+    succeeded (connect-in-dialog hand-off). UART is gated only by
+    having chosen a kind; its port is validated on accept.
+    """
+    if not kind:
+        return False, _HINT_PICK_KIND
+    if kind == "ble":
+        if not ble_selected:
+            return False, _HINT_BLE_SELECT
+        if not ble_connected:
+            return False, _HINT_BLE_CONNECTING
+        return True, ""
+    return True, ""
+
+
+def compute_scan_status(
+    *,
+    device_count: int,
+    has_selection: bool,
+    selected_name: str | None = None,
+) -> tuple[str, str]:
+    """Decide the idle BLE status line (icon state, text) — pure, no Qt.
+
+    This is the line refreshed periodically while scanning. It must *reinforce*
+    the current guidance rather than clobber it: once the user has selected a
+    device the line keeps telling them to press Connect (instead of reverting to
+    the generic device-count prompt on the next scan tick).
+    """
+    if device_count <= 0:
+        return (
+            "checking",
+            "Looking for Bluetooth devices… make sure the device is advertising.",
+        )
+    if has_selection:
+        name = selected_name or "the selected device"
+        return (
+            "on",
+            f"Selected {name}. Press Connect to connect "
+            f"({device_count} device(s) found).",
+        )
+    return (
+        "on",
+        f"Bluetooth is on. {device_count} device(s) found — select one to connect.",
+    )
+
+
+def compute_connect_button(
+    *,
+    selected_id: str | None,
+    connected_id: str | None,
+    connecting: bool = False,
+    canceling: bool = False,
+) -> tuple[str, bool]:
+    """Decide the Connect/Disconnect toggle label and enabled state (pure).
+
+    Selecting a device never connects or disconnects anything; the
+    button is the *only* control that changes the connection, and it is a
+    toggle that re-targets whatever device is currently selected:
+
+    - the selected device **is** the connected one → ``"Disconnect"`` (enabled):
+      pressing it tears the live connection down;
+    - any other (or no) connection for the selected device → ``"Connect"``
+      (enabled): pressing it disconnects the previously connected device, if
+      any, and connects the selected one.
+
+    The button is disabled **only** when there is nothing whatsoever to act on
+    (no device selected **and** nothing connected). It stays enabled while a
+    connect/cancel is in flight and is **never** disabled merely because a
+    device is connected — an active connection always shows an enabled control
+    so the user can disconnect at any moment. The ``connecting`` and
+    ``canceling`` flags are accepted for call-site symmetry but no longer gate
+    the enabled state; in-flight clicks are blocked by the modal progress popup,
+    not by greying the button out.
+    """
+    is_connected_selected = selected_id is not None and selected_id == connected_id
+    has_connection = connected_id is not None
+    # The toggle targets the connected device for "Disconnect" when it is the
+    # selected one or when nothing else is selected; otherwise it offers to
+    # connect the currently-selected device.
+    target_is_disconnect = is_connected_selected or (
+        selected_id is None and has_connection
+    )
+    label = "Disconnect" if target_is_disconnect else "Connect"
+    enabled = selected_id is not None or has_connection
+    return label, enabled
+
+
+# Braille spinner frames used to animate "Connecting…"/"Disconnecting…" states.
+_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
+
+
+def spinner_frame(tick: int) -> str:
+    """Return the spinner glyph for animation step *tick* (pure, no Qt)."""
+    return _SPINNER_FRAMES[tick % len(_SPINNER_FRAMES)]
+
+
+def order_ble_devices(infos):
+    """Order discovered BLE devices for the selection list (ordering only).
+
+    Devices are arranged into three ordering groups — there is no visual
+    grouping, only sort order:
+
+    1. devices advertising the target sample name ``"nRF DataFwd"``;
+    2. other *named* devices;
+    3. *unnamed* devices.
+
+    Within a group the secondary key is **signal strength** (RSSI), strongest
+    first; a missing RSSI sorts last. The sort is stable, so devices that are
+    otherwise equal keep their discovery order.
+    """
+    def group(info) -> int:
+        name = (info.details.get("name") or "").strip()
+        if name == DEFAULT_DEVICE_NAME:
+            return 0
+        if name:
+            return 1
+        return 2
+
+    def rssi(info) -> float:
+        value = info.details.get("rssi")
+        return float(value) if isinstance(value, (int, float)) else float("-inf")
+
+    return sorted(infos, key=lambda i: (group(i), -rssi(i)))
+
+
+class _BusyDialog(QDialog):
+    """Tiny non-modal popup with an animated spinner, e.g. while disconnecting.
+
+    It is intentionally non-blocking: the GUI stays responsive (the actual
+    disconnect runs on a worker thread) and the popup is closed by the caller
+    once the operation finishes.
+    """
+
+    def __init__(self, parent, text: str) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Please wait")
+        self.setModal(False)
+        # Drop the close button — the popup is dismissed programmatically.
+        self.setWindowFlags(
+            self.windowFlags() & ~Qt.WindowType.WindowCloseButtonHint
+        )
+        row = QHBoxLayout(self)
+        self._spin = QLabel(spinner_frame(0))
+        self._label = QLabel(text)
+        row.addWidget(self._spin)
+        row.addWidget(self._label)
+        self._tick = 0
+        self._timer = QTimer(self)
+        self._timer.setInterval(100)
+        self._timer.timeout.connect(self._advance)
+        self._timer.start()
+
+    def _advance(self) -> None:
+        self._tick += 1
+        self._spin.setText(spinner_frame(self._tick))
+
+    def closeEvent(self, event) -> None:  # noqa: N802 (Qt naming)
+        self._timer.stop()
+        super().closeEvent(event)
+
+
+class _ConnectProgressDialog(QDialog):
+    """Application-modal popup shown while a BLE connection is established.
+
+    It grabs input focus so the New Session form is inaccessible during the
+    connect (the operation can take seconds and must not be interrupted by
+    further clicks). It offers **Cancel**; cancellation is handled by the
+    caller, which keeps the device's Connect button disabled until the
+    in-flight attempt has been safely torn down (avoiding the "too many
+    connections right after cancelling" device fault).
+    """
+
+    cancel_requested = Signal()
+
+    def __init__(self, parent, device_name: str) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Connecting")
+        self.setWindowModality(Qt.WindowModality.ApplicationModal)
+        # No close/help button — Cancel is the only way out.
+        self.setWindowFlags(
+            self.windowFlags()
+            & ~Qt.WindowType.WindowCloseButtonHint
+            & ~Qt.WindowType.WindowContextHelpButtonHint
+        )
+        self.setMinimumWidth(360)
+        layout = QVBoxLayout(self)
+        row = QHBoxLayout()
+        self._spin = QLabel(spinner_frame(0))
+        self._label = QLabel(f"Connecting to {device_name}…")
+        self._label.setWordWrap(True)
+        row.addWidget(self._spin)
+        row.addWidget(self._label, 1)
+        layout.addLayout(row)
+
+        btn_row = QHBoxLayout()
+        btn_row.addStretch(1)
+        self._cancel = QPushButton("Cancel")
+        self._cancel.clicked.connect(self._on_cancel)
+        btn_row.addWidget(self._cancel)
+        layout.addLayout(btn_row)
+
+        self._tick = 0
+        self._timer = QTimer(self)
+        self._timer.setInterval(100)
+        self._timer.timeout.connect(self._advance)
+        self._timer.start()
+
+    def _advance(self) -> None:
+        self._tick += 1
+        self._spin.setText(spinner_frame(self._tick))
+
+    def _on_cancel(self) -> None:
+        # Reflect that cancellation is underway; the caller closes the popup
+        # once the in-flight connection has been safely released.
+        log_user_action("Clicked Cancel in the BLE connecting popup")
+        self._cancel.setEnabled(False)
+        self._label.setText("Cancelling… please wait")
+        self.cancel_requested.emit()
+
+    def reject(self) -> None:  # noqa: D401 - intercept Esc to behave like Cancel
+        if self._cancel.isEnabled():
+            self._on_cancel()
+
+    def closeEvent(self, event) -> None:  # noqa: N802 (Qt naming)
+        self._timer.stop()
+        super().closeEvent(event)
+
+
+class NewSessionDialog(QDialog):
+    """Dialog that returns a validated :class:`SessionConfig`."""
+
+    def __init__(self, platform: PlatformAdapter, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("New session")
+        self.resize(540, 520)
+        self._platform = platform
+        self._config: SessionConfig | None = None
+        self._source_field_widgets: dict[str, Any] = {}
+
+        # Connect-in-dialog state: the BLE source is opened here
+        # and handed to the new session; OK is gated on a live connection.
+        self._prepared_source: Any = None
+        self._ble_selected_info: Any = None
+        self._ble_connected = False
+        self._threads: list[QThread] = []
+        self._workers: list[Any] = []
+        # Live (continuous) BLE scan that streams detections while the dialog is
+        # open — no Refresh button, no fixed scan wait. ``_seen_rows`` maps a
+        # device address to its row so detections upsert in place (keeping the
+        # current selection and the connected-row highlight stable).
+        self._scanner: Any = None
+        self._scanner_thread: QThread | None = None
+        self._seen_rows: dict[str, int] = {}
+        # All discovered devices, keyed by address, so the streamed detections
+        # can be kept in the sort order (nRF first, then named, then
+        # unnamed; RSSI strongest-first within a group) as the list updates.
+        self._device_infos: dict[str, Any] = {}
+        # Detections arrive faster than is useful to render; they are coalesced
+        # into ``_device_infos`` and the table is refreshed on a fixed 1 s timer
+        # so rows do not flicker/re-sort several times a second.
+        self._devices_dirty = False
+        self._refresh_timer = QTimer(self)
+        self._refresh_timer.setInterval(_DEVICE_REFRESH_MS)
+        self._refresh_timer.timeout.connect(self._flush_device_rows)
+        # The BLE scan is started only *after* the dialog is first shown so the
+        # window pops up immediately and the Bluetooth work happens afterwards.
+        self._shown = False
+        # Set just before accept(): distinguishes a confirmed hand-off (keep the
+        # prepared source open) from a cancel/close (release the connection so
+        # the device starts advertising again and reappears on reopen).
+        self._accepted = False
+        # Each device selection bumps this token; an in-flight connection whose
+        # token is stale (the user clicked another device) is discarded. The
+        # source being connected is tracked so it can be aborted on supersede.
+        self._connect_token = 0
+        self._connecting_source: Any = None
+        # Explicit connect/cancel lifecycle: connection is only
+        # attempted when the user clicks Connect, behind a modal progress popup.
+        self._connected_info: Any = None
+        self._connecting = False
+        self._canceling = False
+        self._progress: _ConnectProgressDialog | None = None
+
+        # Status-line spinner animation (connecting/disconnecting feedback).
+        self._spin_tick = 0
+        self._spin_base = ""
+        self._spin_tone = "neutral"
+        self._spin_timer = QTimer(self)
+        self._spin_timer.setInterval(120)
+        self._spin_timer.timeout.connect(self._on_spin_tick)
+        self._disconnect_popup: _BusyDialog | None = None
+
+        outer = QVBoxLayout(self)
+        outer.setSpacing(6)
+
+        # ── Session identity ──────────────────────────────────────────
+        form = QFormLayout()
+        form.setContentsMargins(0, 0, 0, 0)
+        form.setVerticalSpacing(6)
+        outer.addLayout(form)
+
+        self._tag = QLineEdit()
+        self._tag.setPlaceholderText("auto-generated if left blank")
+        form.addRow("Session tag:", self._tag)
+
+        self._plot_secs = QDoubleSpinBox()
+        self._plot_secs.setRange(1.0, 600.0)
+        self._plot_secs.setValue(10.0)
+        self._plot_secs.setSuffix(" s")
+        form.addRow("Plot window:", self._plot_secs)
+
+        # ── Data source ───────────────────────────────────────────────
+        source_box = QGroupBox("Data source")
+        slayout = QFormLayout(source_box)
+        self._source_layout = slayout
+        outer.addWidget(source_box)
+
+        self._source_kind = QComboBox()
+        for kind in SOURCE_KINDS:
+            self._source_kind.addItem(kind, kind)
+        slayout.addRow("Kind:", self._source_kind)
+
+        # ── BLE controls (read-only Bluetooth status + live device list) ──
+        # Built once; shown only while the BLE kind is selected. The Bluetooth
+        # state is a *read-only* reflection of the host OS setting — the app
+        # never turns the adapter on/off.
+        self._ble_host = QWidget()
+        ble_layout = QVBoxLayout(self._ble_host)
+        ble_layout.setContentsMargins(0, 0, 0, 0)
+        ble_layout.setSpacing(4)
+
+        status_row = QHBoxLayout()
+        status_row.setContentsMargins(0, 0, 0, 0)
+        status_row.setSpacing(6)
+        self._bt_icon = QLabel("")
+        self._bt_icon.setToolTip(
+            "Read-only Bluetooth status, reflecting your host OS setting. The "
+            "app does not change it; enable Bluetooth in your operating system."
+        )
+        status_row.addWidget(self._bt_icon)
+        self._bt_status = QLabel("")
+        self._bt_status.setWordWrap(True)
+        status_row.addWidget(self._bt_status, 1)
+        ble_layout.addLayout(status_row)
+
+        # Guidance shown only when Bluetooth is off/unavailable.
+        self._bt_hint = QLabel(
+            "Bluetooth is turned off. Enable Bluetooth in your host operating "
+            "system settings, then reopen this dialog."
+        )
+        self._bt_hint.setWordWrap(True)
+        self._bt_hint.setStyleSheet("color:#AA8800;")
+        self._bt_hint.setVisible(False)
+        ble_layout.addWidget(self._bt_hint)
+
+        self._ble_list = QTableWidget(0, 3)
+        self._ble_list.setHorizontalHeaderLabels(["Name", "Address", "Signal"])
+        self._ble_list.setMinimumHeight(140)
+        self._ble_list.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self._ble_list.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
+        self._ble_list.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        self._ble_list.verticalHeader().setVisible(False)
+        # Name and Address are user-resizable (drag the header dividers); the
+        # Signal column keeps its content-based default width, which is good.
+        header = self._ble_list.horizontalHeader()
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.Interactive)
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.Interactive)
+        header.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
+        header.setStretchLastSection(False)
+        self._ble_list.setColumnWidth(0, 240)
+        self._ble_list.setColumnWidth(1, 180)
+        self._ble_list.itemSelectionChanged.connect(self._on_ble_device_selected)
+        ble_layout.addWidget(self._ble_list)
+
+        # Explicit Connect action — selection no longer auto-connects so the
+        # GUI never appears to "halt" the moment a device is clicked. OK stays
+        # disabled until Connect succeeds.
+        connect_row = QHBoxLayout()
+        connect_row.setContentsMargins(0, 0, 0, 0)
+        connect_row.addStretch(1)
+        self._connect_btn = QPushButton("Connect")
+        self._connect_btn.setToolTip(
+            "Connect to the selected device. A progress window appears while the "
+            "connection is established; you can cancel it there."
+        )
+        self._connect_btn.setEnabled(False)
+        self._connect_btn.clicked.connect(self._on_connect_clicked)
+        connect_row.addWidget(self._connect_btn)
+        ble_layout.addLayout(connect_row)
+
+        slayout.addRow(self._ble_host)
+
+        # ── UART discovery button + schema form ───────────────────────
+        self._discover = QPushButton("Discover…")
+        self._discover.clicked.connect(self._on_discover)
+        slayout.addRow("", self._discover)
+
+        self._source_form_host = QWidget()
+        self._source_form = QFormLayout(self._source_form_host)
+        slayout.addRow(self._source_form_host)
+
+        # ── Protocol configuration ────────────────────────────────────
+        # Protocol-specific options live in their own section, separate from
+        # the data-source selection.
+        protocol_box = QGroupBox("Protocol configuration")
+        protocol_layout = QFormLayout(protocol_box)
+        self._expect_crc = QCheckBox("Frames carry CRC-16 trailer")
+        self._expect_crc.setChecked(True)
+        protocol_layout.addRow("", self._expect_crc)
+        outer.addWidget(protocol_box)
+
+        self._ble_note = QLabel("")
+        self._ble_note.setWordWrap(True)
+        self._ble_note.setVisible(False)
+        outer.addWidget(self._ble_note)
+
+        # ── Buttons ───────────────────────────────────────────────────
+        bb = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        bb.accepted.connect(self._accept)
+        bb.rejected.connect(self.reject)
+        self._ok_button = bb.button(QDialogButtonBox.StandardButton.Ok)
+        if self._ok_button is not None:
+            # "OK" is not self-explanatory for this dialog; spell out the action.
+            self._ok_button.setText("Create session")
+        outer.addWidget(bb)
+
+        # Inline hint shown next to the buttons while OK is disabled.
+        self._ok_hint = QLabel("")
+        self._ok_hint.setWordWrap(True)
+        self._ok_hint.setStyleSheet("color:#AA8800;")
+        outer.addWidget(self._ok_hint)
+
+        self._source_kind.currentIndexChanged.connect(self._on_source_kind_changed)
+        # BLE is the default source kind.
+        default_idx = self._source_kind.findData(DEFAULT_SOURCE_KIND)
+        if default_idx >= 0:
+            self._source_kind.setCurrentIndex(default_idx)
+        self._rebuild_source_fields()
+        log_user_action("Opened the New Session dialog")
+
+
+    # ------------------------------------------------------------------
+    # Public
+    # ------------------------------------------------------------------
+
+    def result_config(self) -> SessionConfig | None:
+        return self._config
+
+    def reject(self) -> None:  # noqa: D401 - log Cancel / Esc on the dialog
+        log_user_action("Cancelled the New Session dialog")
+        self._stop_live_scan()
+        self._release_unconfirmed_connection()
+        super().reject()
+
+    def closeEvent(self, event) -> None:  # noqa: N802 (Qt naming)
+        log_user_action("Closed the New Session dialog")
+        self._stop_live_scan()
+        self._release_unconfirmed_connection()
+        super().closeEvent(event)
+
+    def showEvent(self, event) -> None:  # noqa: N802 (Qt naming)
+        # Show the window first, then kick off the Bluetooth scan on the next
+        # event-loop turn so the dialog pops up immediately (the bleak backend
+        # import + scan no longer block the first paint).
+        super().showEvent(event)
+        if not self._shown:
+            self._shown = True
+            if self._source_kind.currentData() == "ble":
+                QTimer.singleShot(0, self._start_live_scan)
+
+    def _release_unconfirmed_connection(self) -> None:
+        """Close a still-open BLE connection when the dialog is cancelled/closed.
+
+        Without this, a device connected in the dialog stays connected after a
+        cancel/close; a connected peripheral stops advertising, so it would not
+        reappear in the scan on reopen. Skipped when the session was confirmed
+        (the live source is handed off and must stay open).
+        """
+        if self._accepted:
+            return
+        self._abort_pending_connection()
+        self._discard_prepared_source()
+
+    def prepared_source(self) -> Any:
+        """The live source opened in the dialog, handed to the new session.
+
+        Non-``None`` only for BLE once a device has been selected and connected.
+        UART currently reconnects at session start, so this is
+        ``None`` for UART.
+        """
+        return self._prepared_source
+
+    # ------------------------------------------------------------------
+    # Source sub-form
+    # ------------------------------------------------------------------
+
+    def _on_source_kind_changed(self) -> None:
+        kind = self._source_kind.currentData()
+        log_user_action("Selected data source kind: %s", kind)
+        # Drop any half-prepared BLE connection when leaving BLE.
+        self._discard_prepared_source()
+        self._rebuild_source_fields()
+
+    def _rebuild_source_fields(self) -> None:
+        while self._source_form.count():
+            item = self._source_form.takeAt(0)
+            w = item.widget()
+            if w is not None:
+                w.deleteLater()
+        self._source_field_widgets.clear()
+
+        kind = self._source_kind.currentData()
+        is_ble = kind == "ble"
+
+        # Stop any live BLE scan; it is (re)started only for the BLE kind below.
+        self._stop_live_scan()
+
+        # BLE uses its bespoke connect-in-dialog UI; UART uses the schema form.
+        self._ble_host.setVisible(is_ble)
+        self._source_form_host.setVisible(not is_ble)
+        self._discover.setVisible(not is_ble)
+        self._ble_note.setVisible(False)
+
+        if is_ble:
+            self._ble_list.setRowCount(0)
+            self._seen_rows = {}
+            self._device_infos = {}
+            self._ble_selected_info = None
+            self._ble_connected = False
+            self._connected_info = None
+            self._connecting = False
+            self._canceling = False
+            self._connect_btn.setEnabled(False)
+            self._update_ok_state()
+            # Live, continuous scan: devices stream into the list as the dialog
+            # is open (no Refresh button, no fixed scan wait). The very first
+            # scan is deferred to showEvent so the window pops up immediately;
+            # later kind switches (dialog already shown) start it right away.
+            if self._shown:
+                self._start_live_scan()
+            return
+
+        if not kind:
+            self._update_ok_state()
+            return
+
+        cls = source_for_kind(kind)
+        schema = cls.config_schema()
+        for f in schema.fields:
+            widget = self._make_widget(f)
+            self._source_field_widgets[f.name] = (f, widget)
+            self._source_form.addRow(f"{f.label}{' *' if f.required else ''}:", widget)
+
+        if kind == "uart":
+            self._auto_fill_uart_port()
+        self._update_ok_state()
+
+
+    def _auto_fill_uart_port(self) -> None:
+        try:
+            cls = source_for_kind("uart")
+            infos = cls.discover(self._platform)
+        except Exception:
+            return
+        if not infos:
+            return
+        candidates = sorted(
+            infos,
+            key=lambda i: (0 if i.details.get("looks_like_nrf") else 1, i.id),
+        )
+        port_widget = self._source_field_widgets.get("port")
+        if port_widget:
+            _, w = port_widget
+            w.setText(candidates[0].id)
+
+    def _make_widget(self, f: ConfigField):
+        if f.kind == "int":
+            sb = QSpinBox()
+            sb.setRange(-(2**31), 2**31 - 1)
+            if isinstance(f.default, int):
+                sb.setValue(f.default)
+            return sb
+        if f.kind == "float":
+            ds = QDoubleSpinBox()
+            ds.setDecimals(4)
+            ds.setRange(0.0, 10_000.0)
+            if isinstance(f.default, (int, float)):
+                ds.setValue(float(f.default))
+            return ds
+        if f.kind == "bool":
+            cb = QCheckBox()
+            cb.setChecked(bool(f.default))
+            return cb
+        le = QLineEdit()
+        le.setText(str(f.default) if f.default is not None else "")
+        if f.help:
+            le.setToolTip(f.help)
+        return le
+
+    def _read_value(self, f: ConfigField, widget: Any) -> Any:
+        if f.kind == "int":
+            return int(widget.value())
+        if f.kind == "float":
+            return float(widget.value())
+        if f.kind == "bool":
+            return bool(widget.isChecked())
+        return widget.text().strip()
+
+    # ------------------------------------------------------------------
+    # Discover (UART only)
+    # ------------------------------------------------------------------
+
+    def _on_discover(self) -> None:
+        kind = self._source_kind.currentData()
+        log_user_action("Clicked Discover for source kind %r", kind)
+        if kind == "uart":
+            self._discover_uart()
+        elif kind == "ble":
+            self._discover_ble()
+        else:
+            QMessageBox.information(self, "Discover", "Discovery is not supported for this source.")
+
+    def _discover_uart(self) -> None:
+        cls = source_for_kind("uart")
+        infos = cls.discover(self._platform)
+        if not infos:
+            QMessageBox.information(self, "Discover", "No serial ports detected.")
+            return
+        candidates = sorted(
+            infos, key=lambda i: (0 if i.details.get("looks_like_nrf") else 1, i.id)
+        )
+        items = [
+            f"{'★  ' if i.details.get('looks_like_nrf') else '   '}{i.display}"
+            for i in candidates
+        ]
+        item, ok = QInputDialog.getItem(
+            self, "Discover serial ports", "Select port:", items, 0, False
+        )
+        if not ok:
+            return
+        chosen = candidates[items.index(item)]
+        log_user_action("Selected serial port %s from discovery", chosen.id)
+        port_widget = self._source_field_widgets.get("port")
+        if port_widget:
+            _, w = port_widget
+            w.setText(chosen.id)
+
+    def _discover_ble(self) -> None:
+        # BLE no longer uses the Discover… button; selection happens via the
+        # Bluetooth toggle + live list. Kept as a no-op guard for safety.
+        QMessageBox.information(
+            self, "Bluetooth", "Turn Bluetooth on and pick a device from the list."
+        )
+
+    # ------------------------------------------------------------------
+    # BLE: Bluetooth toggle + live list + connect-in-dialog
+    # ------------------------------------------------------------------
+
+    def _run_off_thread(self, fn, on_done, on_failed) -> None:
+        """Run a blocking *fn* on a worker thread; deliver result on GUI thread.
+
+        The result/failure handlers must run on the **GUI thread** (they touch
+        widgets). Connecting the worker signals to *bound methods of self* — a
+        QObject living on the GUI thread — makes Qt use a queued cross-thread
+        connection, so the handlers run on the GUI thread. Connecting to a bare
+        lambda instead would run them on the worker thread (direct connection)
+        and crash the app the moment a widget is touched.
+        """
+        thread = QThread(self)
+        worker = ScanWorker(fn)
+        worker.moveToThread(thread)
+        # Stash per-run state on the worker so the shared dispatch slots can
+        # recover it via sender().
+        worker._df_on_done = on_done
+        worker._df_on_failed = on_failed
+        worker._df_thread = thread
+        thread.started.connect(worker.run)
+        worker.done.connect(self._on_worker_done)
+        worker.failed.connect(self._on_worker_failed)
+        self._threads.append(thread)
+        self._workers.append(worker)
+        thread.start()
+
+    def _on_worker_done(self, result) -> None:
+        worker = self.sender()
+        try:
+            worker._df_on_done(result)
+        finally:
+            self._finish_worker(worker)
+
+    def _on_worker_failed(self, exc) -> None:
+        worker = self.sender()
+        try:
+            worker._df_on_failed(exc)
+        finally:
+            self._finish_worker(worker)
+
+    def _finish_worker(self, worker) -> None:
+        thread = worker._df_thread
+        thread.quit()
+        thread.wait()
+        worker.deleteLater()
+        if thread in self._threads:
+            self._threads.remove(thread)
+        if worker in self._workers:
+            self._workers.remove(worker)
+
+    def _set_bt_indicator(self, state: str, text: str) -> None:
+        """Drive the read-only Bluetooth status icon/text and the guidance note.
+
+        *state* is one of ``"on"``, ``"off"``, ``"checking"``. The app never
+        changes the adapter; when off it only guides the user to host OS
+        settings.
+        """
+        glyph = {"on": "🔵", "off": "⚪", "checking": "⏳"}.get(state, "⚪")
+        color = {"on": "#2EA043", "off": "#9E9E9E", "checking": "#9E9E9E"}.get(state, "#9E9E9E")
+        self._bt_icon.setText(glyph)
+        self._bt_status.setText(text)
+        self._bt_status.setStyleSheet(f"color:{color};")
+        self._bt_hint.setVisible(state == "off")
+
+    def _start_live_scan(self, *, clear: bool = True) -> None:
+        """Begin a continuous BLE scan that streams detections into the list.
+
+        With *clear* the list and dedup map are reset first (a fresh scan); when
+        resuming after a connect attempt (*clear=False*) the already-discovered
+        rows, the current selection and the connected highlight are preserved.
+        """
+        if self._scanner_thread is not None:
+            return  # already scanning
+        if clear:
+            self._seen_rows = {}
+            self._device_infos = {}
+            self._ble_list.setRowCount(0)
+            self._set_bt_indicator("checking", "Looking for Bluetooth devices…")
+            self._update_ok_state()
+
+        from data_forwarder_host.gui.ble_live_scanner import BleLiveScanner
+
+        # No Qt parent: the dialog must never own (and therefore never destroy)
+        # a running scan thread. Lifetime is managed explicitly via the
+        # ``self._scanner_thread`` reference and the detach registry on teardown.
+        thread = QThread()
+        scanner = BleLiveScanner()
+        scanner.moveToThread(thread)
+        # Bound-method (GUI-thread QObject) slots → queued cross-thread delivery,
+        # so all widget updates happen on the main thread.
+        scanner.device_found.connect(self._on_live_device_found)
+        scanner.state_changed.connect(self._on_live_scan_state)
+        thread.started.connect(scanner.run)
+        self._scanner = scanner
+        self._scanner_thread = thread
+        thread.start()
+        # Repaint the list on a fixed cadence rather than per advertisement.
+        self._refresh_timer.start()
+
+    def _stop_live_scan(self) -> None:
+        """Stop the live BLE scan and tear down its worker thread.
+
+        Crash-safety: a still-running ``QThread`` must **never** be destroyed
+        (Qt aborts the process with "QThread: Destroyed while thread is still
+        running"). If the worker does not finish within the join timeout — e.g.
+        a wedged Bluetooth backend — we detach the thread from this dialog and
+        keep it alive in a process-wide registry until it finishes, instead of
+        deleting it out from under itself.
+        """
+        self._refresh_timer.stop()
+        scanner = self._scanner
+        thread = self._scanner_thread
+        self._scanner = None
+        self._scanner_thread = None
+        if scanner is not None:
+            try:
+                scanner.device_found.disconnect(self._on_live_device_found)
+                scanner.state_changed.disconnect(self._on_live_scan_state)
+            except (RuntimeError, TypeError):
+                pass
+            scanner.stop()
+        if thread is None:
+            return
+        thread.quit()
+        if thread.wait(6000):
+            thread.deleteLater()
+            if scanner is not None:
+                scanner.deleteLater()
+            return
+        # Did not stop in time — keep it alive (detached) until it finishes so
+        # destroying the dialog cannot abort the process.
+        _detach_running_scan_thread(thread, scanner)
+
+    def _on_live_device_found(self, info) -> None:
+        """Coalesce a streamed detection; the list repaints on the 1 s timer."""
+        addr = str(info.id)
+        self._device_infos[addr] = info
+        # Keep the cached selected/connected info fresh.
+        if self._ble_selected_info is not None and str(self._ble_selected_info.id) == addr:
+            self._ble_selected_info = info
+        if self._connected_info is not None and str(self._connected_info.id) == addr:
+            self._connected_info = info
+        self._devices_dirty = True
+
+    def _ordered_devices(self) -> list:
+        """Devices in display order: connected first, then the default order."""
+        ordered = order_ble_devices(list(self._device_infos.values()))
+        cid = (
+            str(self._connected_info.id)
+            if (self._ble_connected and self._connected_info is not None)
+            else None
+        )
+        if cid is not None and any(str(i.id) == cid for i in ordered):
+            ordered = [i for i in ordered if str(i.id) == cid] + [
+                i for i in ordered if str(i.id) != cid
+            ]
+        return ordered
+
+    def _flush_device_rows(self) -> None:
+        """Repaint the device list from coalesced detections (1 s cadence).
+
+        Re-renders in sorted order (connected pinned on top) when the order
+        changes; otherwise updates the visible rows in place. The current
+        selection and the connected-row highlight are preserved.
+        """
+        if not self._devices_dirty:
+            return
+        self._devices_dirty = False
+        ordered = self._ordered_devices()
+        desired = [str(i.id) for i in ordered]
+        if desired != self._current_row_order():
+            self._render_device_rows(ordered)
+        else:
+            for info in ordered:
+                self._update_device_row_cells(str(info.id), info)
+        self._refresh_connected_highlight()
+        self._update_scan_status()
+
+    def _reorder_device_rows(self) -> None:
+        """Force an immediate repaint (e.g. after connect/disconnect)."""
+        if self._device_infos:
+            self._devices_dirty = True
+            self._flush_device_rows()
+
+    def _current_row_order(self) -> list[str]:
+        """Addresses in current table-row order (top to bottom)."""
+        order: list[str | None] = [None] * self._ble_list.rowCount()
+        for addr, row in self._seen_rows.items():
+            if 0 <= row < len(order):
+                order[row] = addr
+        return [a for a in order if a is not None]
+
+    def _render_device_rows(self, ordered) -> None:
+        """Rebuild the table in *ordered* sequence, preserving the selection."""
+        selected_addr = (
+            str(self._ble_selected_info.id)
+            if self._ble_selected_info is not None
+            else None
+        )
+        # Block selection signals while rebuilding so the passive-selection
+        # handler does not fire spuriously during the repopulate.
+        self._ble_list.blockSignals(True)
+        try:
+            self._ble_list.setRowCount(0)
+            self._seen_rows = {}
+            select_row = None
+            for info in ordered:
+                addr = str(info.id)
+                name, address, signal = self._device_columns(info)
+                row = self._ble_list.rowCount()
+                self._ble_list.insertRow(row)
+                name_item = QTableWidgetItem(name)
+                name_item.setData(Qt.ItemDataRole.UserRole, info)
+                self._ble_list.setItem(row, 0, name_item)
+                self._ble_list.setItem(row, 1, QTableWidgetItem(address))
+                self._ble_list.setItem(row, 2, QTableWidgetItem(signal))
+                self._seen_rows[addr] = row
+                if addr == selected_addr:
+                    select_row = row
+        finally:
+            self._ble_list.blockSignals(False)
+        if select_row is not None:
+            self._ble_list.selectRow(select_row)
+
+    def _update_device_row_cells(self, addr: str, info) -> None:
+        """Update one already-present row in place (no reordering)."""
+        row = self._seen_rows.get(addr)
+        if row is None:
+            return
+        name, address, signal = self._device_columns(info)
+        name_item = self._ble_list.item(row, 0)
+        if name_item is not None:
+            name_item.setData(Qt.ItemDataRole.UserRole, info)
+            name_item.setText(name)
+        addr_item = self._ble_list.item(row, 1)
+        if addr_item is not None:
+            addr_item.setText(address)
+        sig_item = self._ble_list.item(row, 2)
+        if sig_item is not None:
+            sig_item.setText(signal)
+
+    def _on_live_scan_state(self, state: str) -> None:
+        if state == "on":
+            self._update_scan_status()
+        elif state == "off":
+            self._set_bt_indicator(
+                "off",
+                "Bluetooth is off or unavailable. Enable Bluetooth in your host "
+                "operating system, then reopen this dialog.",
+            )
+        else:
+            self._set_bt_indicator(
+                "off",
+                "Bluetooth status could not be determined. Enable Bluetooth in "
+                "your host operating system, then reopen this dialog.",
+            )
+        self._update_ok_state()
+
+    def _update_scan_status(self) -> None:
+        """Refresh the live device-count line (unless a connect status is shown)."""
+        # Don't clobber the green "Connected"/connecting/cancelling status line.
+        if self._connecting or self._canceling or self._ble_connected:
+            return
+        has_selection = self._ble_selected_info is not None
+        selected_name = (
+            (self._ble_selected_info.details.get("name") or self._ble_selected_info.id)
+            if has_selection
+            else None
+        )
+        state, text = compute_scan_status(
+            device_count=self._ble_list.rowCount(),
+            has_selection=has_selection,
+            selected_name=selected_name,
+        )
+        self._set_bt_indicator(state, text)
+
+    @staticmethod
+    def _device_columns(info) -> tuple[str, str, str]:
+        """Return the (name, address, signal) cell texts for a discovered device."""
+        star = "★ " if info.details.get("looks_like_nrf") else ""
+        name = f"{star}{info.details.get('name') or '(unnamed)'}"
+        rssi = info.details.get("rssi")
+        signal = f"{rssi} dBm" if rssi is not None else "—"
+        return name, str(info.id), signal
+
+    def _set_connect_status(self, text: str, *, tone: str = "neutral") -> None:
+        """Show a *static* connection status line (stops any spinner).
+
+        *tone* selects the colour: ``"neutral"`` (default, e.g. while
+        connecting — neither green nor red), ``"ok"`` (connected) or
+        ``"error"`` (failure, red).
+        """
+        self._stop_status_spinner()
+        color = {"neutral": "#9E9E9E", "ok": "#2EA043", "error": "#E5534B"}.get(
+            tone, "#9E9E9E"
+        )
+        self._bt_status.setText(text)
+        self._bt_status.setStyleSheet(f"color:{color};")
+        self._bt_hint.setVisible(False)
+
+    # -- animated status spinner -------------------------------------------
+
+    def _start_status_spinner(self, base_text: str, *, tone: str = "neutral") -> None:
+        """Animate *base_text* with a trailing spinner (e.g. while connecting)."""
+        self._spin_base = base_text
+        self._spin_tone = tone
+        self._spin_tick = 0
+        self._apply_spinner_text()
+        if not self._spin_timer.isActive():
+            self._spin_timer.start()
+
+    def _on_spin_tick(self) -> None:
+        self._spin_tick += 1
+        self._apply_spinner_text()
+
+    def _apply_spinner_text(self) -> None:
+        color = {"neutral": "#9E9E9E", "ok": "#2EA043", "error": "#E5534B"}.get(
+            self._spin_tone, "#9E9E9E"
+        )
+        self._bt_status.setText(f"{self._spin_base}… {spinner_frame(self._spin_tick)}")
+        self._bt_status.setStyleSheet(f"color:{color};")
+        self._bt_hint.setVisible(False)
+
+    def _stop_status_spinner(self) -> None:
+        if self._spin_timer.isActive():
+            self._spin_timer.stop()
+
+    # -- disconnecting popup ------------------------------------------------
+
+    def _show_disconnecting_popup(self) -> None:
+        if self._disconnect_popup is None:
+            self._disconnect_popup = _BusyDialog(
+                self, "Disconnecting from the current device…"
+            )
+        self._disconnect_popup.show()
+        self._disconnect_popup.raise_()
+
+    def _close_disconnecting_popup(self) -> None:
+        if self._disconnect_popup is not None:
+            self._disconnect_popup.close()
+            self._disconnect_popup.deleteLater()
+            self._disconnect_popup = None
+
+    @staticmethod
+    def _safe_close(src) -> None:
+        try:
+            src.close()
+        except Exception:
+            pass
+
+    def _abort_pending_connection(self) -> None:
+        """Best-effort stop of an in-flight connection that has been superseded."""
+        src = self._connecting_source
+        self._connecting_source = None
+        if src is not None:
+            self._safe_close(src)
+
+    def _on_ble_device_selected(self) -> None:
+        row = self._ble_list.currentRow()
+        if row < 0:
+            return
+        name_item = self._ble_list.item(row, 0)
+        if name_item is None:
+            return
+        info = name_item.data(Qt.ItemDataRole.UserRole)
+
+        same = (
+            self._ble_selected_info is not None
+            and self._ble_selected_info.id == info.id
+        )
+        self._ble_selected_info = info
+        if not same:
+            log_user_action(
+                "Selected BLE device %r (%s)", info.details.get("name"), info.id
+            )
+
+        # Selection NEVER connects or disconnects anything. The active
+        # connection (if any) is left fully intact; selecting only re-targets the
+        # Connect/Disconnect button and the OK gating onto the chosen device.
+        if self._selected_is_connected():
+            self._set_connect_status(
+                f"Connected to {self._connected_name()}. Ready to start.", tone="ok"
+            )
+        else:
+            # Route the "press Connect" guidance through the shared idle-status
+            # path so the periodic scan refresh reinforces (never clobbers) it.
+            self._update_scan_status()
+        self._update_connect_button()
+        self._update_ok_state()
+
+    def _connected_name(self) -> str:
+        """Display name of the currently connected device (or a fallback)."""
+        info = self._connected_info
+        if info is None:
+            return "device"
+        return info.details.get("name") or info.id
+
+    def _selected_is_connected(self) -> bool:
+        """True when the selected device is the one that is currently connected."""
+        return (
+            self._ble_connected
+            and self._connected_info is not None
+            and self._ble_selected_info is not None
+            and self._ble_selected_info.id == self._connected_info.id
+        )
+
+    def _on_connect_clicked(self) -> None:
+        if self._connecting or self._canceling:
+            return
+        # The button is a Connect/Disconnect toggle. Disconnect when
+        # the connected device is the toggle's target: it is the selected one,
+        # or nothing else is selected.
+        if self._ble_connected and (
+            self._selected_is_connected() or self._ble_selected_info is None
+        ):
+            log_user_action("Clicked Disconnect in the New Session dialog")
+            self._begin_disconnect()
+            return
+        info = self._ble_selected_info
+        if info is None:
+            return
+        log_user_action("Clicked Connect in the New Session dialog")
+        self._connect_token += 1
+        self._begin_connect(self._connect_token, info)
+
+    def _begin_disconnect(self) -> None:
+        """Tear down the live connection (Disconnect button)."""
+        src = self._prepared_source
+        # Invalidate any in-flight resolution and drop all connection state.
+        self._connect_token += 1
+        self._connecting_source = None
+        self._prepared_source = None
+        self._ble_connected = False
+        self._connected_info = None
+        self._set_connect_status("Disconnected. Press Connect to reconnect.")
+        if src is not None:
+            self._show_disconnecting_popup()
+            # Keep the button enabled: the modal disconnecting popup
+            # already blocks interaction, so the control is never greyed out.
+            self._update_connect_button()
+            self._run_off_thread(
+                lambda: self._safe_close(src),
+                lambda _r: self._on_disconnect_done(),
+                lambda _e: self._on_disconnect_done(),
+            )
+        else:
+            self._update_connect_button()
+        self._update_ok_state()
+
+    def _on_disconnect_done(self) -> None:
+        self._close_disconnecting_popup()
+        self._update_connect_button()
+        self._update_ok_state()
+        self._reorder_device_rows()
+
+    def _begin_connect(self, token: int, info) -> None:
+        """Open the modal progress popup and connect to *info* off-thread.
+
+        When another device is already connected, switching to a new one
+        releases the previous source as part of this same connect (still behind
+        the modal popup), so selection itself stayed side-effect-free
+        and the disconnect happens only on the explicit Connect press.
+        """
+        if token != self._connect_token:
+            return  # a newer action superseded this one
+
+        name = info.details.get("name") or info.id
+
+        # Pause the live scan for the duration of the connect: a scan and a
+        # connect contending for the same adapter can stall or fail. The list is
+        # kept (rows/selection/highlight) and streaming resumes once the connect
+        # attempt resolves.
+        self._stop_live_scan()
+
+        # Release whatever was connected/half-connected to a different device.
+        old_sources = [
+            s for s in (self._connecting_source, self._prepared_source) if s is not None
+        ]
+        self._connecting_source = None
+        self._prepared_source = None
+        self._ble_connected = False
+        self._connected_info = None
+        self._refresh_connected_highlight()
+
+        self._connecting = True
+        self._update_connect_button()
+        self._set_connect_status(f"Connecting to {name}.")
+
+        self._progress = _ConnectProgressDialog(self, name)
+        self._progress.cancel_requested.connect(
+            lambda t=token: self._on_connect_cancel(t)
+        )
+        self._progress.show()
+        self._progress.raise_()
+
+        from data_forwarder_host.source.ble_nus import BleNusSource
+
+        src = BleNusSource(address=info.id, name=info.details.get("name") or "")
+        self._connecting_source = src
+
+        def _connect():
+            for old in old_sources:
+                self._safe_close(old)
+            src.open()
+            return src
+
+        self._run_off_thread(
+            _connect,
+            lambda r: self._on_ble_connect_done(token, r),
+            lambda e: self._on_ble_connect_failed(token, e),
+        )
+
+    def _close_progress(self) -> None:
+        if self._progress is not None:
+            self._progress.close()
+            self._progress.deleteLater()
+            self._progress = None
+
+    def _on_connect_cancel(self, token: int) -> None:
+        """User pressed Cancel: invalidate the attempt and tear it down safely.
+
+        The in-flight ``open()`` cannot be interrupted mid-flight, so we mark it
+        stale (bump the token) and keep Connect disabled until the worker
+        resolves and the source is released. This serialises connect/cancel and
+        prevents the "too many connections right after cancelling" device fault.
+        """
+        if token != self._connect_token:
+            return  # already resolved
+        self._connect_token += 1
+        self._connecting = False
+        self._canceling = True
+        self._update_connect_button()
+        log_user_action("Cancelled BLE connection to selected device")
+        # _on_ble_connect_done/_failed will fire for the stale token and call
+        # _finish_cancel_if_pending(), which closes the popup and re-enables UI.
+
+    def _finish_cancel_if_pending(self) -> None:
+        if not self._canceling:
+            return
+        self._canceling = False
+        self._connecting_source = None
+        self._close_progress()
+        self._set_connect_status("Connection cancelled. Press Connect to retry.")
+        self._update_connect_button()
+        self._update_ok_state()
+        self._resume_live_scan()
+
+    def _resume_live_scan(self) -> None:
+        """Restart streaming detections after a connect attempt resolves."""
+        if self._source_kind.currentData() == "ble" and self.isVisible():
+            self._start_live_scan(clear=False)
+
+    def _on_ble_connect_done(self, token: int, src) -> None:
+        if token != self._connect_token:
+            # Stale (superseded or cancelled) — release and resolve cancellation.
+            self._safe_close(src)
+            self._finish_cancel_if_pending()
+            return
+        self._connecting = False
+        self._connecting_source = None
+        self._prepared_source = src
+        self._ble_connected = True
+        self._connected_info = self._ble_selected_info
+        info = self._ble_selected_info
+        name = (info.details.get("name") or info.id) if info else "device"
+        log_user_action("Connected to BLE device %s", name)
+        self._close_progress()
+        self._set_connect_status(f"Connected to {name}. Ready to start.", tone="ok")
+        self._update_connect_button()
+        self._update_ok_state()
+        self._reorder_device_rows()
+        self._resume_live_scan()
+
+    def _on_ble_connect_failed(self, token: int, exc) -> None:
+        if token != self._connect_token:
+            self._finish_cancel_if_pending()
+            return
+        self._connecting = False
+        self._connecting_source = None
+        self._ble_connected = False
+        self._discard_prepared_source(keep_selection=True)
+        log_user_action("BLE connection failed: %s", exc)
+        self._close_progress()
+        self._set_connect_status(
+            f"Connection failed: {exc}\nPress Connect to retry.", tone="error"
+        )
+        self._update_connect_button()
+        self._update_ok_state()
+        self._resume_live_scan()
+
+    def _update_connect_button(self) -> None:
+        """Drive the Connect/Disconnect toggle (never permanently disabled)."""
+        selected_id = (
+            self._ble_selected_info.id if self._ble_selected_info is not None else None
+        )
+        connected_id = (
+            self._connected_info.id
+            if (self._ble_connected and self._connected_info is not None)
+            else None
+        )
+        label, enabled = compute_connect_button(
+            selected_id=selected_id,
+            connected_id=connected_id,
+            connecting=self._connecting,
+            canceling=self._canceling,
+        )
+        self._connect_btn.setText(label)
+        self._connect_btn.setEnabled(enabled)
+        self._refresh_connected_highlight()
+
+    def _refresh_connected_highlight(self) -> None:
+        """Mark which device row is currently connected.
+
+        The connected device is shown with a check mark, bold text and a soft
+        green row background so the user has clear, persistent confirmation of
+        which device the live connection is on (independent of the selection).
+        """
+        connected_id = (
+            self._connected_info.id
+            if (self._ble_connected and self._connected_info is not None)
+            else None
+        )
+        # Translucent green tint (not an opaque light fill) so the row stays
+        # readable on both light and dark themes — it shades the existing base
+        # colour instead of replacing it with a light background under light text.
+        ok_bg = QBrush(QColor(46, 160, 67, 70))
+        clear_bg = QBrush()
+        for row in range(self._ble_list.rowCount()):
+            name_item = self._ble_list.item(row, 0)
+            if name_item is None:
+                continue
+            info = name_item.data(Qt.ItemDataRole.UserRole)
+            base_name, _address, _signal = self._device_columns(info)
+            is_connected = (
+                connected_id is not None
+                and info is not None
+                and info.id == connected_id
+            )
+            name_item.setText(f"✓ {base_name}" if is_connected else base_name)
+            for col in range(self._ble_list.columnCount()):
+                cell = self._ble_list.item(row, col)
+                if cell is None:
+                    continue
+                cell.setBackground(ok_bg if is_connected else clear_bg)
+                font = cell.font()
+                font.setBold(is_connected)
+                cell.setFont(font)
+
+
+    def _discard_prepared_source(self, *, keep_selection: bool = False) -> None:
+        src = self._prepared_source
+        self._prepared_source = None
+        self._ble_connected = False
+        if not keep_selection:
+            self._ble_selected_info = None
+        if src is not None:
+            try:
+                src.close()
+            except Exception:
+                pass
+
+    def _update_ok_state(self) -> None:
+        kind = self._source_kind.currentData()
+        enabled, hint = compute_ok_state(
+            kind,
+            ble_selected=self._ble_selected_info is not None,
+            ble_connected=self._selected_is_connected(),
+        )
+        self._ok_button.setEnabled(enabled)
+        self._ok_hint.setText(hint)
+        self._ok_hint.setVisible(bool(hint))
+
+
+    # ------------------------------------------------------------------
+    # Accept
+    # ------------------------------------------------------------------
+
+    def _accept(self) -> None:
+        kind = self._source_kind.currentData()
+        if not kind:
+            QMessageBox.warning(self, "Session", "Pick a data source.")
+            return
+
+        params: dict[str, Any] = {}
+        for fname, (f, widget) in self._source_field_widgets.items():
+            v = self._read_value(f, widget)
+            if f.required and (v is None or v == ""):
+                QMessageBox.warning(self, "Session", f"Source field {f.label!r} is required.")
+                return
+            if v is not None and v != "":
+                params[fname] = v
+
+        # BLE: identity comes from the device selected + connected in this
+        # dialog. The live source is handed off via prepared_source(); the
+        # config stores the address (+ name) so a reopened session can
+        # reconnect.
+        if kind == "ble":
+            info = self._ble_selected_info
+            if info is None or not self._selected_is_connected():
+                QMessageBox.warning(self, "Session", _HINT_BLE_SELECT)
+                return
+            params["address"] = info.id
+            name = info.details.get("name") or ""
+            if name:
+                params["name"] = name
+
+        # Normalize UART port path: if it looks like a ttyACM/ttyUSB but is missing
+        # the leading slash, add it (e.g. "dev/ttyACM1" → "/dev/ttyACM1").
+        if kind == "uart" and "port" in params:
+            port = str(params["port"]).strip()
+            if port and not port.startswith("/") and not port.startswith("COM"):
+                if port.startswith("dev/"):
+                    params["port"] = "/" + port
+                    # Inform user of the normalization
+                    port_widget = self._source_field_widgets.get("port")
+                    if port_widget:
+                        _, w = port_widget
+                        w.setText(params["port"])
+
+        tag = self._tag.text().strip() or f"{kind}-{uuid.uuid4().hex[:6]}"
+        source_spec = SourceSpec(kind=kind, role=RoleMode.LISTENER, params=params)
+
+        # The recording label and output directory are defined in the session
+        # window (control panel), not here — a session can be created without a
+        # label; the label is required only to *start* recording.
+        cfg = SessionConfig(
+            tag=tag,
+            source=source_spec,
+            expect_crc=self._expect_crc.isChecked(),
+            plot_window_seconds=float(self._plot_secs.value()),
+            # The bandwidth window is independent of the plot window: it starts
+            # at a fixed 1 s default and is adjustable only from the session
+            # window.
+            bandwidth_window_seconds=DEFAULT_BANDWIDTH_WINDOW_SECONDS,
+        )
+        try:
+            cfg.validate()
+        except ConfigError as exc:
+            QMessageBox.critical(self, "Invalid configuration", str(exc))
+            return
+        self._config = cfg
+        log_user_action(
+            "Confirmed new session: tag=%s source=%s", cfg.tag, source_spec.kind
+        )
+        self._accepted = True
+        self._stop_live_scan()
+        self.accept()

--- a/tools/data_forwarder_host/gui/main_window.py
+++ b/tools/data_forwarder_host/gui/main_window.py
@@ -1,0 +1,767 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Top-level application window."""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from base64 import b64decode, b64encode
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import Qt, QByteArray, QTimer, Signal
+from PySide6.QtGui import QAction, QCloseEvent, QColor
+from PySide6.QtWidgets import (
+    QApplication,
+    QDockWidget,
+    QFileDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QMessageBox,
+    QPushButton,
+    QSizePolicy,
+    QStackedWidget,
+    QStatusBar,
+    QVBoxLayout,
+    QWidget,
+)
+
+from data_forwarder_host.gui.dialogs.about_dialog import AboutDialog
+from data_forwarder_host.gui.dialogs.new_session_dialog import (
+    NewSessionDialog,
+    _BusyDialog,
+)
+from data_forwarder_host.gui.menus import build_menus
+from data_forwarder_host.gui.session_tab import SessionTab
+from data_forwarder_host.gui.theme import Theme, apply_theme
+from data_forwarder_host.gui.widgets.host_metrics_label import HostMetricsLabel
+from data_forwarder_host.gui.widgets.log_panel import LogPanel
+from data_forwarder_host.gui.widgets.session_tab_widget import SessionTabWidget
+from data_forwarder_host.session.states import SessionState
+from data_forwarder_host.utils.logging import configure_logging, log_user_action
+from data_forwarder_host.utils.version import get_version
+
+log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from data_forwarder_host.app import AppContext
+    from data_forwarder_host.session.config import SessionConfig
+
+# Tab title prefix per session state.
+_STATE_ICON: dict[SessionState, str] = {
+    SessionState.CONFIGURED: "○",
+    SessionState.RUNNING:    "▶",
+    SessionState.STOPPED:    "◼",
+    SessionState.ERROR:      "✕",
+}
+_ICON_RECORDING = "⏺"
+
+# Tab text colours per state (empty string → invalid QColor → reset to palette default).
+_STATE_COLOR: dict[SessionState, str] = {
+    SessionState.RUNNING:    "",         # default colour — streaming but not recording
+    SessionState.STOPPED:    "#888888",  # gray
+    SessionState.CONFIGURED: "#888888",  # gray — not yet started
+    SessionState.ERROR:      "#FF4444",  # red
+}
+
+
+def _tab_color(state: SessionState, recording: bool, rec_tick: int = 0) -> QColor:
+    if recording:
+        # Blink: bright red on even ticks, dim red on odd ticks.
+        return QColor("#FF2222") if rec_tick else QColor("#993333")
+    c = _STATE_COLOR.get(state)
+    return QColor(c) if c else QColor()  # invalid QColor resets to palette default
+
+
+class _WelcomeWidget(QWidget):
+    """Shown when no session tab is open.
+
+    Reorganised around a single focal call-to-action: the branding is demoted
+    to a small muted header in the top-left corner, while a centred hero
+    promotes **Get started** with a large **New Session** button. Supporting
+    material (quick-start steps, keyboard shortcuts) sits in a muted footer.
+    """
+
+    def __init__(
+        self,
+        on_new_session: "Callable[[], None]",
+        on_open_session: "Callable[[], None]",
+        parent: QWidget | None = None,
+    ) -> None:
+        from typing import Callable  # noqa: PLC0415
+        super().__init__(parent)
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(40, 28, 40, 28)
+        root.setSpacing(0)
+
+        # ── Branding pushed to the top-left corner, de-emphasised ─────
+        brand_row = QHBoxLayout()
+        brand = QLabel("Data Forwarder Host")
+        bf = brand.font()
+        bf.setPointSize(12)
+        bf.setBold(True)
+        brand.setFont(bf)
+        brand.setStyleSheet("color: palette(mid);")
+        brand_row.addWidget(brand)
+        brand_row.addStretch(1)
+        root.addLayout(brand_row)
+
+        # ── Centred hero: the promoted call-to-action ─────────────────
+        root.addStretch(3)
+
+        hero = QVBoxLayout()
+        hero.setSpacing(0)
+
+        get_started = QLabel("Get started")
+        gf = get_started.font()
+        gf.setPointSize(34)
+        gf.setBold(True)
+        get_started.setFont(gf)
+        get_started.setAlignment(Qt.AlignmentFlag.AlignHCenter)
+        hero.addWidget(get_started)
+
+        hero.addSpacing(10)
+
+        tagline = QLabel(
+            "Receive, record and forward sensor data from nRF devices "
+            "over UART or Bluetooth LE."
+        )
+        tagline.setStyleSheet("color: palette(mid); font-size: 14px;")
+        tagline.setWordWrap(True)
+        tagline.setAlignment(Qt.AlignmentFlag.AlignHCenter)
+        tagline.setMaximumWidth(520)
+        hero.addWidget(tagline, alignment=Qt.AlignmentFlag.AlignHCenter)
+
+        hero.addSpacing(36)
+
+        btn_new = QPushButton("New Session")
+        btn_new.setMinimumHeight(56)
+        btn_new.setMinimumWidth(300)
+        btn_new.setMaximumWidth(420)
+        btn_new.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        btn_new.setDefault(True)
+        btn_new.setAutoDefault(True)
+        btn_new.setCursor(Qt.CursorShape.PointingHandCursor)
+        # Explicit accent styling (fixed colours, not palette-derived) so the
+        # primary call-to-action reads identically and with strong contrast in
+        # every theme — System / Light / Dark. The default QPushButton inherited
+        # the window palette, which left it near-invisible (dark-on-dark) on a
+        # dark desktop and never stood out as the obvious place to click.
+        btn_new.setStyleSheet(
+            "QPushButton {"
+            "  background-color: #2E7CF6;"
+            "  color: #FFFFFF;"
+            "  padding: 12px 32px;"
+            "  font-size: 16px;"
+            "  font-weight: bold;"
+            "  border: none;"
+            "  border-radius: 10px;"
+            "}"
+            "QPushButton:hover { background-color: #4A90FF; }"
+            "QPushButton:pressed { background-color: #1F6AE0; }"
+        )
+        btn_new.clicked.connect(on_new_session)
+        hero.addWidget(btn_new, alignment=Qt.AlignmentFlag.AlignHCenter)
+
+        hero.addSpacing(12)
+
+        btn_open = QPushButton("Open saved session config…")
+        btn_open.setMinimumHeight(36)
+        btn_open.setMaximumWidth(420)
+        btn_open.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        btn_open.setFlat(True)
+        btn_open.setStyleSheet(
+            "QPushButton { font-size: 12px; color: palette(mid); border: none; }"
+        )
+        btn_open.clicked.connect(on_open_session)
+        hero.addWidget(btn_open, alignment=Qt.AlignmentFlag.AlignHCenter)
+
+        root.addLayout(hero)
+
+        root.addStretch(3)
+
+        # ── Muted footer: quick-start steps + keyboard shortcuts ──────
+        sep = QFrame()
+        sep.setFrameShape(QFrame.Shape.HLine)
+        sep.setFrameShadow(QFrame.Shadow.Sunken)
+        root.addWidget(sep)
+        root.addSpacing(16)
+
+        footer = QHBoxLayout()
+        footer.setSpacing(48)
+
+        # Quick start steps
+        qs = QVBoxLayout()
+        qs.setSpacing(0)
+        qs_hdr = QLabel("Quick start")
+        qf = qs_hdr.font()
+        qf.setBold(True)
+        qs_hdr.setFont(qf)
+        qs_hdr.setStyleSheet("color: palette(mid); font-size: 11px;")
+        qs.addWidget(qs_hdr)
+        qs.addSpacing(8)
+        for i, step in enumerate(
+            [
+                "Connect your nRF device via USB, or power it on within "
+                "Bluetooth LE range.",
+                "Click <b>New Session</b> and choose the data source "
+                "(UART or Bluetooth LE).",
+                "For Bluetooth LE, select the device and press <b>Connect</b>.",
+                "Set any other session details, then click <b>Create session</b>.",
+                "Enter a recording <b>label</b> and choose an output directory.",
+                "Press <b>Record</b> to start capturing data.",
+                "Press <b>Stop</b> to finish; a single CSV file is written to your "
+                "output directory.",
+            ],
+            1,
+        ):
+            row = QHBoxLayout()
+            num = QLabel(f"<b>{i}</b>")
+            num.setStyleSheet(
+                "min-width: 18px; max-width: 18px; color: palette(mid); font-size: 11px;"
+            )
+            num.setAlignment(Qt.AlignmentFlag.AlignTop)
+            lbl = QLabel(step)
+            lbl.setStyleSheet("color: palette(mid); font-size: 11px;")
+            lbl.setWordWrap(True)
+            row.addWidget(num)
+            row.addWidget(lbl)
+            row.addStretch()
+            qs.addLayout(row)
+            qs.addSpacing(4)
+        qs.addStretch(1)
+        footer.addLayout(qs, stretch=3)
+
+        # Vertical separator between footer columns
+        vsep = QFrame()
+        vsep.setFrameShape(QFrame.Shape.VLine)
+        vsep.setFrameShadow(QFrame.Shadow.Sunken)
+        footer.addWidget(vsep)
+
+        # Keyboard shortcuts
+        kb = QVBoxLayout()
+        kb.setSpacing(0)
+        kbd_hdr = QLabel("Keyboard shortcuts")
+        kf = kbd_hdr.font()
+        kf.setBold(True)
+        kbd_hdr.setFont(kf)
+        kbd_hdr.setStyleSheet("color: palette(mid); font-size: 11px;")
+        kb.addWidget(kbd_hdr)
+        kb.addSpacing(8)
+        for key, action in (
+            ("Ctrl+N", "New session"),
+            ("Ctrl+O", "Open saved session config"),
+        ):
+            krow = QHBoxLayout()
+            kbd = QLabel(key)
+            kbd.setStyleSheet(
+                "font-family: monospace; background: palette(mid);"
+                " padding: 2px 5px; border-radius: 3px; font-size: 10px;"
+            )
+            kbd.setFixedWidth(96)
+            desc = QLabel(action)
+            desc.setStyleSheet("color: palette(mid); font-size: 11px;")
+            krow.addWidget(kbd)
+            krow.addSpacing(8)
+            krow.addWidget(desc)
+            krow.addStretch()
+            kb.addLayout(krow)
+            kb.addSpacing(5)
+        kb.addStretch(1)
+        footer.addLayout(kb, stretch=2)
+
+        root.addLayout(footer)
+
+
+class MainWindow(QMainWindow):
+    # Emitted from the background shutdown thread once all sessions have been
+    # torn down; routed (queued) back to the GUI thread to quit the app.
+    _teardown_finished = Signal()
+
+    def __init__(self, ctx: "AppContext") -> None:
+        super().__init__()
+        # Explicitly request all three title-bar buttons; required on some
+        # Linux/Wayland compositors that don't add them by default.
+        self.setWindowFlags(
+            Qt.WindowType.Window
+            | Qt.WindowType.WindowTitleHint
+            | Qt.WindowType.WindowSystemMenuHint
+            | Qt.WindowType.WindowMinimizeButtonHint
+            | Qt.WindowType.WindowMaximizeButtonHint
+            | Qt.WindowType.WindowCloseButtonHint
+        )
+        self._ctx = ctx
+        self.setWindowTitle(f"Data Forwarder Host  v{get_version()}")
+        self.resize(1280, 800)
+
+        # Tabs. A browser-style "+" button sits to the right of the last tab;
+        # it is a real button, not a tab, and opens New Session.
+        self._tabs = SessionTabWidget()
+        self._tabs.setTabsClosable(True)
+        self._tabs.setMovable(True)
+        self._tabs.tabCloseRequested.connect(self._on_tab_close_requested)
+        # Open New Session on the next event-loop turn rather than synchronously
+        # inside the "+" button's clicked handler: entering the dialog's modal
+        # loop while the button still holds the mouse grab disrupts the BLE
+        # scanner thread/timers started in the dialog's showEvent and makes the
+        # scan spuriously report "Bluetooth off". Deferring matches the previous
+        # pseudo-tab behaviour, which opened the dialog via a queued callback.
+        self._tabs.new_session_requested.connect(
+            lambda: QTimer.singleShot(0, self._on_new_session)
+        )
+
+        # Stack: page 0 = welcome, page 1 = tab widget.
+        self._welcome = _WelcomeWidget(
+            on_new_session=self._on_new_session,
+            on_open_session=self._on_open_session,
+        )
+        self._stack = QStackedWidget()
+        self._stack.addWidget(self._welcome)
+        self._stack.addWidget(self._tabs)
+        self._stack.setCurrentIndex(0)
+        self.setCentralWidget(self._stack)
+
+        # Status bar
+        status = QStatusBar()
+        self._host_metrics = HostMetricsLabel()
+        self._host_metrics.setToolTip("Host and application resource usage")
+        status.addPermanentWidget(self._host_metrics)
+        status.addPermanentWidget(QLabel(f"v{get_version()}"))
+        self.setStatusBar(status)
+
+        # Log panel as a dock (hidden by default)
+        self._log_dock = QDockWidget("Application log", self)
+        self._log_dock.setWidget(LogPanel())
+        self._log_dock.setAllowedAreas(Qt.DockWidgetArea.BottomDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea)
+        self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, self._log_dock)
+        self._log_dock.hide()
+
+        # Menus
+        self._actions: dict[str, QAction] = build_menus(
+            self,
+            on_new_session=self._on_new_session,
+            on_close_session=self._on_close_current_session,
+            on_open_session=self._on_open_session,
+            on_save_session=self._on_save_session,
+            on_save_session_as=self._on_save_session_as,
+            on_quit=self.close,
+            on_toggle_error_panel=self._on_toggle_error_panel,
+            on_toggle_log_panel=self._on_toggle_log_panel,
+            on_theme=self._on_theme,
+            on_log_level=self._on_log_level,
+            current_log_level=ctx.settings.log_level,
+            on_about=self._on_about,
+            on_toggle_panel=self._on_toggle_panel,
+        )
+
+        # SessionManager wiring
+        ctx.session_manager.session_closed.connect(self._on_session_closed)
+
+        # Background-shutdown bookkeeping (responsive close).
+        self._closing = False
+        self._teardown_finished.connect(self._finish_quit)
+
+        # Recording-indicator timer: 1-second tick drives blink and elapsed display.
+        self._rec_tick: int = 0
+        self._rec_timer = QTimer(self)
+        self._rec_timer.setInterval(1000)
+        self._rec_timer.timeout.connect(self._on_rec_tick)
+        self._rec_timer.start()
+
+        # Restore previously saved window geometry.
+        self._restore_geometry()
+
+    def _restore_geometry(self) -> None:
+        b64 = getattr(self._ctx.settings, "window_geometry_b64", "")
+        if not b64:
+            return
+        try:
+            self.restoreGeometry(QByteArray(b64decode(b64.encode("ascii"))))
+        except Exception:
+            log.exception("failed to restore window geometry")
+
+    def _save_geometry(self) -> None:
+        try:
+            data = bytes(self.saveGeometry())
+            self._ctx.settings.window_geometry_b64 = b64encode(data).decode("ascii")
+        except Exception:
+            log.exception("failed to save window geometry")
+
+    # ------------------------------------------------------------------
+    # Menu handlers
+    # ------------------------------------------------------------------
+
+    def _on_new_session(self) -> None:
+        log_user_action("Requested a new session")
+        dlg = NewSessionDialog(self._ctx.platform, parent=self)
+        if dlg.exec() != dlg.DialogCode.Accepted:
+            # The dialog logs its own cancel/close action.
+            return
+        cfg = dlg.result_config()
+        if cfg is None:
+            return
+        prepared_source = dlg.prepared_source()
+        # Bridge the visible gap between confirming the dialog and the session
+        # tab appearing (charts, log consoles and controller wiring take a
+        # moment to build). Mirror the "Connecting to <device>…" feedback with
+        # a small "Opening session…" popup. The actual construction is kicked
+        # off from inside the popup's own modal exec() loop so the popup is
+        # mapped/painted before the GUI thread blocks on building the widgets.
+        popup = _BusyDialog(self, "Opening session…")
+        popup.setWindowTitle("Opening session")
+
+        def _do_open() -> None:
+            try:
+                self._open_session_tab(cfg, prepared_source=prepared_source)
+            finally:
+                popup.accept()
+
+        QTimer.singleShot(80, _do_open)
+        popup.exec()
+        popup.deleteLater()
+
+    def _open_session_tab(self, cfg: "SessionConfig", prepared_source=None) -> None:
+        from data_forwarder_host.session.config import SessionConfig  # noqa: PLC0415
+        from data_forwarder_host.pipeline.process_host import (  # noqa: PLC0415
+            process_mode_enabled,
+        )
+        try:
+            controller = self._ctx.session_manager.create(
+                cfg, prepared_source, use_process=process_mode_enabled()
+            )
+        except Exception as exc:
+            QMessageBox.critical(self, "Session", f"Failed to create session: {exc}")
+            return
+        tab = SessionTab(controller)
+        # Restore previously saved layout (expanded sections, splitter sizes).
+        if cfg.layout_state:
+            tab.apply_layout_state(cfg.layout_state)
+        # Honour the global "Show error panel" preference for new sessions.
+        self._set_error_panel_visible(tab, self._actions["show_error"].isChecked())
+        # Honour the global View ▸ Panels preferences for new sessions.
+        self._apply_panel_states(tab)
+        idx = self._tabs.addTab(tab, self._tab_title(cfg.tag, SessionState.CONFIGURED, False))
+        self._tabs.setCurrentIndex(idx)
+        self._stack.setCurrentIndex(1)
+        self._refresh_file_actions()
+
+        # Place the cursor in the recording-label field so the user can type a
+        # label immediately. Deferred so it sticks after the tab is
+        # shown and activated.
+        QTimer.singleShot(0, tab.focus_recording_label)
+
+        # Keep the tab title in sync with session state and recording flag.
+        def _on_state(state: SessionState, _tab: SessionTab = tab) -> None:
+            self._update_tab_title(_tab)
+
+        def _on_rec(_recording: bool, _tab: SessionTab = tab) -> None:
+            self._update_tab_title(_tab)
+
+        controller.state_changed.connect(_on_state)
+        controller.recording_changed.connect(_on_rec)
+
+        # Reserve and listen on the device channel immediately so session_info
+        # is observed without waiting for the user to press Record.
+        try:
+            controller.start()
+        except Exception as exc:
+            QMessageBox.warning(
+                self,
+                "Session",
+                f"Could not open device channel: {exc}",
+            )
+
+    # ------------------------------------------------------------------
+    # Tab title helpers
+    # ------------------------------------------------------------------
+
+    def _tab_title(self, tag: str, state: SessionState, recording: bool, ctrl=None) -> str:
+        if recording and ctrl is not None:
+            elapsed = ctrl.recorder.elapsed_seconds()
+            dot = "⏺" if self._rec_tick else "●"
+            if elapsed is not None:
+                m = int(elapsed) // 60
+                s = int(elapsed) % 60
+                return f"{dot} {tag}  {m}:{s:02d}"
+            return f"{dot} {tag}"
+        icon = _ICON_RECORDING if recording else _STATE_ICON.get(state, "○")
+        return f"{icon} {tag}"
+
+    def _update_tab_title(self, tab: "SessionTab") -> None:
+        idx = self._tabs.indexOf(tab)
+        if idx < 0:
+            return
+        ctrl = tab.controller
+        state = ctrl.state()
+        recording = ctrl.is_recording()
+        title = self._tab_title(ctrl.config.tag, state, recording, ctrl)
+        self._tabs.setTabText(idx, title)
+        self._tabs.tabBar().setTabTextColor(idx, _tab_color(state, recording, self._rec_tick))
+
+    def _on_rec_tick(self) -> None:
+        """Timer callback: toggle blink state and refresh all recording tab titles."""
+        self._rec_tick ^= 1
+        for i in range(self._tabs.count()):
+            w = self._tabs.widget(i)
+            if isinstance(w, SessionTab) and w.controller.is_recording():
+                self._update_tab_title(w)
+
+    def _on_close_current_session(self) -> None:
+        log_user_action("Requested closing the current session")
+        idx = self._tabs.currentIndex()
+        if idx < 0:
+            return
+        self._close_tab(idx)
+
+    def _on_tab_close_requested(self, idx: int) -> None:
+        log_user_action("Clicked the close button on a session tab")
+        self._close_tab(idx)
+
+    def _close_tab(self, idx: int) -> None:
+        widget = self._tabs.widget(idx)
+        if not isinstance(widget, SessionTab):
+            self._tabs.removeTab(idx)
+            return
+        ctrl = widget.controller
+        if not self._confirm_and_finalise(ctrl):
+            return
+        self._tabs.removeTab(idx)
+        self._ctx.session_manager.close(ctrl.id)
+        # Switch back to the welcome screen once the last session tab is gone.
+        if self._tabs.count() == 0:
+            self._stack.setCurrentIndex(0)
+        self._refresh_file_actions()
+
+    def _confirm_and_finalise(self, ctrl) -> bool:
+        """Pop the 3-option close dialog if needed and finalise the session.
+
+        The data-loss decision dialog is shown **only while a recording is
+        actively in progress**. A session that is merely streaming or
+        already stopped has nothing unsaved to lose, so it closes silently
+        (stopping any live stream first).
+
+        Returns ``True`` if the caller may proceed to close the session,
+        ``False`` if the user cancelled.
+        """
+        recording = ctrl.is_recording()
+        if not recording:
+            # Nothing unsaved — stop any live stream and allow the close.
+            if ctrl.state() == SessionState.RUNNING:
+                try:
+                    ctrl.stop()
+                except Exception:
+                    log.exception("error stopping stream on close")
+            return True
+
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Icon.Warning)
+        box.setWindowTitle("Close session")
+        box.setText(
+            f"Session \u2018{ctrl.config.tag}\u2019 is recording.\n\n"
+            "Stop and save the recorded data to its CSV file, discard the "
+            "recorded data, or cancel and keep the session open?"
+        )
+        save_btn = box.addButton("Stop && Save", QMessageBox.ButtonRole.AcceptRole)
+        discard_btn = box.addButton("Discard", QMessageBox.ButtonRole.DestructiveRole)
+        cancel_btn = box.addButton("Cancel", QMessageBox.ButtonRole.RejectRole)
+        box.setDefaultButton(cancel_btn)
+        box.exec()
+        clicked = box.clickedButton()
+
+        if clicked is cancel_btn:
+            return False
+        try:
+            if clicked is save_btn:
+                ctrl.stop()                 # auto-writes CSV if recording
+            elif clicked is discard_btn:
+                ctrl.cancel_recording()
+                ctrl.stop()
+        except Exception:
+            log.exception("error finalising session on close")
+        return True
+
+    def _on_session_closed(self, _session_id: str) -> None:
+        # Tab is removed in _close_tab already.
+        pass
+
+    # ------------------------------------------------------------------
+    # File menu — save / open session config
+    # ------------------------------------------------------------------
+
+    def _refresh_file_actions(self) -> None:
+        has = self._tabs.count() > 0
+        self._actions["save_session"].setEnabled(has)
+        self._actions["save_session_as"].setEnabled(has)
+
+    def _on_open_session(self) -> None:
+        log_user_action("Requested opening a saved session config")
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Open session configuration", "", "Session config (*.json)"
+        )
+        if not path:
+            log_user_action("Cancelled the open-session dialog")
+            return
+        from data_forwarder_host.session.config import config_from_dict, ConfigError  # noqa: PLC0415
+        try:
+            data = json.loads(Path(path).read_text(encoding="utf-8"))
+            cfg = config_from_dict(data)
+        except Exception as exc:
+            QMessageBox.critical(self, "Open", f"Failed to load configuration:\n{exc}")
+            return
+        self._open_session_tab(cfg)
+
+    def _on_save_session(self) -> None:
+        log_user_action("Requested saving the session config")
+        widget = self._tabs.currentWidget()
+        if not isinstance(widget, SessionTab):
+            return
+        if not hasattr(self, "_last_save_path"):
+            self._last_save_path: str | None = None
+        if self._last_save_path:
+            self._write_session_config(widget, self._last_save_path)
+        else:
+            self._on_save_session_as()
+
+    def _on_save_session_as(self) -> None:
+        log_user_action("Requested saving the session config as a new file")
+        widget = self._tabs.currentWidget()
+        if not isinstance(widget, SessionTab):
+            return
+        default = f"{widget.controller.config.tag}.json"
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save session configuration", default, "Session config (*.json)"
+        )
+        if path:
+            self._last_save_path = path
+            self._write_session_config(widget, path)
+
+    def _write_session_config(self, tab: SessionTab, path: str) -> None:
+        from dataclasses import replace as dc_replace  # noqa: PLC0415
+        from data_forwarder_host.session.config import config_to_dict  # noqa: PLC0415
+        try:
+            cfg = tab.controller.current_config()
+            layout_state = tab.get_layout_state()
+            if layout_state:
+                cfg = dc_replace(cfg, layout_state=layout_state)
+            Path(path).write_text(
+                json.dumps(config_to_dict(cfg), indent=2),
+                encoding="utf-8",
+            )
+        except Exception as exc:
+            QMessageBox.critical(self, "Save", f"Failed to save:\n{exc}")
+
+    def _on_toggle_error_panel(self, on: bool) -> None:
+        log_user_action("Toggled the error panel %s", "on" if on else "off")
+        # Apply to every open session, not just the current tab, so the View
+        # menu acts as a global preference across all sessions.
+        for i in range(self._tabs.count()):
+            w = self._tabs.widget(i)
+            if isinstance(w, SessionTab):
+                self._set_error_panel_visible(w, on)
+
+    @staticmethod
+    def _set_error_panel_visible(tab: SessionTab, on: bool) -> None:
+        # The error panel is the last widget in the tab's outer layout.
+        for i in range(tab.layout().count()):
+            w = tab.layout().itemAt(i).widget()
+            if w is not None and w.__class__.__name__ == "ErrorPanel":
+                w.setVisible(on)
+
+    # ------------------------------------------------------------------
+    # View ▸ Panels (global per-panel visibility preference)
+    # ------------------------------------------------------------------
+
+    _PANEL_KEYS = ("combined", "individual", "channel_ascii", "decoded_frames")
+
+    def _apply_panel_states(self, tab: SessionTab) -> None:
+        """Initialise a tab's panel visibility from the current menu states."""
+        for key in self._PANEL_KEYS:
+            act = self._actions.get(f"panel_{key}")
+            if act is not None:
+                tab.set_panel_visible(key, act.isChecked())
+
+    def _on_toggle_panel(self, key: str, on: bool) -> None:
+        log_user_action("Toggled the %s panel %s", key, "on" if on else "off")
+        # Global preference: apply to every open session tab.
+        for i in range(self._tabs.count()):
+            w = self._tabs.widget(i)
+            if isinstance(w, SessionTab):
+                w.set_panel_visible(key, on)
+
+    def _on_toggle_log_panel(self, on: bool) -> None:
+        log_user_action("Toggled the application log panel %s", "on" if on else "off")
+        self._log_dock.setVisible(on)
+
+    def _on_log_level(self, level: str) -> None:
+        log_user_action("Changed the log level to %s", level)
+        configure_logging(level)
+        self._ctx.settings.log_level = level
+        log.info("log level changed to %s", level)
+
+    def _on_about(self) -> None:
+        log_user_action("Opened the About dialog")
+        AboutDialog(self).exec()
+
+    def _on_theme(self, theme: "Theme") -> None:
+        log_user_action("Changed the theme to %s", getattr(theme, "name", theme))
+        apply_theme(theme)
+
+    # ------------------------------------------------------------------
+    # Close
+    # ------------------------------------------------------------------
+
+    def closeEvent(self, event: QCloseEvent) -> None:
+        log_user_action("Clicked the application close button")
+
+        # Re-entrant close (e.g. the implicit close after the background
+        # teardown quits the app): just let it through.
+        if self._closing:
+            event.accept()
+            return
+
+        # Ask per session that still has an active stream or recording. This
+        # (and the decision dialog) must stay on the GUI thread.
+        for i in range(self._tabs.count()):
+            w = self._tabs.widget(i)
+            if not isinstance(w, SessionTab):
+                continue
+            ctrl = w.controller
+            if ctrl.state() == SessionState.RUNNING or ctrl.is_recording():
+                if not self._confirm_and_finalise(ctrl):
+                    log_user_action("Cancelled application close")
+                    event.ignore()
+                    return
+
+        # Make the GUI disappear immediately for a responsive feel, then finish
+        # tearing the sessions down on a background thread (closing a device —
+        # especially Bluetooth LE — can block for seconds). The app quits once
+        # teardown completes.
+        self._closing = True
+        log_user_action("Closing application; finalising sessions in background")
+        self._save_geometry()
+        self.hide()
+        QApplication.processEvents()
+
+        threading.Thread(
+            target=self._background_teardown, name="dfh-shutdown", daemon=True
+        ).start()
+        event.ignore()  # stay alive until the background teardown asks us to quit
+
+    def _background_teardown(self) -> None:
+        """Tear down all sessions off the GUI thread, then request quit."""
+        try:
+            self._ctx.session_manager.shutdown_all()
+        except Exception:
+            log.exception("error during background shutdown")
+        finally:
+            self._teardown_finished.emit()
+
+    def _finish_quit(self) -> None:
+        """Runs on the GUI thread once background teardown is complete."""
+        log_user_action("Application teardown complete; exiting")
+        QApplication.instance().quit()

--- a/tools/data_forwarder_host/gui/menus.py
+++ b/tools/data_forwarder_host/gui/menus.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Menu construction for the main window."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from PySide6.QtGui import QAction, QActionGroup
+from PySide6.QtWidgets import QMainWindow, QMenu
+
+from data_forwarder_host.gui.theme import Theme
+
+
+def build_menus(
+    window: QMainWindow,
+    *,
+    on_new_session: Callable[[], None],
+    on_close_session: Callable[[], None],
+    on_open_session: Callable[[], None],
+    on_save_session: Callable[[], None],
+    on_save_session_as: Callable[[], None],
+    on_quit: Callable[[], None],
+    on_toggle_error_panel: Callable[[bool], None],
+    on_toggle_log_panel: Callable[[bool], None],
+    on_theme: Callable[[Theme], None],
+    on_log_level: Callable[[str], None],
+    current_log_level: str = "INFO",
+    on_about: Callable[[], None],
+    on_toggle_panel: Callable[[str, bool], None] | None = None,
+) -> dict[str, QAction]:
+    """Build the menu bar; return a dict of actions for state toggling."""
+    bar = window.menuBar()
+
+    # ── File ──────────────────────────────────────────────────────────
+    m_file: QMenu = bar.addMenu("&File")
+
+    act_quit = QAction("&Quit", window)
+    act_quit.triggered.connect(on_quit)
+    m_file.addAction(act_quit)
+
+    # ── Session ───────────────────────────────────────────────────────
+    m_session: QMenu = bar.addMenu("&Session")
+
+    act_new = QAction("&New session…", window)
+    act_new.setShortcut("Ctrl+N")
+    act_new.triggered.connect(on_new_session)
+    m_session.addAction(act_new)
+
+    act_close = QAction("&Close session", window)
+    act_close.triggered.connect(on_close_session)
+    m_session.addAction(act_close)
+
+    m_session.addSeparator()
+
+    act_open = QAction("&Open session config…", window)
+    act_open.setShortcut("Ctrl+O")
+    act_open.triggered.connect(on_open_session)
+    m_session.addAction(act_open)
+
+    act_save = QAction("&Save session config", window)
+    act_save.setShortcut("Ctrl+S")
+    act_save.setEnabled(False)          # enabled once a session exists
+    act_save.triggered.connect(on_save_session)
+    m_session.addAction(act_save)
+
+    act_save_as = QAction("Save session config &as…", window)
+    act_save_as.setShortcut("Ctrl+Shift+S")
+    act_save_as.setEnabled(False)
+    act_save_as.triggered.connect(on_save_session_as)
+    m_session.addAction(act_save_as)
+
+    # View
+    m_view: QMenu = bar.addMenu("&View")
+    act_err = QAction("Show error panel", window, checkable=True)
+    act_err.setChecked(False)
+    act_err.toggled.connect(on_toggle_error_panel)
+    m_view.addAction(act_err)
+
+    act_log = QAction("Show log panel", window, checkable=True)
+    act_log.setChecked(False)
+    act_log.toggled.connect(on_toggle_log_panel)
+    m_view.addAction(act_log)
+
+    # Panels submenu — per-panel visibility toggles applied to every open
+    # session tab as a global preference. Combined View and Individual Channels
+    # are on by default; Channel ASCII and Decoded Frames are off by default.
+    m_panels = m_view.addMenu("Panels")
+    panel_actions: dict[str, QAction] = {}
+    _PANELS = (
+        ("combined", "Combined View", True),
+        ("individual", "Individual Channels", True),
+        ("channel_ascii", "Channel ASCII", False),
+        ("decoded_frames", "Decoded Frames", False),
+    )
+    for key, label, default_on in _PANELS:
+        act = QAction(label, window, checkable=True)
+        act.setChecked(default_on)
+        if on_toggle_panel is not None:
+            act.toggled.connect(lambda on, k=key: on_toggle_panel(k, on))
+        m_panels.addAction(act)
+        panel_actions[f"panel_{key}"] = act
+
+    m_theme = m_view.addMenu("Theme")
+    group = QActionGroup(window)
+    for label, theme in (("System", Theme.SYSTEM), ("Light", Theme.LIGHT), ("Dark", Theme.DARK)):
+        act = QAction(label, window, checkable=True)
+        group.addAction(act)
+        m_theme.addAction(act)
+        if theme == Theme.SYSTEM:
+            act.setChecked(True)
+        act.triggered.connect(lambda _checked=False, t=theme: on_theme(t))
+
+    m_log_level = m_view.addMenu("Log level")
+    log_group = QActionGroup(window)
+    log_group.setExclusive(True)
+    _LOG_LEVELS = (("DEBUG", "DEBUG"), ("INFO", "INFO"), ("WARNING", "WARNING"), ("ERROR", "ERROR"))
+    for label, lvl in _LOG_LEVELS:
+        act = QAction(label, window, checkable=True)
+        act.setChecked(lvl == current_log_level.upper())
+        log_group.addAction(act)
+        m_log_level.addAction(act)
+        act.triggered.connect(lambda _checked=False, l=lvl: on_log_level(l))
+
+    # Help
+    m_help: QMenu = bar.addMenu("&Help")
+    act_about = QAction("&About…", window)
+    act_about.triggered.connect(on_about)
+    m_help.addAction(act_about)
+
+    return {
+        "new_session": act_new,
+        "close_session": act_close,
+        "open_session": act_open,
+        "save_session": act_save,
+        "save_session_as": act_save_as,
+        "quit": act_quit,
+        "show_error": act_err,
+        "show_log": act_log,
+        "about": act_about,
+        **panel_actions,
+    }

--- a/tools/data_forwarder_host/gui/scan_worker.py
+++ b/tools/data_forwarder_host/gui/scan_worker.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Run a blocking callable on a worker thread and report the result via signals.
+
+Device discovery (UART enumeration, and especially a BLE radio scan that waits
+a fixed timeout) blocks for several seconds. Running it on the Qt GUI thread
+freezes the whole window. :class:`ScanWorker` wraps any no-argument callable so
+it can be executed on a :class:`~PySide6.QtCore.QThread`, emitting exactly one
+of ``done`` (with the return value) or ``failed`` (with the raised exception)
+back on the thread the signals are connected from.
+
+The worker is deliberately generic and Qt-only: it knows nothing about sources
+or discovery, so it is reusable in isolation without a display.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from PySide6.QtCore import QObject, Signal
+
+
+class ScanWorker(QObject):
+    """Execute a no-arg callable, emitting ``done(result)`` or ``failed(exc)``.
+
+    Exactly one signal is emitted per :meth:`run` call. Move the worker to a
+    :class:`QThread` and trigger :meth:`run` from the thread's ``started``
+    signal to keep the GUI responsive while the callable blocks.
+    """
+
+    done = Signal(object)
+    failed = Signal(object)
+
+    def __init__(self, fn: Callable[[], Any]) -> None:
+        super().__init__()
+        self._fn = fn
+
+    def run(self) -> None:
+        try:
+            result = self._fn()
+        except Exception as exc:  # noqa: BLE001 - reported to the caller via signal
+            self.failed.emit(exc)
+        else:
+            self.done.emit(result)

--- a/tools/data_forwarder_host/gui/session_tab.py
+++ b/tools/data_forwarder_host/gui/session_tab.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Per-session tab assembled from the reusable widgets."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Qt, QTimer
+from PySide6.QtWidgets import (
+    QLabel,
+    QProgressBar,
+    QScrollArea,
+    QSplitter,
+    QVBoxLayout,
+    QWidget,
+)
+
+from data_forwarder_host.gui.widgets.charts_panel import ChartsPanel
+from data_forwarder_host.gui.widgets.control_panel import ControlPanel
+from data_forwarder_host.gui.widgets.error_panel import ErrorPanel
+from data_forwarder_host.gui.widgets.header_strip import HeaderStrip
+from data_forwarder_host.gui.widgets.recording_label_strip import RecordingLabelStrip
+from data_forwarder_host.gui.widgets.save_banner import SaveBanner
+from data_forwarder_host.gui.widgets.session_log_panel import SessionLogPanel
+from data_forwarder_host.session.controller import SessionController
+from data_forwarder_host.session.states import SessionState
+
+
+class SessionTab(QWidget):
+    def __init__(self, controller: SessionController, parent=None) -> None:
+        super().__init__(parent)
+        self._ctrl = controller
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(4, 4, 4, 4)
+        outer.setSpacing(4)
+
+        # ── Header strip ─────────────────────────────────────────────
+        outer.addWidget(HeaderStrip(controller))
+
+        self._no_data_banner = QLabel("No data received yet")
+        self._no_data_banner.setStyleSheet(
+            "QLabel { background:palette(alternate-base); color:palette(text); "
+            "border:1px solid palette(mid); border-radius:4px; padding:6px 10px; "
+            "font-weight:600; }"
+        )
+        self._no_data_banner.setVisible(False)
+        outer.addWidget(self._no_data_banner)
+
+        self._sensor_data_seen = False
+
+        # ── Main horizontal split: narrow controls | scrollable content ─
+        self._body = QSplitter(Qt.Orientation.Horizontal)
+        outer.addWidget(self._body, 1)
+
+        ctrl_panel = ControlPanel(controller)
+        # No maximum width: the panel must stay freely resizable so the full
+        # values in "Session Configuration" and "Session Info" can be read. A
+        # capped width would let the splitter only shrink the panel, never
+        # enlarge it.
+        self._body.addWidget(ctrl_panel)
+
+        # ── One common scroll area: charts on top, log consoles below ─
+        # ChartsPanel has no internal scroll.  SessionLogPanel log
+        # consoles each carry their own internal scrollbar.
+        right_content = QWidget()
+        right_layout = QVBoxLayout(right_content)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+        right_layout.setSpacing(0)
+        # Prominent recording-label strip sits at the top-right, beside/above
+        # the charts and separate from the control-panel form.
+        self._label_strip = RecordingLabelStrip(controller)
+        self._label_strip.label_changed.connect(ctrl_panel.refresh_record_state)
+        right_layout.addWidget(self._label_strip)
+        self._charts_panel = ChartsPanel(controller.data_model)
+        right_layout.addWidget(self._charts_panel)
+        self._log_panel = SessionLogPanel(controller)
+        right_layout.addWidget(self._log_panel)
+        right_layout.addStretch(1)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        scroll.setWidget(right_content)
+        self._body.addWidget(scroll)
+
+        self._body.setStretchFactor(0, 0)   # controls: no extra horizontal growth
+        self._body.setStretchFactor(1, 1)   # charts+logs: take all extra space
+
+        # ── Last-saved CSV banner (bottom of the tab) ────────
+        self._save_banner = SaveBanner()
+        outer.addWidget(self._save_banner)
+
+        # ── Saving progress bar (bottom of the session window) ─
+        # Shown only while a recording-stop CSV dump is being written. The dump
+        # runs incrementally off the event loop, so this bar animates while the
+        # rest of the UI stays responsive.
+        self._saving_bar = QProgressBar()
+        self._saving_bar.setTextVisible(True)
+        self._saving_bar.setFormat("Saving recording to CSV…")
+        self._saving_bar.setVisible(False)
+        outer.addWidget(self._saving_bar)
+
+        # ── Error panel (collapsible, at the bottom) ──────────────────
+        self._error_panel = ErrorPanel(controller.error_log, controller=controller)
+        # Hidden by default; revealed via View ▸ Show error panel.
+        self._error_panel.setVisible(False)
+        outer.addWidget(self._error_panel)
+
+        controller.state_changed.connect(self._on_state_changed)
+        controller.message_received.connect(self._on_message_received)
+        controller.recording_saved.connect(self._save_banner.show_saved)
+        controller.recording_save_started.connect(self._on_save_started)
+        controller.recording_save_progress.connect(self._on_save_progress)
+        controller.recording_saved.connect(self._on_save_done)
+        controller.recording_save_failed.connect(self._on_save_done)
+
+    @property
+    def controller(self) -> SessionController:
+        return self._ctrl
+
+    def focus_recording_label(self) -> None:
+        """Move keyboard focus to the recording-label entry.
+
+        Invoked right after the tab is created so the cursor waits in the
+        label field for immediate typing.
+        """
+        self._label_strip.focus_label()
+
+    def set_panel_visible(self, key: str, on: bool) -> None:
+        """Show/hide one of the session panels (View ▸ Panels)."""
+        if key == "combined":
+            self._charts_panel.set_combined_visible(on)
+        elif key == "individual":
+            self._charts_panel.set_individual_visible(on)
+        elif key == "channel_ascii":
+            self._log_panel.set_channel_ascii_visible(on)
+        elif key == "decoded_frames":
+            self._log_panel.set_decoded_frames_visible(on)
+
+    def _on_state_changed(self, state: object) -> None:
+        running = state == SessionState.RUNNING
+        if running:
+            self._sensor_data_seen = False
+            self._no_data_banner.setVisible(True)
+        else:
+            self._no_data_banner.setVisible(False)
+
+    def _on_message_received(self, msg: object) -> None:
+        kind = getattr(msg, "kind", "")
+        if kind == "sensor_data":
+            self._sensor_data_seen = True
+            self._no_data_banner.setVisible(False)
+
+    # ------------------------------------------------------------------
+    # Saving progress bar
+    # ------------------------------------------------------------------
+
+    def _on_save_started(self) -> None:
+        # Range 0..0 renders an indeterminate (busy) bar until the first
+        # progress update tells us the total row count (unknown for spilled
+        # recordings, which stay indeterminate throughout).
+        self._saving_bar.setRange(0, 0)
+        self._saving_bar.setFormat("Saving recording to CSV…")
+        self._saving_bar.setVisible(True)
+
+    def _on_save_progress(self, rows_written: int, total: int) -> None:
+        if total > 0:
+            self._saving_bar.setRange(0, total)
+            self._saving_bar.setValue(min(rows_written, total))
+            self._saving_bar.setFormat(f"Saving recording to CSV… %p% ({rows_written}/{total})")
+        else:
+            self._saving_bar.setRange(0, 0)
+            self._saving_bar.setFormat(f"Saving recording to CSV… ({rows_written} rows)")
+
+    def _on_save_done(self, *_args: object) -> None:
+        self._saving_bar.setVisible(False)
+        self._saving_bar.reset()
+
+    # ------------------------------------------------------------------
+    # Layout state persistence
+    # ------------------------------------------------------------------
+
+    def get_layout_state(self) -> dict:
+        """Return a serialisable snapshot of the current layout state."""
+        state = self._log_panel.get_layout_state()
+        sizes = self._body.sizes()
+        total = sum(sizes) if sizes else 0
+        if total > 0:
+            state["body_splitter_ratio"] = sizes[0] / total
+        return state
+
+    def apply_layout_state(self, state: dict) -> None:
+        """Restore layout from a previously saved state dict."""
+        self._log_panel.apply_layout_state(state)
+        ratio = state.get("body_splitter_ratio")
+        if ratio is not None:
+            # Defer until after the widget has been shown and laid out.
+            def _restore_splitter() -> None:
+                total = self._body.width()
+                if total > 0:
+                    left = int(total * float(ratio))
+                    self._body.setSizes([left, total - left])
+            QTimer.singleShot(100, _restore_splitter)

--- a/tools/data_forwarder_host/gui/theme.py
+++ b/tools/data_forwarder_host/gui/theme.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Simple light/dark theme palette helpers."""
+
+from __future__ import annotations
+
+from enum import Enum, auto
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor, QPalette
+from PySide6.QtWidgets import QApplication
+
+
+class Theme(Enum):
+    LIGHT = auto()
+    DARK = auto()
+    SYSTEM = auto()
+
+
+def _detect_system_theme(app: QApplication) -> Theme:
+    """Resolve ``SYSTEM`` to ``LIGHT``/``DARK`` from the OS color scheme.
+
+    Relies on ``QStyleHints.colorScheme()`` (Qt 6.5+). When the platform cannot
+    report a scheme (``Qt.ColorScheme.Unknown``) we fall back to ``LIGHT`` so the
+    app is always readable rather than inheriting a half-applied dark desktop
+    palette (dark window background with dark default text).
+    """
+    try:
+        scheme = app.styleHints().colorScheme()
+    except (AttributeError, RuntimeError):
+        return Theme.LIGHT
+    return Theme.DARK if scheme == Qt.ColorScheme.Dark else Theme.LIGHT
+
+
+def _build_palette(roles: dict[QPalette.ColorRole, QColor], disabled_text: QColor) -> QPalette:
+    """Assemble a full :class:`QPalette` and dim its disabled text group.
+
+    Every shade role (``Mid``, ``Midlight``, ``Light``, ``Dark``, ``Shadow``,
+    ``PlaceholderText`` …) is set explicitly so that ``palette(...)`` references
+    in widget stylesheets resolve to theme-correct colours. Leaving them unset
+    is the classic dark-theme bug: Qt falls back to the *default* (light) shades,
+    so ``palette(mid)`` borders/labels stay light-grey on a dark window.
+    """
+    palette = QPalette()
+    for role, color in roles.items():
+        palette.setColor(role, color)
+    for group in (
+        QPalette.ColorGroup.Disabled,
+    ):
+        palette.setColor(group, QPalette.ColorRole.WindowText, disabled_text)
+        palette.setColor(group, QPalette.ColorRole.Text, disabled_text)
+        palette.setColor(group, QPalette.ColorRole.ButtonText, disabled_text)
+    return palette
+
+
+def _light_palette() -> QPalette:
+    return _build_palette(
+        {
+            QPalette.ColorRole.Window: QColor(245, 245, 245),
+            QPalette.ColorRole.WindowText: QColor(20, 20, 20),
+            QPalette.ColorRole.Base: QColor(255, 255, 255),
+            QPalette.ColorRole.AlternateBase: QColor(235, 235, 235),
+            QPalette.ColorRole.ToolTipBase: QColor(255, 255, 225),
+            QPalette.ColorRole.ToolTipText: QColor(20, 20, 20),
+            QPalette.ColorRole.PlaceholderText: QColor(120, 120, 120),
+            QPalette.ColorRole.Text: QColor(20, 20, 20),
+            QPalette.ColorRole.Button: QColor(240, 240, 240),
+            QPalette.ColorRole.ButtonText: QColor(20, 20, 20),
+            QPalette.ColorRole.BrightText: QColor(200, 0, 0),
+            QPalette.ColorRole.Link: QColor(0, 90, 200),
+            QPalette.ColorRole.LinkVisited: QColor(110, 60, 180),
+            QPalette.ColorRole.Highlight: QColor(45, 110, 200),
+            QPalette.ColorRole.HighlightedText: QColor(255, 255, 255),
+            QPalette.ColorRole.Light: QColor(255, 255, 255),
+            QPalette.ColorRole.Midlight: QColor(248, 248, 248),
+            QPalette.ColorRole.Mid: QColor(150, 150, 150),
+            QPalette.ColorRole.Dark: QColor(120, 120, 120),
+            QPalette.ColorRole.Shadow: QColor(90, 90, 90),
+        },
+        disabled_text=QColor(160, 160, 160),
+    )
+
+
+def _dark_palette() -> QPalette:
+    return _build_palette(
+        {
+            QPalette.ColorRole.Window: QColor(45, 45, 45),
+            QPalette.ColorRole.WindowText: QColor(220, 220, 220),
+            QPalette.ColorRole.Base: QColor(30, 30, 30),
+            QPalette.ColorRole.AlternateBase: QColor(55, 55, 55),
+            QPalette.ColorRole.ToolTipBase: QColor(60, 60, 60),
+            QPalette.ColorRole.ToolTipText: QColor(220, 220, 220),
+            QPalette.ColorRole.PlaceholderText: QColor(140, 140, 140),
+            QPalette.ColorRole.Text: QColor(220, 220, 220),
+            QPalette.ColorRole.Button: QColor(60, 60, 60),
+            QPalette.ColorRole.ButtonText: QColor(220, 220, 220),
+            QPalette.ColorRole.BrightText: QColor(255, 90, 90),
+            QPalette.ColorRole.Link: QColor(94, 160, 255),
+            QPalette.ColorRole.LinkVisited: QColor(170, 130, 255),
+            QPalette.ColorRole.Highlight: QColor(53, 120, 224),
+            QPalette.ColorRole.HighlightedText: QColor(255, 255, 255),
+            QPalette.ColorRole.Light: QColor(75, 75, 75),
+            QPalette.ColorRole.Midlight: QColor(62, 62, 62),
+            QPalette.ColorRole.Mid: QColor(120, 120, 120),
+            QPalette.ColorRole.Dark: QColor(28, 28, 28),
+            QPalette.ColorRole.Shadow: QColor(15, 15, 15),
+        },
+        disabled_text=QColor(120, 120, 120),
+    )
+
+
+def apply_theme(theme: Theme) -> None:
+    app = QApplication.instance()
+    if app is None:
+        return
+    # Always apply an explicit, self-consistent palette — including for SYSTEM,
+    # where ``style().standardPalette()`` returns a fixed light palette that does
+    # not follow the OS scheme, producing an unreadable dark-background /
+    # dark-text mix on a dark Ubuntu desktop.
+    resolved = _detect_system_theme(app) if theme == Theme.SYSTEM else theme
+    palette = _dark_palette() if resolved == Theme.DARK else _light_palette()
+    app.setPalette(palette)
+
+
+# Distinct, colour-blind-aware palette for channel traces.
+CHANNEL_COLORS = (
+    "#1f77b4",
+    "#ff7f0e",
+    "#2ca02c",
+    "#d62728",
+    "#9467bd",
+    "#8c564b",
+    "#e377c2",
+    "#7f7f7f",
+    "#bcbd22",
+    "#17becf",
+)
+
+
+def color_for_channel(idx: int) -> str:
+    return CHANNEL_COLORS[idx % len(CHANNEL_COLORS)]

--- a/tools/data_forwarder_host/gui/widgets/__init__.py
+++ b/tools/data_forwarder_host/gui/widgets/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Per-session reusable widgets (plots, control panel, error/log panels)."""

--- a/tools/data_forwarder_host/gui/widgets/bandwidth_details.py
+++ b/tools/data_forwarder_host/gui/widgets/bandwidth_details.py
@@ -1,0 +1,643 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Bandwidth details sub-window.
+
+A non-modal dialog opened from the "Bandwidth details" button next to the
+header throughput readout. It shows more of the data-transfer picture than the
+one-line header:
+
+* the live rates (bytes/s, messages/s, channels/s) over the measurement window;
+* the bandwidth measurement window, editable here;
+* a table of received-frame categories with two counts per row: the
+  session-cumulative ``Total count`` and a window-scoped ``Since reset`` count
+  that the user can zero with a local **Reset** button.
+
+The table columns are user-resizable with the mouse.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import deque
+from time import monotonic
+
+from PySide6.QtCharts import QChart, QChartView, QLineSeries, QValueAxis
+from PySide6.QtCore import QMargins, QPointF, Qt, QTimer
+from PySide6.QtGui import QPainter, QPen
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QDoubleSpinBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+from data_forwarder_host.core.error_log import ErrorCategory, ErrorSummary
+from data_forwarder_host.core.pipeline_metrics import (
+    PipelineSnapshot,
+    build_host_pipeline_snapshot,
+    per_stage_drop_totals,
+)
+from data_forwarder_host.core.transfer_stats import (
+    baseline_counts,
+    breakdown_since,
+    byte_baseline,
+    bytes_breakdown_since,
+)
+from data_forwarder_host.gui.theme import color_for_channel
+from data_forwarder_host.gui.widgets.pipeline_flow import PipelineFlowWidget
+from data_forwarder_host.protocol.base import DecodeStats
+from data_forwarder_host.session.controller import SessionController
+from data_forwarder_host.session.forwarding import ForwardingSession
+from data_forwarder_host.utils.logging import log_user_action
+from data_forwarder_host.utils.slow_span import slow_span, slow_span_fn
+
+_COLUMNS = (
+    "Category",
+    "Total count",
+    "Since reset",
+    "Total bytes",
+    "Bytes since reset",
+)
+
+# Label for the window-scoped reset button. It now clears more than the
+# since-reset counters — it also zeroes each pipeline stage's drop/issue counter
+# and removes the red node-warning borders.
+# The ampersand is doubled so Qt renders a literal "&" instead of treating the
+# following character as a mnemonic (which shows as an underline).
+CLEAR_BUTTON_LABEL = "Clear counters && node warnings"
+
+# Error & loss categories surfaced here, mirroring the Error & Loss Analysis
+# panel. The cumulative PRODUCER_DROP_TOTAL is intentionally omitted (the
+# since-reset PRODUCER_DROP is the meaningful figure in this view).
+_ERROR_CATEGORIES = tuple(
+    c for c in ErrorCategory if c is not ErrorCategory.PRODUCER_DROP_TOTAL
+)
+
+
+def _fmt_size(n: int) -> str:
+    units = ("B", "KB", "MB", "GB")
+    v = float(n)
+    idx = 0
+    while v >= 1000.0 and idx < len(units) - 1:
+        v /= 1000.0
+        idx += 1
+    return f"{int(n)} B" if idx == 0 else f"{v:.1f} {units[idx]}"
+
+
+def _fmt_bytes_per_s(value: float) -> str:
+    units = ("B/s", "KB/s", "MB/s", "GB/s")
+    v = float(value)
+    idx = 0
+    while v >= 1000.0 and idx < len(units) - 1:
+        v /= 1000.0
+        idx += 1
+    return f"{v:.0f} {units[idx]}" if idx == 0 else f"{v:.1f} {units[idx]}"
+
+
+def _pretty_category(name: str) -> str:
+    """Humanise an ``ErrorCategory`` enum name for display."""
+    return name.replace("_", " ").title()
+
+
+def compute_expected_step_points(
+    history: list[tuple[float, float]],
+    times: list[float],
+    window_seconds: float,
+) -> list[tuple[float, float]]:
+    """Piecewise-constant *expected msg/s* line, smoothed like a low-pass filter.
+
+    The expected rate is not a single flat line: it changes whenever the
+    producer's reported sampling frequency changes. Each change must take effect
+    **from its own timepoint forward** (a step), not be redrawn flat across the
+    whole graph. The step transition is smoothed with a
+    first-order (EMA) response whose time constant is the bandwidth measurement
+    window — so a level change ramps in over roughly that window, mirroring how
+    the measured rate itself reacts.
+
+    Args:
+        history: ``(t_seconds, hz)`` expected-rate changes in chronological
+            order (``t_seconds`` on the same axis as *times*).
+        times: x positions (seconds) at which to evaluate the line — typically
+            the timestamps of the actual-rate samples currently on screen.
+        window_seconds: the bandwidth window; used as the smoothing time
+            constant ``tau``.
+
+    Returns:
+        ``(t, value)`` points for the expected series, or ``[]`` if there is
+        nothing to draw.
+    """
+    if not history or not times:
+        return []
+    tau = window_seconds if window_seconds and window_seconds > 0 else 1e-3
+
+    def level_at(t: float) -> float:
+        level = history[0][1]
+        for t_change, hz in history:
+            if t_change <= t:
+                level = hz
+            else:
+                break
+        return level
+
+    lo, hi = times[0], times[-1]
+    # Evaluate at the sample times *and* at every step change inside the window,
+    # so each sub-interval has a single constant level and each step begins
+    # exactly at its change timepoint.
+    grid = sorted(set(times) | {t for t, _ in history if lo <= t <= hi})
+    out: list[tuple[float, float]] = []
+    prev_t = grid[0]
+    smoothed = level_at(grid[0])
+    out.append((grid[0], smoothed))
+    for t in grid[1:]:
+        dt = t - prev_t
+        if dt < 0.0:
+            dt = 0.0
+        # The level is constant on [prev_t, t); use the level in effect at the
+        # interval's start so a change at time ``t`` only ramps in afterwards.
+        target = level_at(prev_t)
+        alpha = 1.0 - math.exp(-dt / tau) if tau > 0 else 1.0
+        smoothed += alpha * (target - smoothed)
+        out.append((t, smoothed))
+        prev_t = t
+    return out
+
+
+def error_rows_since(
+    counts: dict,
+    baseline: dict,
+    categories: tuple,
+) -> list[tuple[str, int, int]]:
+    """Build ``(label, total, since_reset)`` rows for the error/loss categories.
+
+    *since_reset* is the window-local delta ``total - baseline`` (never negative)
+    so the bandwidth-details Reset can zero these counts **without touching the
+    shared error log** — they are secondary, window-scoped figures derived from
+    the general counters but living only in this sub-window.
+    """
+    rows: list[tuple[str, int, int]] = []
+    for cat in categories:
+        total = int(counts.get(cat, 0))
+        base = int(baseline.get(cat, 0))
+        since = total - base
+        if since < 0:
+            since = 0
+        rows.append((_pretty_category(cat.name), total, since))
+    return rows
+
+
+class _MsgRateChart(QChartView):
+    """Rolling line chart of the message rate (msg/s) over time.
+
+    Styled to match the session's individual-channel plots (QtCharts
+    ``QChartView``, no animation, full-bleed plot area). The dialog feeds it a
+    new ``msg/s`` sample on every rates refresh; the chart keeps a rolling
+    window of recent samples and auto-ranges the y axis.
+    """
+
+    _WINDOW_SECONDS: float = 60.0
+
+    def __init__(self, parent=None) -> None:
+        chart = QChart()
+        chart.setAnimationOptions(QChart.AnimationOption.NoAnimation)
+        chart.legend().setVisible(True)
+        chart.legend().setAlignment(Qt.AlignmentFlag.AlignBottom)
+        chart.setMargins(QMargins(0, 0, 0, 0))
+        chart.layout().setContentsMargins(0, 0, 0, 0)
+        super().__init__(chart, parent)
+        self.setRenderHint(QPainter.RenderHint.Antialiasing)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        self.setMinimumHeight(160)
+
+        self._series = QLineSeries()
+        self._series.setName("actual msg/s")
+        pen = QPen(_to_qcolor(color_for_channel(0)))
+        pen.setWidth(2)
+        self._series.setPen(pen)
+        chart.addSeries(self._series)
+
+        # Dynamic "expected" line: the producer's sampling frequency (msg/s)
+        # from session_info. Drawn flat across the visible window and updated
+        # whenever the frequency changes.
+        self._expected_series = QLineSeries()
+        self._expected_series.setName("expected msg/s")
+        exp_pen = QPen(_to_qcolor("#C62828"))
+        exp_pen.setWidth(2)
+        exp_pen.setStyle(Qt.PenStyle.DashLine)
+        self._expected_series.setPen(exp_pen)
+        chart.addSeries(self._expected_series)
+        self._expected: float | None = None
+        # History of (t_seconds, hz) expected-rate changes so the line steps at
+        # each change timepoint; smoothing time constant comes
+        # from the bandwidth window.
+        self._expected_history: list[tuple[float, float]] = []
+        self._window_seconds: float = 1.0
+
+        self._axis_x = QValueAxis()
+        self._axis_x.setLabelFormat("%.0f")
+        self._axis_x.setTitleText("Time (s)")
+        self._axis_y = QValueAxis()
+        self._axis_y.setLabelFormat("%.0f")
+        self._axis_y.setTitleText("msg/s")
+        chart.addAxis(self._axis_x, Qt.AlignmentFlag.AlignBottom)
+        chart.addAxis(self._axis_y, Qt.AlignmentFlag.AlignLeft)
+        self._series.attachAxis(self._axis_x)
+        self._series.attachAxis(self._axis_y)
+        self._expected_series.attachAxis(self._axis_x)
+        self._expected_series.attachAxis(self._axis_y)
+
+        self._t0 = monotonic()
+        self._points: deque[tuple[float, float]] = deque()
+
+    def set_expected(self, msg_per_second: float | None) -> None:
+        """Set/clear the expected-rate line (producer frequency, msg/s).
+
+        Records a step change at the current time so the line changes level only
+        from this timepoint forward, rather than redrawing flat.
+        """
+        value = (
+            float(msg_per_second) if msg_per_second and msg_per_second > 0 else None
+        )
+        self._expected = value
+        if value is None:
+            self._expected_history.clear()
+        elif not self._expected_history or self._expected_history[-1][1] != value:
+            self._expected_history.append((monotonic() - self._t0, value))
+        self._refresh()
+
+    def set_bandwidth_window(self, seconds: float) -> None:
+        """Update the smoothing time constant (the bandwidth window)."""
+        if seconds and seconds > 0:
+            self._window_seconds = float(seconds)
+            self._refresh()
+
+    def add_sample(self, msg_per_second: float) -> None:
+        now = monotonic() - self._t0
+        self._points.append((now, float(msg_per_second)))
+        cutoff = now - self._WINDOW_SECONDS
+        while self._points and self._points[0][0] < cutoff:
+            self._points.popleft()
+        self._refresh()
+
+    def _refresh(self) -> None:
+        self._series.replace([QPointF(t, v) for t, v in self._points])
+        if not self._points:
+            if self._expected is not None:
+                self._expected_series.replace(
+                    [QPointF(0.0, self._expected), QPointF(1.0, self._expected)]
+                )
+                self._axis_x.setRange(0.0, 1.0)
+                self._axis_y.setRange(0.0, self._expected * 1.1)
+            return
+        x_min = self._points[0][0]
+        x_max = self._points[-1][0]
+        if x_max <= x_min:
+            x_max = x_min + 1.0
+        self._axis_x.setRange(x_min, x_max)
+        y_max = max(v for _t, v in self._points)
+        exp_points = compute_expected_step_points(
+            self._expected_history,
+            [t for t, _ in self._points],
+            self._window_seconds,
+        )
+        if exp_points:
+            self._expected_series.replace([QPointF(t, v) for t, v in exp_points])
+            y_max = max(y_max, max(v for _t, v in exp_points))
+        else:
+            self._expected_series.replace([])
+        # Keep headroom for the latest expected level so the axis stays stable
+        # while the smoothed step ramps toward a new level.
+        if self._expected is not None:
+            y_max = max(y_max, self._expected)
+        # Always start the rate axis at zero and leave a little headroom.
+        self._axis_y.setRange(0.0, (y_max * 1.1) if y_max > 0 else 1.0)
+
+
+def _to_qcolor(name: str):
+    from PySide6.QtGui import QColor
+
+    return QColor(name)
+
+
+class BandwidthDetailsDialog(QDialog):
+    """Detailed data-transfer / reception statistics for one session."""
+
+    def __init__(self, controller: SessionController, parent=None) -> None:
+        super().__init__(parent)
+        self._ctrl = controller
+        self._stats = DecodeStats()
+        # Window-scoped counter baselines; empty means "since reset" == total.
+        self._reset_baseline: dict[str, int] = {}
+        self._reset_bytes_baseline: dict[str, int] = {}
+        # Window-local baseline for the merged error/loss categories. These are
+        # secondary, sub-window-scoped figures: resetting them never touches the
+        # shared error log / general counters.
+        self._error_reset_baseline: dict = {}
+        self._summary: ErrorSummary | None = None
+        # Latest device frame rate (Hz) reported via session_info, shown as the
+        # Device pipeline stage's production rate.
+        self._device_rate: float = 0.0
+
+        self.setWindowTitle(f"Bandwidth details — {controller.config.tag}")
+        # Open at a comfortable size rather than collapsing to the hint. Larger
+        # now that the window also carries the session info and the error table.
+        self.setMinimumSize(560, 520)
+        self.resize(780, 720)
+
+        lay = QVBoxLayout(self)
+        lay.setContentsMargins(10, 10, 10, 10)
+        lay.setSpacing(6)
+
+        # Session info: sampling rate (Hz) and channel count, from session_info.
+        self._sampling_label = QLabel("Sampling rate: — Hz")
+        self._channels_label = QLabel("Channels: —")
+        info_row = QHBoxLayout()
+        info_row.addWidget(self._sampling_label)
+        info_row.addSpacing(20)
+        info_row.addWidget(self._channels_label)
+        info_row.addStretch(1)
+        lay.addLayout(info_row)
+
+        lay.addWidget(QLabel("<b>Live throughput</b>"))
+        self._rates = QLabel()
+        lay.addWidget(self._rates)
+
+        # Rolling chart of the message rate over time (msg/s), styled like the
+        # session's individual-channel plots. The dashed line shows the expected
+        # rate (producer frequency from session_info).
+        lay.addWidget(QLabel("Message rate over time"))
+        self._rate_chart = _MsgRateChart()
+        lay.addWidget(self._rate_chart)
+
+        # Per-stage pipeline flow: source → decode → in-flight gate → model →
+        # recorder, coloured by utilisation with drop badges and a highlighted
+        # bottleneck. Fed a fresh snapshot on each rates refresh.
+        lay.addWidget(QLabel("<b>Live throughput</b>"))
+        self._pipeline = PipelineFlowWidget()
+        lay.addWidget(self._pipeline)
+
+        # Measurement-window control.
+        win_row = QHBoxLayout()
+        win_row.addWidget(QLabel("Bandwidth window:"))
+        self._window_spin = QDoubleSpinBox()
+        self._window_spin.setRange(0.1, 600.0)
+        self._window_spin.setDecimals(1)
+        self._window_spin.setSingleStep(0.5)
+        self._window_spin.setSuffix(" s")
+        self._window_spin.setValue(controller.current_config().bandwidth_window_seconds)
+        self._window_spin.valueChanged.connect(self._on_window_changed)
+        # Seed the chart smoothing time constant from the current window.
+        self._rate_chart.set_bandwidth_window(
+            controller.current_config().bandwidth_window_seconds
+        )
+        win_row.addWidget(self._window_spin)
+        win_row.addStretch(1)
+        lay.addLayout(win_row)
+        lay.addWidget(QLabel("<b>Received frames &amp; transport</b>"))
+        self._table = QTableWidget(0, len(_COLUMNS))
+        self._table.setHorizontalHeaderLabels(list(_COLUMNS))
+        header = self._table.horizontalHeader()
+        # User-resizable columns (drag with the mouse).
+        header.setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
+        header.setStretchLastSection(True)
+        self._table.setColumnWidth(0, 200)
+        self._table.setColumnWidth(1, 90)
+        self._table.setColumnWidth(2, 90)
+        self._table.setColumnWidth(3, 90)
+        self._table.verticalHeader().setVisible(False)
+        self._table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        lay.addWidget(self._table, 1)
+
+        # Window-scoped reset.
+        btn_row = QHBoxLayout()
+        btn_row.addStretch(1)
+        self._reset_btn = QPushButton(CLEAR_BUTTON_LABEL)
+        self._reset_btn.setToolTip(
+            "Zero the per-category 'Since reset' counts in this window only and "
+            "clear each pipeline stage's drop counter and red warning border; "
+            "they start counting up again from now"
+        )
+        self._reset_btn.clicked.connect(self._on_reset_counters)
+        btn_row.addWidget(self._reset_btn)
+        lay.addLayout(btn_row)
+
+        controller.stats_updated.connect(self._on_stats)
+        # Keep the window control in sync when changed from the session window.
+        controller.bandwidth_window_changed.connect(self._on_external_window_changed)
+        # Error & loss table + expected-rate line driven by the error log and
+        # the session_info sampling rate.
+        controller.error_log.summary_changed.connect(self._on_error_summary)
+        controller.session_sampling_changed.connect(self._on_sampling_changed)
+
+        # Seed the session-info fields and expected-rate line if already known.
+        sampling = controller.latest_sampling_info()
+        if sampling is not None:
+            self._on_sampling_changed(sampling[0], sampling[1])
+        self._on_error_summary(controller.error_log.summary())
+
+        # Refresh the live rates a couple of times a second.
+        self._timer = QTimer(self)
+        self._timer.setInterval(500)
+        self._timer.timeout.connect(self._refresh_rates)
+        self._timer.start()
+
+        self._refresh_rates()
+        self._refresh_table()
+
+    # ------------------------------------------------------------------
+    # Slots
+    # ------------------------------------------------------------------
+
+    def _on_window_changed(self, seconds: float) -> None:
+        log_user_action("Changed the bandwidth window to %.1f s", float(seconds))
+        self._rate_chart.set_bandwidth_window(float(seconds))
+        self._ctrl.set_bandwidth_window_seconds(float(seconds))
+
+    def _on_external_window_changed(self, seconds: float) -> None:
+        self._rate_chart.set_bandwidth_window(float(seconds))
+        if abs(self._window_spin.value() - seconds) < 1e-9:
+            return
+        blocked = self._window_spin.blockSignals(True)
+        self._window_spin.setValue(seconds)
+        self._window_spin.blockSignals(blocked)
+
+    def _on_reset_counters(self) -> None:
+        # Snapshot the current totals; subsequent rows show counts since now.
+        # This re-anchors only the window-local baselines (frame + error/loss);
+        # the shared error log and general counters are untouched. It
+        # also clears the pipeline node warnings — each stage's drop counter and
+        # red border — until new frames are dropped.
+        log_user_action("Clicked Clear counters & node warnings in bandwidth details")
+        self._reset_baseline = baseline_counts(self._stats)
+        self._reset_bytes_baseline = byte_baseline(self._stats)
+        if self._summary is not None:
+            self._error_reset_baseline = dict(self._summary.counts)
+        self._pipeline.clear_warnings()
+        self._refresh_table()
+
+    def _on_stats(self, stats: DecodeStats) -> None:
+        self._stats = stats
+        self._refresh_table()
+
+    def _on_sampling_changed(self, hz: float, channels: int) -> None:
+        """Reflect the session_info sampling rate / channel count and expected rate."""
+        self._sampling_label.setText(f"Sampling rate: {hz:.0f} Hz")
+        self._channels_label.setText(f"Channels: {channels}")
+        # Expected messages/s equals the producer sampling frequency. The Device
+        # pipeline stage reflects this as the producer's frame rate.
+        self._device_rate = float(hz)
+        self._rate_chart.set_expected(hz)
+
+    def _on_error_summary(self, summary: ErrorSummary) -> None:
+        self._summary = summary
+        self._refresh_table()
+
+    def closeEvent(self, event) -> None:  # noqa: N802 (Qt naming)
+        log_user_action("Closed the bandwidth details window")
+        super().closeEvent(event)
+
+    # ------------------------------------------------------------------
+    # Rendering
+    # ------------------------------------------------------------------
+
+    def _refresh_rates(self) -> None:
+        with slow_span("bw.refresh_rates"):
+            s = self._ctrl.bandwidth_sample()
+            self._rates.setText(
+                f"{_fmt_bytes_per_s(s.bytes_per_second)} · "
+                f"{s.messages_per_second:.0f} msg/s · "
+                f"{s.channels_per_second:.0f} ch/s"
+            )
+            self._rate_chart.add_sample(s.messages_per_second)
+            with slow_span("bw.pipeline_snapshot"):
+                snap = self._build_pipeline_snapshot(s.messages_per_second)
+            self._pipeline.update_snapshot(snap)
+            # Surface the same per-stage drop totals in the Error & Loss table,
+            # read back from the widget's (baseline-adjusted) snapshot so the
+            # table and diagram always agree.
+            self._refresh_table()
+
+    def _build_pipeline_snapshot(self, msg_s: float) -> PipelineSnapshot:
+        """Assemble a per-stage snapshot from the controller's public metrics.
+
+        A leading Device stage reflects the sensor board's reported frame rate
+        and producer-side drops; on a BLE session a Host BT stage then represents
+        the host OS Bluetooth stack, showing the produced-vs-received rate and
+        the confirmed transport (sequence-gap) loss attributed to it; rates then
+        flow through every host stage at the measured message rate; the in-flight
+        gate carries the overload drop count and its bounded capacity, and the
+        model/recorder show their current backlog. The widget derives utilisation
+        and the bottleneck from this pure structure.
+        """
+        recording = self._ctrl.is_recording()
+        recorder_overflow = 0
+        if self._summary is not None:
+            recorder_overflow = self._summary.counts.get(
+                ErrorCategory.RECORDER_OVERFLOW, 0
+            )
+        # Net the Host BT stage against the live producer-drop count (not the
+        # 1 Hz error summary) so the Device stage and the Host BT subtraction
+        # reconcile against the same up-to-date "dr" that gated the reconcile
+        # release — a device-caused drop then nets onto the Device stage without
+        # briefly showing under Host BT while the coalesced summary catches up.
+        producer_drops = self._ctrl.producer_drop_count()
+        # Use the reconcile-held transport total so a device-caused drop is not
+        # briefly attributed to the Host BT stage before its producer "dr" lands.
+        transport_loss = self._ctrl.host_attributed_transport_loss()
+        return build_host_pipeline_snapshot(
+            message_rate=msg_s,
+            dropped_frames=self._ctrl.dropped_frames(),
+            gate_capacity=ForwardingSession.MAX_IN_FLIGHT,
+            model_queue_depth=self._ctrl.data_model.max_buffer_size,
+            recording=recording,
+            recorder_queue_depth=self._ctrl.recorder.buffered_rows if recording else 0,
+            device_rate=self._device_rate,
+            producer_drops=producer_drops,
+            transport_kind=self._ctrl.config.source.kind,
+            transport_loss=transport_loss,
+            recorder_overflow=recorder_overflow,
+            wall_time_s=monotonic(),
+        )
+
+    @slow_span_fn("bw.refresh_table")
+    def _refresh_table(self) -> None:
+        rows = breakdown_since(self._stats, self._reset_baseline)
+        byte_rows = bytes_breakdown_since(self._stats, self._reset_bytes_baseline)
+        error_rows = (
+            error_rows_since(
+                self._summary.counts, self._error_reset_baseline, _ERROR_CATEGORIES
+            )
+            if self._summary is not None
+            else []
+        )
+        # One unified table: received-frame categories, a separator, then the
+        # error/loss categories appended as further rows so the whole
+        # producer→decoded-frame path is traced in a single form. Finally a
+        # "Dropped frames by stage" section attributes every dropped frame to the
+        # stage that shed it, read from the same pipeline snapshot the diagram
+        # uses so the two views always agree.
+        drop_rows = self._stage_drop_rows()
+        drops_block = (1 + len(drop_rows)) if drop_rows else 0
+        total_rows = (
+            len(rows) + (1 + len(error_rows) if error_rows else 0) + drops_block
+        )
+        self._table.setRowCount(total_rows)
+        for r, ((label, total, since), (_lbl, tbytes, sbytes)) in enumerate(
+            zip(rows, byte_rows)
+        ):
+            self._table.setItem(r, 0, QTableWidgetItem(label))
+            self._table.setItem(r, 1, QTableWidgetItem(str(total)))
+            self._table.setItem(r, 2, QTableWidgetItem(str(since)))
+            self._table.setItem(r, 3, QTableWidgetItem(_fmt_size(tbytes)))
+            self._table.setItem(r, 4, QTableWidgetItem(_fmt_size(sbytes)))
+        next_row = len(rows)
+        if error_rows:
+            sep = next_row
+            header = QTableWidgetItem("— Errors & loss —")
+            self._table.setItem(sep, 0, header)
+            for col in range(1, len(_COLUMNS)):
+                self._table.setItem(sep, col, QTableWidgetItem(""))
+            for i, (label, total, since) in enumerate(error_rows):
+                r = sep + 1 + i
+                self._table.setItem(r, 0, QTableWidgetItem(label))
+                self._table.setItem(r, 1, QTableWidgetItem(str(total)))
+                self._table.setItem(r, 2, QTableWidgetItem(str(since)))
+                # Byte columns are not meaningful for error categories.
+                self._table.setItem(r, 3, QTableWidgetItem("—"))
+                self._table.setItem(r, 4, QTableWidgetItem("—"))
+            next_row = sep + 1 + len(error_rows)
+        if drop_rows:
+            sep = next_row
+            self._table.setItem(sep, 0, QTableWidgetItem("— Dropped frames by stage —"))
+            for col in range(1, len(_COLUMNS)):
+                self._table.setItem(sep, col, QTableWidgetItem(""))
+            for i, (stage_name, drops) in enumerate(drop_rows):
+                r = sep + 1 + i
+                self._table.setItem(r, 0, QTableWidgetItem(f"{stage_name} drops"))
+                self._table.setItem(r, 1, QTableWidgetItem(str(drops)))
+                self._table.setItem(r, 2, QTableWidgetItem("—"))
+                self._table.setItem(r, 3, QTableWidgetItem("—"))
+                self._table.setItem(r, 4, QTableWidgetItem("—"))
+
+    def _stage_drop_rows(self) -> list[tuple[str, int]]:
+        """Per-stage dropped-frame rows for the table, newest snapshot, drops>0.
+
+        Reads :func:`per_stage_drop_totals` from the pipeline widget's current
+        (baseline-adjusted) snapshot so the Error & Loss table and the pipeline
+        diagram report identical per-stage drop counts, and both clear together
+        when node warnings are cleared.
+        """
+        snap = self._pipeline.snapshot
+        if snap is None:
+            return []
+        return [
+            (name, drops)
+            for name, drops in per_stage_drop_totals(snap)
+            if drops > 0
+        ]

--- a/tools/data_forwarder_host/gui/widgets/channel_grid.py
+++ b/tools/data_forwarder_host/gui/widgets/channel_grid.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Grid of per-channel mini-plots."""
+
+from __future__ import annotations
+
+from PySide6.QtCharts import QChart, QChartView, QLineSeries, QValueAxis
+from PySide6.QtCore import QPointF, Qt
+from PySide6.QtGui import QPainter
+from PySide6.QtWidgets import QGridLayout, QSizePolicy, QWidget
+
+from data_forwarder_host.core.data_model import DataModel
+from data_forwarder_host.gui.theme import color_for_channel
+
+
+class _MiniPlot(QChartView):
+    def __init__(self, name: str, color: str, parent=None) -> None:
+        chart = QChart()
+        chart.setTitle(name)
+        chart.legend().setVisible(False)
+        chart.setAnimationOptions(QChart.AnimationOption.NoAnimation)
+        super().__init__(chart, parent)
+        self.setRenderHint(QPainter.RenderHint.Antialiasing)
+        self.setMinimumHeight(110)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self._series = QLineSeries()
+        chart.addSeries(self._series)
+        from PySide6.QtGui import QColor
+        self._series.setColor(QColor(color))
+        self._axis_x = QValueAxis()
+        self._axis_y = QValueAxis()
+        self._axis_x.setLabelFormat("%d")
+        self._axis_y.setLabelFormat("%.3g")
+        chart.addAxis(self._axis_x, Qt.AlignmentFlag.AlignBottom)
+        chart.addAxis(self._axis_y, Qt.AlignmentFlag.AlignLeft)
+        self._series.attachAxis(self._axis_x)
+        self._series.attachAxis(self._axis_y)
+
+    def update_data(self, ts, val) -> None:
+        if ts.size == 0:
+            self._series.replace([])
+            return
+        self._series.replace([QPointF(float(t), float(v)) for t, v in zip(ts.tolist(), val.tolist())])
+        self._axis_x.setRange(int(ts[0]), int(ts[-1]))
+        vmin, vmax = float(val.min()), float(val.max())
+        if vmin == vmax:
+            vmin -= 1.0
+            vmax += 1.0
+        pad = 0.05 * (vmax - vmin)
+        self._axis_y.setRange(vmin - pad, vmax + pad)
+
+
+class ChannelGrid(QWidget):
+    """Compact grid of per-channel mini-plots, recomputed at the model's redraw rate."""
+
+    COLS = 4
+
+    def __init__(self, data_model: DataModel, parent=None) -> None:
+        super().__init__(parent)
+        self._model = data_model
+        self._layout = QGridLayout(self)
+        self._layout.setContentsMargins(4, 4, 4, 4)
+        self._layout.setSpacing(6)
+        self._mini: list[_MiniPlot] = []
+
+        data_model.channels_changed.connect(self._rebuild)
+        data_model.data_appended.connect(self._refresh)
+        data_model.cleared.connect(self._refresh)
+
+        self._rebuild()
+
+    def _rebuild(self) -> None:
+        for w in self._mini:
+            self._layout.removeWidget(w)
+            w.deleteLater()
+        self._mini = []
+        for i, name in enumerate(self._model.channel_names):
+            mp = _MiniPlot(name, color_for_channel(i))
+            self._mini.append(mp)
+            self._layout.addWidget(mp, i // self.COLS, i % self.COLS)
+
+    def _refresh(self, *_args) -> None:
+        window_ms = int(self._model.plot_window_seconds * 1000)
+        for i, mp in enumerate(self._mini):
+            ts, val = self._model.buffer(i).latest_window(window_ms)
+            mp.update_data(ts, val)

--- a/tools/data_forwarder_host/gui/widgets/charts_panel.py
+++ b/tools/data_forwarder_host/gui/widgets/charts_panel.py
@@ -1,0 +1,276 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""ChartsPanel — combined overview + collapsible per-channel sub-charts.
+
+Layout (inside one QScrollArea)::
+
+    ▾ Combined View                     ← expanded by default
+        <CombinedPlot — all channels overlaid>
+    ▸ Individual Channels               ← collapsed by default; when expanded:
+        ▾ ch0                             all child sections open together
+        ▾ ch1
+        ▾ ch2  ...
+
+A single ``QScrollArea`` provides a common scroll bar for the whole view.
+Per-channel sections are rebuilt automatically when ``channels_changed`` fires.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCharts import QChart, QChartView, QLineSeries, QValueAxis
+from PySide6.QtCore import Qt
+from PySide6.QtCore import QMargins
+from PySide6.QtGui import QColor, QPainter, QPen
+from PySide6.QtWidgets import (
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+from data_forwarder_host.core.data_model import DataModel
+from data_forwarder_host.core.decimation import decimate_minmax
+from data_forwarder_host.utils.slow_span import slow_span
+from data_forwarder_host.gui.theme import color_for_channel
+from data_forwarder_host.gui.widgets.collapsible_section import CollapsibleSection
+from data_forwarder_host.gui.widgets.combined_plot import CombinedPlot
+
+
+# ---------------------------------------------------------------------------
+# Internal single-channel chart
+# ---------------------------------------------------------------------------
+
+
+class _ChannelChart(QChartView):
+    """Single-channel rolling time-series chart.
+
+    The channel name is shown in the parent ``CollapsibleSection`` header, so
+    the chart title is omitted to maximise the plot area.  X axis shows time
+    in seconds (same unit as ``CombinedPlot``) so the user can correlate
+    events across the two views.
+    """
+
+    def __init__(self, name: str, color: str, parent: QWidget | None = None) -> None:
+        chart = QChart()
+        # Title omitted — shown by the CollapsibleSection header above.
+        chart.legend().setVisible(False)
+        chart.setAnimationOptions(QChart.AnimationOption.NoAnimation)
+        # Minimise padding so the chart fills the available width.
+        chart.setMargins(QMargins(0, 0, 0, 0))
+        chart.layout().setContentsMargins(0, 0, 0, 0)
+        super().__init__(chart, parent)
+        self.setRenderHint(QPainter.RenderHint.Antialiasing)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self.setMinimumHeight(120)
+
+        self._series = QLineSeries()
+        self._series.setColor(QColor(color))
+        chart.addSeries(self._series)
+
+        # X axis in seconds — same unit as CombinedPlot so tick positions align.
+        self._axis_x = QValueAxis()
+        self._axis_x.setLabelFormat("%.1f")
+        self._axis_y = QValueAxis()
+        self._axis_y.setLabelFormat("%.3g")
+        chart.addAxis(self._axis_x, Qt.AlignmentFlag.AlignBottom)
+        chart.addAxis(self._axis_y, Qt.AlignmentFlag.AlignLeft)
+        self._series.attachAxis(self._axis_x)
+        self._series.attachAxis(self._axis_y)
+
+        # Dashed vertical recording markers: start (red) and stop (blue).
+        self._marker = QLineSeries()
+        marker_pen = QPen(QColor("#d62728"))
+        marker_pen.setWidth(2)
+        marker_pen.setStyle(Qt.PenStyle.DashLine)
+        self._marker.setPen(marker_pen)
+        chart.addSeries(self._marker)
+        self._marker.attachAxis(self._axis_x)
+        self._marker.attachAxis(self._axis_y)
+
+        self._stop_marker = QLineSeries()
+        stop_pen = QPen(QColor("#1f77b4"))
+        stop_pen.setWidth(2)
+        stop_pen.setStyle(Qt.PenStyle.DashLine)
+        self._stop_marker.setPen(stop_pen)
+        chart.addSeries(self._stop_marker)
+        self._stop_marker.attachAxis(self._axis_x)
+        self._stop_marker.attachAxis(self._axis_y)
+
+    def update_data(self, ts, val, marker_ms=None, right_ms=None, stop_marker_ms=None, x_window=None) -> None:  # type: ignore[type-arg]
+        from PySide6.QtCore import QPointF
+
+        if ts.size == 0:
+            self._series.replace([])
+            self._marker.replace([])
+            self._stop_marker.replace([])
+            # Even with no points this chart must keep the shared X window so its
+            # (empty) axis still lines up with the other charts.
+            if x_window is not None:
+                self._axis_x.setRange(x_window[0], x_window[1])
+            return
+        # Render-time min/max decimation bounds the on-screen point count so the
+        # redraw is O(points_on_screen), not O(buffer_size). Peaks
+        # are preserved, so the y auto-range below is unaffected.
+        with slow_span("charts.decimate", extra=f"in={ts.size}"):
+            ts, val = decimate_minmax(ts, val)
+        # Convert ms → s so the X axis matches the CombinedPlot.
+        with slow_span("charts.series_replace", extra=f"pts={ts.size}"):
+            self._series.replace(
+                [QPointF(float(t) / 1000.0, float(v)) for t, v in zip(ts.tolist(), val.tolist())]
+            )
+        x_lo, x_hi = ts[0] / 1000.0, ts[-1] / 1000.0
+        if x_window is not None:
+            # Use the model's shared rolling window so all charts line up exactly.
+            # The data-derived edges remain the fallback when no shared
+            # window is available yet.
+            x_lo, x_hi = x_window[0], x_window[1]
+        elif right_ms is not None and right_ms / 1000.0 > x_lo:
+            # Right edge follows the smoothed playout position, matching
+            # the CombinedPlot; fall back to the newest sample when idle/behind.
+            x_hi = right_ms / 1000.0
+        self._axis_x.setRange(x_lo, x_hi)
+        vmin, vmax = float(val.min()), float(val.max())
+        if vmin == vmax:
+            vmin -= 1.0
+            vmax += 1.0
+        pad = 0.05 * (vmax - vmin)
+        self._axis_y.setRange(vmin - pad, vmax + pad)
+        self._update_marker(self._marker, marker_ms, x_lo, x_hi)
+        self._update_marker(self._stop_marker, stop_marker_ms, x_lo, x_hi)
+
+    def _update_marker(self, series, marker_ms, x_lo: float, x_hi: float) -> None:
+        from PySide6.QtCore import QPointF
+
+        if marker_ms is None:
+            series.replace([])
+            return
+        marker_s = marker_ms / 1000.0
+        if not (x_lo <= marker_s <= x_hi):
+            series.replace([])
+            return
+        series.replace(
+            [QPointF(marker_s, self._axis_y.min()), QPointF(marker_s, self._axis_y.max())]
+        )
+
+
+# ---------------------------------------------------------------------------
+# ChartsPanel
+# ---------------------------------------------------------------------------
+
+
+class ChartsPanel(QWidget):
+    """Charts area for one session tab.
+
+    No internal scroll area — the parent ``session_tab`` provides a single
+    common scroll bar that covers the charts and the log consoles together.
+
+    * ``▾ Combined View`` — all channels overlaid, expanded by default.
+    * ``▸ Individual Channels`` — collapsed by default; expanding it opens
+      all per-channel sub-sections simultaneously.
+    """
+
+    def __init__(self, data_model: DataModel, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._model = data_model
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        self._layout = outer  # alias used by _rebuild_channels
+
+        # ── Combined overview (expanded by default) ─────────────────────
+        combined_chart = CombinedPlot(data_model)
+        combined_chart.setMinimumHeight(320)
+        self._combined_section = CollapsibleSection(
+            "Combined View", combined_chart, expanded=True
+        )
+        outer.addWidget(self._combined_section)
+
+        # ── Individual channels parent section (collapsed by default) ───
+        self._channels_body = QWidget()
+        self._channels_layout = QVBoxLayout(self._channels_body)
+        self._channels_layout.setContentsMargins(0, 0, 0, 0)
+        self._channels_layout.setSpacing(0)
+
+        self._channels_section = CollapsibleSection(
+            "Individual Channels", self._channels_body, expanded=False
+        )
+        # When the parent section is toggled, propagate to all children.
+        self._channels_section.toggled.connect(self._on_channels_section_toggled)
+        self._layout.addWidget(self._channels_section)
+
+        self._layout.addStretch(1)
+
+        # ── Per-channel state ───────────────────────────────────────────
+        self._channel_charts: list[_ChannelChart] = []
+        self._channel_sections: list[CollapsibleSection] = []
+
+        data_model.channels_changed.connect(self._rebuild_channels)
+        data_model.data_appended.connect(self._refresh_channels)
+        data_model.cleared.connect(self._refresh_channels)
+        data_model.recording_marker_changed.connect(self._refresh_channels)
+
+        self._rebuild_channels()
+
+    # ------------------------------------------------------------------
+
+    def set_combined_visible(self, on: bool) -> None:
+        """Show/hide the Combined View section (View ▸ Panels)."""
+        self._combined_section.setVisible(on)
+
+    def set_individual_visible(self, on: bool) -> None:
+        """Show/hide the Individual Channels section (View ▸ Panels)."""
+        self._channels_section.setVisible(on)
+
+    # ------------------------------------------------------------------
+
+    def _on_channels_section_toggled(self, expanded: bool) -> None:
+        """Expand or collapse all per-channel sections together."""
+        for sec in self._channel_sections:
+            sec.set_expanded(expanded)
+        # Catch up the per-channel charts now that they are visible again;
+        # their refreshes are skipped while the section is collapsed.
+        if expanded:
+            self._refresh_channels()
+
+    def _rebuild_channels(self) -> None:
+        while self._channels_layout.count():
+            item = self._channels_layout.takeAt(0)
+            w = item.widget()
+            if w is not None:
+                w.deleteLater()
+
+        self._channel_charts = []
+        self._channel_sections = []
+
+        parent_expanded = self._channels_section.is_expanded()
+        for i, name in enumerate(self._model.channel_names):
+            chart = _ChannelChart(name, color_for_channel(i))
+            sec = CollapsibleSection(name, chart, expanded=parent_expanded)
+            self._channel_charts.append(chart)
+            self._channel_sections.append(sec)
+            self._channels_layout.addWidget(sec)
+
+        self._channels_layout.addStretch(1)
+
+    def _refresh_channels(self, *_args: object) -> None:
+        # The per-channel charts only exist on screen while the "Individual
+        # Channels" section is expanded (collapsed by default). Skip the costly
+        # per-tick rebuild otherwise; expanding the section refreshes them
+        # immediately via _on_channels_section_toggled.
+        if not self._channels_section.is_expanded():
+            return
+        window_ms = int(self._model.plot_window_seconds * 1000)
+        marker_ms = self._model.recording_start_marker_ms
+        stop_marker_ms = self._model.recording_stop_marker_ms
+        right_ms = self._model.playout_position_ms()
+        # One shared rolling X window for every chart so all axes line up exactly.
+        # Converted ms → s to match the per-chart axis unit.
+        win = self._model.visible_x_window_ms()
+        x_window = (win[0] / 1000.0, win[1] / 1000.0) if win is not None else None
+        with slow_span("charts.refresh_channels", extra=f"n={self._model.channel_count}"):
+            for i, chart in enumerate(self._channel_charts):
+                if i < self._model.channel_count:
+                    with slow_span("charts.latest_window"):
+                        ts, val = self._model.buffer(i).latest_window(window_ms)
+                    chart.update_data(ts, val, marker_ms, right_ms, stop_marker_ms, x_window)

--- a/tools/data_forwarder_host/gui/widgets/collapsible_section.py
+++ b/tools/data_forwarder_host/gui/widgets/collapsible_section.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""CollapsibleSection — a clickable header that shows or hides a content widget.
+
+Usage::
+
+    chart = CombinedPlot(model)
+    section = CollapsibleSection("Combined View", chart, expanded=True)
+    layout.addWidget(section)
+
+The header row shows a disclosure chevron (▸ collapsed / ▾ expanded).
+Clicking anywhere on the header row toggles the content.
+
+When collapsed the widget shrinks to the header height so that the parent
+layout (splitter, VBox …) reclaims the freed vertical space immediately.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QPushButton, QSizePolicy, QVBoxLayout, QWidget
+
+from data_forwarder_host.utils.logging import log_user_action
+
+
+class CollapsibleSection(QWidget):
+    """Header-toggle widget wrapping any QWidget as collapsible content.
+
+    Parameters
+    ----------
+    title:
+        Text shown in the header row next to the chevron.
+    content:
+        The widget to show/hide.  It is reparented to this section.
+    expanded:
+        Initial state.  ``True`` = content visible.
+    """
+
+    #: Emitted after every toggle with the new expanded state.
+    toggled = Signal(bool)
+
+    _HDR_H: int = 26   # fixed header row height (pixels)
+
+    def __init__(
+        self,
+        title: str,
+        content: QWidget,
+        *,
+        expanded: bool = True,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        # ── Header button ───────────────────────────────────────────────
+        self._btn = QPushButton()
+        self._btn.setCheckable(True)
+        self._btn.setChecked(expanded)
+        self._btn.setFlat(True)
+        self._btn.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
+        self._btn.setFixedHeight(self._HDR_H)
+        self._btn.setStyleSheet(
+            "QPushButton {"
+            "  text-align: left;"
+            "  padding: 2px 8px;"
+            "  font-weight: bold;"
+            "  border: none;"
+            "  border-bottom: 1px solid palette(mid);"
+            "  background: palette(button);"
+            "}"
+            "QPushButton:hover { background: palette(midlight); }"
+        )
+        self._btn.clicked.connect(self._on_toggle)
+        outer.addWidget(self._btn)
+
+        # ── Content ─────────────────────────────────────────────────────
+        self._content = content
+        outer.addWidget(content)
+
+        # ── Apply initial state ─────────────────────────────────────────
+        self._title = title
+        self._apply(expanded, emit=False)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def set_expanded(self, on: bool) -> None:
+        """Programmatically expand or collapse the section."""
+        self._btn.setChecked(on)
+        self._apply(on)
+
+    def is_expanded(self) -> bool:
+        return self._btn.isChecked()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _on_toggle(self, checked: bool) -> None:
+        log_user_action(
+            "%s section %r", "Expanded" if checked else "Collapsed", self._title
+        )
+        self._apply(checked)
+
+    def _apply(self, expanded: bool, *, emit: bool = True) -> None:
+        chevron = "▾" if expanded else "▸"
+        self._btn.setText(f"  {chevron}  {self._title}")
+        self._content.setVisible(expanded)
+
+        # Constrain the section's maximum height so the parent layout
+        # reclaims vertical space while the content is hidden.
+        if expanded:
+            self.setMaximumHeight(16_777_215)   # QWIDGETSIZE_MAX — unconstrained
+        else:
+            self.setMaximumHeight(self._HDR_H + 2)
+
+        if emit:
+            self.toggled.emit(expanded)

--- a/tools/data_forwarder_host/gui/widgets/combined_plot.py
+++ b/tools/data_forwarder_host/gui/widgets/combined_plot.py
@@ -1,0 +1,235 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Combined rolling plot — all channels overlaid in a QtCharts ``QChartView``."""
+
+from __future__ import annotations
+
+from PySide6.QtCharts import QChart, QChartView, QLineSeries, QValueAxis
+from PySide6.QtCore import QPointF, Qt
+from PySide6.QtCore import QMargins
+from PySide6.QtGui import QBrush, QColor, QPainter, QPen
+from PySide6.QtWidgets import QSizePolicy
+
+from data_forwarder_host.core.data_model import DataModel
+from data_forwarder_host.core.decimation import decimate_minmax
+from data_forwarder_host.utils.slow_span import slow_span
+from data_forwarder_host.gui.theme import color_for_channel
+
+
+class CombinedPlot(QChartView):
+    """All channels overlaid on a single time axis (rolling window)."""
+
+    def __init__(self, data_model: DataModel, parent=None) -> None:
+        chart = QChart()
+        chart.setAnimationOptions(QChart.AnimationOption.NoAnimation)
+        chart.legend().setVisible(True)
+        chart.legend().setAlignment(Qt.AlignmentFlag.AlignBottom)
+        # Reduce internal chart padding so the plot area fills the view.
+        chart.setMargins(QMargins(0, 0, 0, 0))
+        chart.layout().setContentsMargins(0, 0, 0, 0)
+        super().__init__(chart, parent)
+        self.setRenderHint(QPainter.RenderHint.Antialiasing)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self.setMinimumHeight(280)
+
+        self._model = data_model
+        self._series: list[QLineSeries] = []
+        self._hidden: set[int] = set()
+
+        self._axis_x = QValueAxis()
+        self._axis_x.setLabelFormat("%.1f")
+        self._axis_x.setTitleText("Time (s)")
+        self._axis_y = QValueAxis()
+        self._axis_y.setLabelFormat("%.3g")
+        chart.addAxis(self._axis_x, Qt.AlignmentFlag.AlignBottom)
+        chart.addAxis(self._axis_y, Qt.AlignmentFlag.AlignLeft)
+
+        # Recording markers: dashed vertical lines drawn where the current
+        # recording began (red) and ended (blue). Both are kept out of the
+        # legend and the auto-range computation.
+        self._marker = QLineSeries()
+        self._marker.setName("recording start")
+        marker_pen = QPen(QColor("#d62728"))
+        marker_pen.setWidth(2)
+        marker_pen.setStyle(Qt.PenStyle.DashLine)
+        self._marker.setPen(marker_pen)
+        chart.addSeries(self._marker)
+        self._marker.attachAxis(self._axis_x)
+        self._marker.attachAxis(self._axis_y)
+        chart.legend().markers(self._marker)[0].setVisible(False)
+
+        self._stop_marker = QLineSeries()
+        self._stop_marker.setName("recording stop")
+        stop_pen = QPen(QColor("#1f77b4"))
+        stop_pen.setWidth(2)
+        stop_pen.setStyle(Qt.PenStyle.DashLine)
+        self._stop_marker.setPen(stop_pen)
+        chart.addSeries(self._stop_marker)
+        self._stop_marker.attachAxis(self._axis_x)
+        self._stop_marker.attachAxis(self._axis_y)
+        chart.legend().markers(self._stop_marker)[0].setVisible(False)
+
+        data_model.channels_changed.connect(self._rebuild_series)
+        data_model.data_appended.connect(self._on_data_changed)
+        data_model.cleared.connect(self._on_data_changed)
+        data_model.recording_marker_changed.connect(self._on_data_changed)
+
+        self._rebuild_series()
+
+    def _rebuild_series(self) -> None:
+        chart = self.chart()
+        for s in self._series:
+            chart.removeSeries(s)
+        self._series = []
+        # Channel identity may change on rebuild, so visible-state is reset.
+        self._hidden = set()
+        for i, name in enumerate(self._model.channel_names):
+            s = QLineSeries()
+            s.setName(name)
+            pen = QPen()
+            pen.setColor(Qt.GlobalColor.black)
+            pen.setWidth(1)
+            s.setPen(pen)
+            s.setColor(_to_qcolor(color_for_channel(i)))
+            chart.addSeries(s)
+            s.attachAxis(self._axis_x)
+            s.attachAxis(self._axis_y)
+            self._series.append(s)
+            # Clicking a channel's legend marker toggles its visibility.
+            for marker in chart.legend().markers(s):
+                marker.clicked.connect(
+                    lambda idx=i: self.toggle_channel(idx)
+                )
+        self._refresh()
+
+    def toggle_channel(self, index: int) -> None:
+        """Show/hide channel *index* in the combined overlay.
+
+        A hidden channel's trace is removed from the chart and excluded from the
+        x/y auto-range; its legend marker stays in the legend but is greyed.
+        Toggling again restores the trace and its range participation.
+        """
+        if not (0 <= index < len(self._series)):
+            return
+        if index in self._hidden:
+            self._hidden.discard(index)
+        else:
+            self._hidden.add(index)
+        self._apply_marker_style(index)
+        self._refresh()
+
+    def _apply_marker_style(self, index: int) -> None:
+        hidden = index in self._hidden
+        for marker in self.chart().legend().markers(self._series[index]):
+            brush = QBrush(marker.labelBrush())
+            color = QColor(brush.color())
+            color.setAlphaF(0.35 if hidden else 1.0)
+            brush.setColor(color)
+            marker.setLabelBrush(brush)
+
+    def _on_data_changed(self, *_args) -> None:
+        # Skip the (expensive) per-tick point rebuild whenever this chart is not
+        # actually on screen — e.g. its collapsible section is collapsed or the
+        # owning session tab is in the background. ``showEvent`` repaints it the
+        # moment it becomes visible again, so no data is lost.
+        if not self.isVisible():
+            return
+        self._refresh()
+
+    def _refresh(self, *_args) -> None:
+        window_ms = int(self._model.plot_window_seconds * 1000)
+        y_min = float("inf")
+        y_max = float("-inf")
+        x_min = 0
+        x_max = 0
+        with slow_span("combined.refresh", extra=f"ch={len(self._series)}") as span:
+            for i, s in enumerate(self._series):
+                # Hidden channels are excluded from both the trace and
+                # auto-range.
+                if i in self._hidden:
+                    s.replace([])
+                    continue
+                with slow_span("combined.latest_window"):
+                    ts, val = self._model.buffer(i).latest_window(window_ms)
+                if ts.size == 0:
+                    s.replace([])
+                    continue
+                # Decimate at render time so the number of points pushed to
+                # the series is bounded regardless of buffer size — redraw
+                # becomes O(points_on_screen), not O(buffer_size).
+                # min/max bucketing preserves peaks, so the
+                # auto-range below is unchanged.
+                with slow_span("combined.decimate", extra=f"in={ts.size}"):
+                    ts, val = decimate_minmax(ts, val)
+                with slow_span("combined.series_replace", extra=f"pts={ts.size}"):
+                    pts = [
+                        QPointF(float(t) / 1000.0, float(v))
+                        for t, v in zip(ts.tolist(), val.tolist())
+                    ]
+                    s.replace(pts)
+                x_min = ts[0] / 1000.0
+                x_max = ts[-1] / 1000.0
+                y_min = min(y_min, float(val.min()))
+                y_max = max(y_max, float(val.max()))
+            span.note(f"hidden={len(self._hidden)}")
+
+        if x_max > x_min:
+            # The right edge follows the smoothed playout position so
+            # the view scrolls continuously between arrivals and late/batched
+            # samples fill in as the edge passes their device timestamp. Falls
+            # back to the newest sample when the clock is idle or behind the
+            # oldest visible point.
+            right_ms = self._model.playout_position_ms()
+            x_hi = x_max
+            if right_ms is not None and right_ms / 1000.0 > x_min:
+                x_hi = right_ms / 1000.0
+            self._axis_x.setRange(x_min, x_hi)
+        else:
+            x_hi = x_max
+
+        # Override the X range with the model's shared rolling window so this
+        # chart and every per-channel chart line up exactly: the same horizontal
+        # position is the same time across all of them. The data-driven
+        # x_min/x_max above remain the fallback for marker visibility
+        # before any data has been seen.
+        win = self._model.visible_x_window_ms()
+        if win is not None:
+            x_min = win[0] / 1000.0
+            x_hi = win[1] / 1000.0
+            self._axis_x.setRange(x_min, x_hi)
+
+        if y_min < y_max:
+            pad = 0.05 * (y_max - y_min) if (y_max - y_min) else 1.0
+            self._axis_y.setRange(y_min - pad, y_max + pad)
+
+        self._update_marker(x_min, x_hi)
+
+    def showEvent(self, event) -> None:  # noqa: N802 (Qt naming)
+        # Catch up immediately when revealed (e.g. section expanded or tab
+        # re-activated) since refreshes were skipped while hidden.
+        super().showEvent(event)
+        self._refresh()
+
+    def _update_marker(self, x_min: float, x_max: float) -> None:
+        self._draw_marker(self._marker, self._model.recording_start_marker_ms,
+                          x_min, x_max)
+        self._draw_marker(self._stop_marker, self._model.recording_stop_marker_ms,
+                          x_min, x_max)
+
+    def _draw_marker(self, series: QLineSeries, marker_ms, x_min: float,
+                     x_max: float) -> None:
+        if marker_ms is None:
+            series.replace([])
+            return
+        marker_s = marker_ms / 1000.0
+        # Only draw the marker while it is within the visible rolling window.
+        if x_max > x_min and not (x_min <= marker_s <= x_max):
+            series.replace([])
+            return
+        lo, hi = self._axis_y.min(), self._axis_y.max()
+        series.replace([QPointF(marker_s, lo), QPointF(marker_s, hi)])
+
+
+def _to_qcolor(name: str):
+    from PySide6.QtGui import QColor
+    return QColor(name)

--- a/tools/data_forwarder_host/gui/widgets/control_panel.py
+++ b/tools/data_forwarder_host/gui/widgets/control_panel.py
@@ -1,0 +1,394 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Per-tab control panel.
+
+Session model
+-------------
+The device channel is opened automatically when the session tab is created, so
+``session_info`` is observed and the live plots update without user action.
+Two buttons drive CSV capture on top of that stream:
+
+* **Record** — begin capturing samples to the output CSV. Enabled only once a
+  valid recording label is defined *and* the device has sent
+  ``session_info`` (metadata gate). If the channel previously errored, pressing
+  Record clears the error and reopens it first.
+* **Stop**   — stop capturing and finalise the CSV file. The device channel
+  stays open and listening so the user can immediately record again.
+
+There is no sink subsystem: recorded data is written to a single CSV file when
+recording stops.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDoubleSpinBox,
+    QFileDialog,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPlainTextEdit,
+    QPushButton,
+    QStyle,
+    QVBoxLayout,
+    QWidget,
+)
+
+from data_forwarder_host.session.controller import SessionController
+from data_forwarder_host.session.states import SessionState
+from data_forwarder_host.utils.logging import log_user_action
+
+log = logging.getLogger(__name__)
+
+
+class ControlPanel(QWidget):
+    def __init__(self, controller: SessionController, parent=None) -> None:
+        super().__init__(parent)
+        self._ctrl = controller
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(8, 8, 8, 8)
+        outer.setSpacing(8)
+
+        # ── Recording ─────────────────────────────────────────────────
+        outer.addWidget(self._section_label("Recording"))
+        hint = QLabel(
+            "<small style='color:gray;'>The device channel opens automatically. "
+            "Record starts CSV capture once session_info arrives; Stop ends "
+            "capture and writes the CSV (the channel keeps listening).</small>"
+        )
+        hint.setWordWrap(True)
+        outer.addWidget(hint)
+
+        rec_form = QFormLayout()
+        rec_form.setContentsMargins(0, 0, 0, 0)
+
+        out_row = QWidget()
+        out_lay = QHBoxLayout(out_row)
+        out_lay.setContentsMargins(0, 0, 0, 0)
+        self._output_dir = QLineEdit()
+        self._output_dir.setText(controller.config.output_dir)
+        self._output_dir.setPlaceholderText("default: recordings")
+        btn_browse = QPushButton("…")
+        btn_browse.setFixedWidth(32)
+        out_lay.addWidget(self._output_dir)
+        out_lay.addWidget(btn_browse)
+        rec_form.addRow("Output dir:", out_row)
+        outer.addLayout(rec_form)
+
+        row = QHBoxLayout()
+        self._btn_record = QPushButton("Record")
+        self._btn_record.setMinimumHeight(44)
+        self._btn_record.setStyleSheet(
+            "QPushButton { font-size: 13px; font-weight: bold; padding: 6px 12px; }"
+        )
+        self._btn_record.setIcon(
+            self.style().standardIcon(QStyle.StandardPixmap.SP_MediaPlay)
+        )
+        self._btn_stop = QPushButton("Stop")
+        self._btn_stop.setMinimumHeight(44)
+        self._btn_stop.setStyleSheet(
+            "QPushButton { font-size: 13px; font-weight: bold; padding: 6px 12px; }"
+        )
+        self._btn_stop.setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_MediaStop))
+        row.addWidget(self._btn_record)
+        row.addWidget(self._btn_stop)
+        outer.addLayout(row)
+
+        self._label_hint = QLabel()
+        self._label_hint.setWordWrap(True)
+        self._label_hint.setStyleSheet("color:#AA8800; font-size: 11px;")
+        outer.addWidget(self._label_hint)
+
+        # ── Session configuration ─────────────────────────────────────
+        outer.addWidget(self._section_label("Session Configuration"))
+        cfg_form = QFormLayout()
+        cfg_form.setContentsMargins(0, 0, 0, 0)
+        self._plot_secs = QDoubleSpinBox()
+        self._plot_secs.setRange(1.0, 600.0)
+        self._plot_secs.setValue(controller.data_model.plot_window_seconds)
+        self._plot_secs.setSuffix(" s")
+        self._plot_secs.setToolTip("Rolling plot window length. Change takes effect immediately.")
+        cfg_form.addRow("Plot window:", self._plot_secs)
+
+        self._bandwidth_secs = QDoubleSpinBox()
+        self._bandwidth_secs.setRange(0.1, 600.0)
+        self._bandwidth_secs.setSingleStep(0.1)
+        self._bandwidth_secs.setValue(controller.bandwidth.window_seconds)
+        self._bandwidth_secs.setSuffix(" s")
+        self._bandwidth_secs.setToolTip(
+            "Trailing window for the live bandwidth readout. Change takes effect immediately."
+        )
+        cfg_form.addRow("Bandwidth window:", self._bandwidth_secs)
+        outer.addLayout(cfg_form)
+
+        outer.addWidget(self._section_label("Session Info"))
+        self._phase = QLabel("awaiting device metadata...")
+        self._phase.setStyleSheet("color:palette(mid); font-size:11px; font-weight:bold;")
+        outer.addWidget(self._phase)
+
+        # Structured metadata fields (created dynamically on first session_info)
+        self._metadata_form = QFormLayout()
+        self._metadata_form.setContentsMargins(0, 0, 0, 0)
+        self._metadata_form.setSpacing(4)
+        self._metadata_fields: dict[str, QLineEdit] = {}
+        outer.addLayout(self._metadata_form)
+
+        self._metadata_status = QLabel()
+        self._metadata_status.setStyleSheet("color:palette(mid); font-size:10px; font-style:italic;")
+        self._metadata_status.setText("waiting for session_info from device...")
+        outer.addWidget(self._metadata_status)
+
+        outer.addStretch(1)
+
+        # ── Wiring ────────────────────────────────────────────────────
+        self._btn_record.clicked.connect(self._on_record)
+        self._btn_stop.clicked.connect(self._on_stop)
+        btn_browse.clicked.connect(self._on_browse_output_dir)
+        self._output_dir.textChanged.connect(self._on_output_dir_changed)
+        self._plot_secs.valueChanged.connect(
+            lambda v: controller.data_model.set_plot_window_seconds(v)
+        )
+        self._bandwidth_secs.valueChanged.connect(
+            lambda v: controller.set_bandwidth_window_seconds(v)
+        )
+        # Keep this control in sync when the window is changed elsewhere
+        # (e.g. the Bandwidth details sub-window).
+        controller.bandwidth_window_changed.connect(self._on_bandwidth_window_changed)
+
+        controller.state_changed.connect(self._on_state_changed)
+        controller.recording_changed.connect(self._on_recording_changed)
+        controller.recording_empty.connect(self._on_recording_empty)
+        # While a recording is being written to CSV, both Record and Stop stay
+        # locked; Record re-enables only once the save completes (Feature 1).
+        controller.recording_save_started.connect(self._refresh_buttons)
+        controller.recording_saved.connect(self._refresh_buttons)
+        controller.recording_save_failed.connect(self._refresh_buttons)
+        controller.session_info_received.connect(self._on_session_info_received)
+        controller.session_info_mismatch.connect(self._on_session_info_mismatch)
+        controller.session_phase_changed.connect(self._on_session_phase_changed)
+
+        self._refresh_buttons()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _section_label(text: str) -> QLabel:
+        lbl = QLabel(f"<b>{text}</b>")
+        lbl.setAlignment(Qt.AlignmentFlag.AlignLeft)
+        return lbl
+
+    def _on_bandwidth_window_changed(self, seconds: float) -> None:
+        """Reflect an external bandwidth-window change without re-emitting."""
+        if abs(self._bandwidth_secs.value() - seconds) < 1e-9:
+            return
+        blocked = self._bandwidth_secs.blockSignals(True)
+        self._bandwidth_secs.setValue(seconds)
+        self._bandwidth_secs.blockSignals(blocked)
+
+    def _refresh_buttons(self, *_args: object) -> None:
+        state = self._ctrl.state()
+        recording = self._ctrl.is_recording()
+        can_record = self._ctrl.can_record()
+        metadata_ready = self._ctrl.metadata_ready()
+        saving = self._ctrl.is_saving()
+
+        # Record starts CSV capture. The channel is already streaming (opened on
+        # tab creation); enable only when metadata has arrived, a valid label is
+        # defined, we are not already capturing, and no previous recording is
+        # still being written to CSV (Feature 1).
+        self._btn_record.setEnabled(
+            can_record and metadata_ready and not recording and not saving
+        )
+        # Stop ends the active capture (the channel keeps listening afterwards).
+        # It is also locked while a CSV save is draining.
+        self._btn_stop.setEnabled(recording and not saving)
+
+        # Output dir is locked while a capture is live or a save is draining.
+        # (The recording label is owned by the prominent RecordingLabelStrip
+        # beside the charts — which manages its own disable state.)
+        self._output_dir.setEnabled(not recording and not saving)
+
+        if saving:
+            self._label_hint.setText("Saving recording to CSV…")
+        elif not can_record:
+            self._label_hint.setText("Define a valid recording label to enable Record.")
+        elif not metadata_ready:
+            self._label_hint.setText(
+                "Awaiting session_info from device; Record enables once metadata arrives."
+            )
+        elif state == SessionState.ERROR:
+            self._label_hint.setText("Channel errored — press Record to reconnect.")
+        else:
+            self._label_hint.setText("")
+
+    def refresh_record_state(self, *_args: object) -> None:
+        """Re-evaluate the Record button after the external label strip changes
+        the recording label."""
+        self._refresh_buttons()
+
+    # ------------------------------------------------------------------
+    # Slots
+    # ------------------------------------------------------------------
+
+    def _on_state_changed(self, state: SessionState) -> None:
+        self._refresh_buttons()
+
+    def _on_recording_changed(self, recording: bool) -> None:
+        self._refresh_buttons()
+
+    def _on_output_dir_changed(self, text: str) -> None:
+        self._ctrl.set_output_dir(text.strip())
+
+    def _on_browse_output_dir(self) -> None:
+        log_user_action("Clicked browse for output directory")
+        path = QFileDialog.getExistingDirectory(self, "Select output directory")
+        if path:
+            log_user_action("Selected output directory %s", path)
+            self._output_dir.setText(path)
+
+    def _on_record(self) -> None:
+        log_user_action("Clicked Record")
+        # Clear a prior error transparently so we can recover.
+        if self._ctrl.state() == SessionState.ERROR:
+            self._ctrl.reset()
+        # The channel is opened automatically when the tab opens; if it is not
+        # currently streaming (e.g. it errored or was stopped), reopen it first.
+        if self._ctrl.state() != SessionState.RUNNING:
+            try:
+                self._ctrl.start()
+            except Exception as exc:
+                QMessageBox.warning(self, "Recording", f"Could not open channel: {exc}")
+                return
+        try:
+            self._ctrl.start_recording()
+        except Exception as exc:
+            QMessageBox.warning(self, "Recording", f"Could not start: {exc}")
+
+    def _on_stop(self) -> None:
+        log_user_action("Clicked Stop")
+        # Stop capture and write the CSV; the channel stays open/listening so
+        # the user can immediately record again within the same session.
+        if self._ctrl.is_recording():
+            self._ctrl.stop_recording()
+
+    def _on_recording_empty(self) -> None:
+        QMessageBox.information(
+            self,
+            "Recording",
+            "No data was recorded yet. No CSV file was generated.",
+        )
+
+    def _on_session_info_received(self, raw: object) -> None:
+        payload = raw if isinstance(raw, dict) else {}
+        d = payload.get("d") if isinstance(payload.get("d"), dict) else {}
+
+        # The structured fields are populated once from the first session_info
+        # and must never accept user input. On every subsequent session_info
+        # the read-only fields are refreshed to reflect the latest device
+        # values: most fields (hz, st, name, dr) may change freely;
+        # sid and ch_n cannot change without terminating the session,
+        # so refreshing them here is a harmless no-op in practice.
+        if self._metadata_fields:
+            self._refresh_metadata_fields(d)
+            return
+
+        # Extract fields and display in structured form. Each entry carries a
+        # tooltip mirroring the "Session Configuration" pattern.
+        field_defs = [
+            ("sid", "Session ID", str(d.get("sid", "—")),
+             "Unique identifier the device assigned to this streaming session."),
+            ("hz", "Sampling Rate (Hz)", str(d.get("hz", "—")),
+             "Per-channel sampling frequency reported by the device, in Hz."),
+            ("ch_n", "Channels",
+             ", ".join(d.get("ch_n", [])) if d.get("ch_n") else "—",
+             "Names of the channels streamed by the device."),
+            ("st", "Sensor Type", str(d.get("st", "—")),
+             "Sensor type reported by the device."),
+            ("dr", "Drop Count", str(d.get("dr", "—")),
+             "Frames the device reports it dropped before transmission."),
+            ("name", "Device Name", str(d.get("name", "—")),
+             "Human-readable device name reported in session_info."),
+        ]
+
+        for key, label, value, tooltip in field_defs:
+            field = QLineEdit()
+            field.setText(value)
+            field.setReadOnly(True)
+            # Make read-only Session Info fields visually distinct from the
+            # editable Session Configuration inputs: flat (no frame), muted
+            # transparent background, and non-focusable so they don't look or
+            # behave like text inputs.
+            field.setFrame(False)
+            field.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+            field.setCursorPosition(0)
+            field.setStyleSheet(
+                "QLineEdit { background: transparent; border: none; "
+                "color: palette(text); padding: 0; }"
+            )
+            field.setToolTip(tooltip)
+            self._metadata_fields[key] = field
+            label_widget = QLabel(f"{label}:")
+            label_widget.setToolTip(tooltip)
+            self._metadata_form.addRow(label_widget, field)
+
+        self._metadata_status.setText(f"received at {raw.get('t', '?')} = session_info")
+        self._refresh_buttons()  # Update Record button state now that metadata is ready
+
+    @staticmethod
+    def _format_metadata_value(key: str, d: dict) -> str:
+        if key == "ch_n":
+            return ", ".join(d.get("ch_n", [])) if d.get("ch_n") else "—"
+        return str(d.get(key, "—"))
+
+    def _refresh_metadata_fields(self, d: dict) -> None:
+        """Refresh the read-only Session Info fields from the latest payload."""
+        for key, field in self._metadata_fields.items():
+            if key in d:
+                field.setText(self._format_metadata_value(key, d))
+
+    def _on_session_phase_changed(self, phase: str) -> None:
+        # Format phase for display: "awaiting device metadata" → "Awaiting Device Metadata"
+        display_phase = " ".join(word.capitalize() for word in phase.split())
+        self._phase.setText(display_phase)
+        # A phase transition (notably "ready to record" once session_info has
+        # arrived) changes recording availability; refresh the buttons so the
+        # Record action is enabled regardless of the order in which the label
+        # was entered vs. the metadata arriving.
+        self._refresh_buttons()
+
+    def _on_session_info_mismatch(self, detail: str, has_buffered_data: bool) -> None:
+        if not has_buffered_data:
+            QMessageBox.critical(
+                self,
+                "Session metadata changed",
+                f"{detail}.\n\nSession stopped with error.",
+            )
+            return
+
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Icon.Critical)
+        box.setWindowTitle("Session metadata changed")
+        box.setText(
+            "Session metadata changed. Recording was automatically stopped.\n\n"
+            "Do you want to save buffered data to CSV?"
+        )
+        save_btn = box.addButton("Save buffered data", QMessageBox.ButtonRole.AcceptRole)
+        drop_btn = box.addButton("Drop buffered data", QMessageBox.ButtonRole.DestructiveRole)
+        box.setDefaultButton(save_btn)
+        box.exec()
+
+        if box.clickedButton() == save_btn:
+            try:
+                self._ctrl.save_pending_mismatch_recording()
+            except Exception as exc:
+                QMessageBox.warning(self, "Recording", f"Could not save buffered data: {exc}")
+        elif box.clickedButton() == drop_btn:
+            self._ctrl.drop_pending_mismatch_recording()

--- a/tools/data_forwarder_host/gui/widgets/error_panel.py
+++ b/tools/data_forwarder_host/gui/widgets/error_panel.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""ErrorPanel — live event list + summary table + incomplete banner."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Qt, QTimer
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QDoubleSpinBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QSplitter,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from data_forwarder_host.core.error_log import (
+    ErrorCategory,
+    ErrorEvent,
+    ErrorLog,
+    ErrorSummary,
+)
+from data_forwarder_host.gui.widgets.ffdc_dialog import FfdcDialog
+from data_forwarder_host.utils.logging import log_user_action
+
+# Coalesce live-event-list updates to <=20 Hz. A transport flood can confirm many
+# losses in a single burst; appending one widget item and calling scrollToBottom()
+# for every event would stall the GUI thread (the appends/scrolls happen inside
+# the inbox drain loop). Buffering and flushing in batches keeps per-event cost
+# O(1) and the flush cost bounded regardless of the loss rate.
+_EVENT_FLUSH_MS = 50
+_MAX_LIVE_EVENTS = 1000
+
+
+class ErrorPanel(QWidget):
+    def __init__(self, error_log: ErrorLog, controller=None, parent=None) -> None:
+        super().__init__(parent)
+        self._log = error_log
+        self._controller = controller
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(6, 6, 6, 6)
+        outer.setSpacing(4)
+
+        self._banner = QLabel()
+        self._banner.setStyleSheet(
+            "QLabel { background:#d62728; color:white; padding:6px; font-weight:bold; }"
+        )
+        self._banner.setVisible(False)
+        outer.addWidget(self._banner)
+
+        # Loss confirmation window: how long a missing sensor_data sequence
+        # number is awaited before it is counted as a TRANSPORT loss.
+        if controller is not None:
+            cfg_row = QHBoxLayout()
+            cfg_row.setContentsMargins(0, 0, 0, 0)
+            lbl = QLabel("Loss confirmation window:")
+            lbl.setToolTip(
+                "How long a missing sensor_data sequence number (d/seq) is "
+                "awaited before it is confirmed a transport loss. Frames that "
+                "arrive late/out of order within this window are not losses."
+            )
+            cfg_row.addWidget(lbl)
+            self._loss_window = QDoubleSpinBox()
+            self._loss_window.setDecimals(2)
+            self._loss_window.setRange(0.05, 30.0)
+            self._loss_window.setSingleStep(0.25)
+            self._loss_window.setSuffix(" s")
+            self._loss_window.setValue(controller.loss_confirmation_window_seconds())
+            self._loss_window.valueChanged.connect(self._on_loss_window_changed)
+            cfg_row.addWidget(self._loss_window)
+            cfg_row.addStretch(1)
+            outer.addLayout(cfg_row)
+
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+        outer.addWidget(splitter, 1)
+
+        # Left: live error event list
+        left = QWidget()
+        left_lay = QVBoxLayout(left)
+        left_lay.setContentsMargins(0, 0, 0, 0)
+        left_lay.addWidget(QLabel("<b>⚠ Live Error Events</b>"))
+        self._events = QListWidget()
+        left_lay.addWidget(self._events)
+        splitter.addWidget(left)
+
+        # Right: per-category loss & error analysis table
+        right = QWidget()
+        right_lay = QVBoxLayout(right)
+        right_lay.setContentsMargins(0, 0, 0, 0)
+        header_row = QHBoxLayout()
+        header_row.addWidget(QLabel("<b>📊 Error &amp; Loss Analysis</b>"))
+        header_row.addStretch(1)
+        self._ffdc_btn = QPushButton("First Failure Data Capture")
+        self._ffdc_btn.setToolTip(
+            "Inspect the first captured failure of each category "
+            "(bytestream, expected vs. actual, Python trace)"
+        )
+        self._ffdc_btn.clicked.connect(self._open_ffdc)
+        header_row.addWidget(self._ffdc_btn)
+        right_lay.addLayout(header_row)
+        self._table = QTableWidget(len(ErrorCategory), 2)
+        self._table.setHorizontalHeaderLabels(["Count", "% of messages"])
+        self._table.setVerticalHeaderLabels([c.name for c in ErrorCategory])
+        self._table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        self._table.verticalHeader().setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+        self._table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        right_lay.addWidget(self._table)
+        splitter.addWidget(right)
+        splitter.setStretchFactor(0, 2)
+        splitter.setStretchFactor(1, 1)
+
+        error_log.event_added.connect(self._on_event)
+        error_log.summary_changed.connect(self._on_summary)
+        error_log.cleared.connect(self._on_cleared)
+        # Seed display.
+        self._on_summary(error_log.summary())
+
+        # Buffered live-event rendering: _on_event only appends to this list; the
+        # QListWidget is updated in batches by _flush_events on a timer.
+        self._pending_events: list[ErrorEvent] = []
+        self._flush_timer = QTimer(self)
+        self._flush_timer.setInterval(_EVENT_FLUSH_MS)
+        self._flush_timer.timeout.connect(self._flush_events)
+        self._flush_timer.start()
+
+        self._ffdc_dialog: FfdcDialog | None = None
+
+    def _open_ffdc(self) -> None:
+        """Open (or re-focus) the First Failure Data Capture sub-window."""
+        log_user_action("Clicked First Failure Data Capture")
+        if self._ffdc_dialog is None:
+            self._ffdc_dialog = FfdcDialog(self._log, self)
+        else:
+            self._ffdc_dialog.refresh()
+        self._ffdc_dialog.show()
+        self._ffdc_dialog.raise_()
+        self._ffdc_dialog.activateWindow()
+
+    def _on_loss_window_changed(self, seconds: float) -> None:
+        """Apply a new transport loss confirmation window from the spinner."""
+        log_user_action("Changed the loss confirmation window to %.2f s", float(seconds))
+        if self._controller is not None:
+            self._controller.set_loss_confirmation_window_seconds(float(seconds))
+
+    def _on_cleared(self) -> None:
+        """Reset the live-event list and banner when a new recording starts."""
+        self._pending_events.clear()
+        self._events.clear()
+        self._banner.setVisible(False)
+
+    def _on_event(self, evt: ErrorEvent) -> None:
+        # Buffer only; the widget is updated in batches by _flush_events so a
+        # burst of confirmed losses cannot stall the GUI thread with one addItem
+        # + scrollToBottom per event.
+        self._pending_events.append(evt)
+
+    def _flush_events(self) -> None:
+        """Append all buffered events to the list in one batch (timer-driven)."""
+        if not self._pending_events:
+            return
+        pending = self._pending_events
+        self._pending_events = []
+        for evt in pending:
+            item = QListWidgetItem(
+                f"[{evt.t_host_utc}] {evt.category.name} ({evt.session_state.name}): {evt.detail}"
+            )
+            item.setForeground(QColor("#d62728"))
+            self._events.addItem(item)
+        # Cap list to a bounded number of items.
+        overflow = self._events.count() - _MAX_LIVE_EVENTS
+        for _ in range(max(0, overflow)):
+            self._events.takeItem(0)
+        self._events.scrollToBottom()
+
+    def _on_summary(self, summary: ErrorSummary) -> None:
+        for row, cat in enumerate(ErrorCategory):
+            cnt = summary.counts.get(cat, 0)
+            pct = summary.percentages.get(cat, 0.0)
+            self._table.setItem(row, 0, QTableWidgetItem(str(cnt)))
+            self._table.setItem(row, 1, QTableWidgetItem(f"{pct:.4f}"))
+
+        if summary.incomplete:
+            total_lost = summary.counts.get(ErrorCategory.RECORDER_OVERFLOW, 0)
+            denom = summary.total_messages + total_lost
+            pct = (100.0 * total_lost / denom) if denom else 0.0
+            self._banner.setText(f"Recording is incomplete ({pct:.4f}% lost)")
+            self._banner.setVisible(True)
+        else:
+            self._banner.setVisible(False)

--- a/tools/data_forwarder_host/gui/widgets/ffdc_dialog.py
+++ b/tools/data_forwarder_host/gui/widgets/ffdc_dialog.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""First Failure Data Capture (FFDC) sub-window.
+
+Opened from the **First Failure Data Capture** button in the Error & Loss
+Analysis panel. It snapshots the per-session error journal and, for each error
+category, shows the *first* failure that occurred with its diagnostic detail:
+
+* a Python error trace (when the failure carried an exception);
+* real issue analysis for the frame — the raw bytestream as hex and as ASCII,
+  plus what was expected versus what actually arrived.
+
+Each category is a collapsible section, and within it each diagnostic view is a
+nested collapsible section, so the user can expand only what they want to focus
+on. The heavy lifting (selecting first failures, formatting bytestreams) lives
+in the GUI-free :mod:`data_forwarder_host.core.ffdc` module.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtGui import QFont
+from PySide6.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QPlainTextEdit,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from data_forwarder_host.core.error_log import ErrorLog
+from data_forwarder_host.core.ffdc import FfdcEntry, build_ffdc
+from data_forwarder_host.gui.widgets.collapsible_section import CollapsibleSection
+from data_forwarder_host.utils.logging import log_user_action
+
+_EMPTY = "No failures have been captured in this session yet."
+
+
+def _mono_view(text: str) -> QPlainTextEdit:
+    view = QPlainTextEdit()
+    view.setReadOnly(True)
+    view.setPlainText(text)
+    view.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
+    font = QFont("monospace")
+    font.setStyleHint(QFont.StyleHint.Monospace)
+    view.setFont(font)
+    view.setMinimumHeight(80)
+    return view
+
+
+class FfdcDialog(QDialog):
+    """Expandable First Failure Data Capture report for one session."""
+
+    def __init__(self, error_log: ErrorLog, parent=None) -> None:
+        super().__init__(parent)
+        self._log = error_log
+
+        self.setWindowTitle("First Failure Data Capture")
+        self.setMinimumSize(640, 480)
+        self.resize(820, 600)
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(10, 10, 10, 10)
+        outer.setSpacing(6)
+
+        intro = QLabel(
+            "The first occurrence of each error category is captured below. "
+            "Expand a category, then expand the view you want to focus on."
+        )
+        intro.setWordWrap(True)
+        outer.addWidget(intro)
+
+        # Scrollable stack of per-category captures.
+        self._scroll = QScrollArea()
+        self._scroll.setWidgetResizable(True)
+        outer.addWidget(self._scroll, 1)
+        self._host = QWidget()
+        self._host_lay = QVBoxLayout(self._host)
+        self._host_lay.setContentsMargins(0, 0, 0, 0)
+        self._host_lay.setSpacing(4)
+        self._scroll.setWidget(self._host)
+
+        btn_row = QHBoxLayout()
+        self._refresh_btn = QPushButton("Refresh capture")
+        self._refresh_btn.setToolTip("Re-snapshot the session error journal")
+        self._refresh_btn.clicked.connect(self._on_refresh_clicked)
+        btn_row.addWidget(self._refresh_btn)
+        btn_row.addStretch(1)
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self._on_close_clicked)
+        btn_row.addWidget(close_btn)
+        outer.addLayout(btn_row)
+
+        self.refresh()
+
+    # ------------------------------------------------------------------
+    # Slots
+    # ------------------------------------------------------------------
+
+    def _on_refresh_clicked(self) -> None:
+        log_user_action("Clicked Refresh capture in the FFDC window")
+        self.refresh()
+
+    def _on_close_clicked(self) -> None:
+        log_user_action("Clicked Close in the FFDC window")
+        self.close()
+
+    def closeEvent(self, event) -> None:  # noqa: N802 (Qt naming)
+        log_user_action("Closed the FFDC window")
+        super().closeEvent(event)
+
+    # ------------------------------------------------------------------
+    # Rendering
+    # ------------------------------------------------------------------
+
+    def refresh(self) -> None:
+        """Rebuild the report from the current error journal."""
+        self._clear()
+        entries = build_ffdc(self._log.events())
+        if not entries:
+            self._host_lay.addWidget(QLabel(_EMPTY))
+            self._host_lay.addStretch(1)
+            return
+        for entry in entries:
+            self._host_lay.addWidget(self._build_entry(entry))
+        self._host_lay.addStretch(1)
+
+    def _build_entry(self, entry: FfdcEntry) -> CollapsibleSection:
+        body = QWidget()
+        body_lay = QVBoxLayout(body)
+        body_lay.setContentsMargins(8, 4, 4, 4)
+        body_lay.setSpacing(4)
+
+        header = QLabel(f"<b>{entry.detail}</b><br><i>first seen {entry.timestamp}</i>")
+        header.setWordWrap(True)
+        body_lay.addWidget(header)
+
+        if entry.panels:
+            for i, panel in enumerate(entry.panels):
+                # Expand the first diagnostic view by default; leave the rest
+                # collapsed so the user opts in to what they want to see.
+                sub = CollapsibleSection(
+                    panel.title, _mono_view(panel.text), expanded=(i == 0)
+                )
+                body_lay.addWidget(sub)
+        else:
+            body_lay.addWidget(QLabel("No additional diagnostic context was captured."))
+
+        return CollapsibleSection(
+            f"{entry.category} — first failure", body, expanded=False
+        )
+
+    def _clear(self) -> None:
+        while self._host_lay.count():
+            item = self._host_lay.takeAt(0)
+            w = item.widget()
+            if w is not None:
+                w.deleteLater()

--- a/tools/data_forwarder_host/gui/widgets/header_strip.py
+++ b/tools/data_forwarder_host/gui/widgets/header_strip.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Top-of-tab strip showing session identity and live status."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QSizePolicy
+
+from data_forwarder_host.gui.widgets.bandwidth_details import BandwidthDetailsDialog
+from data_forwarder_host.session.controller import SessionController
+from data_forwarder_host.session.states import SessionState
+from data_forwarder_host.utils.logging import log_user_action
+
+
+class HeaderStrip(QFrame):
+    def __init__(self, controller: SessionController, parent=None) -> None:
+        super().__init__(parent)
+        self._ctrl = controller
+        self.setFrameShape(QFrame.Shape.StyledPanel)
+
+        lay = QHBoxLayout(self)
+        lay.setContentsMargins(8, 4, 8, 4)
+
+        self._tag = QLabel(f"<b>{controller.config.tag}</b>")
+        self._source = QLabel(controller.describe_source())
+        self._protocol = QLabel(controller.describe_protocol())
+        # Single combined status label (state + recording).
+        self._status = QLabel()
+
+        for w in (self._tag, self._source, self._protocol, self._status):
+            w.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+            lay.addWidget(w)
+            lay.addSpacing(12)
+        lay.addStretch(1)
+
+        # Live throughput readout, right-aligned after the stretch.
+        self._bandwidth = QLabel()
+        self._bandwidth.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        self._bandwidth.setToolTip(
+            "Live throughput over the bandwidth measurement window"
+        )
+        lay.addWidget(self._bandwidth)
+
+        # Button: opens the detailed bandwidth / reception sub-window.
+        # Uses a text label (an icon glyph rendered as an empty box
+        # on some platforms).
+        self._bandwidth_info = QPushButton("Bandwidth details")
+        self._bandwidth_info.setToolTip("More data-transfer details")
+        self._bandwidth_info.clicked.connect(self._open_bandwidth_details)
+        lay.addWidget(self._bandwidth_info)
+        self._bandwidth_dialog: BandwidthDetailsDialog | None = None
+
+        # Timer that fires every second while recording to update the counter.
+        self._elapsed_timer = QTimer(self)
+        self._elapsed_timer.setInterval(1000)
+        self._elapsed_timer.timeout.connect(self._refresh_status)
+
+        # Timer that continuously refreshes the bandwidth readout.
+        self._bandwidth_timer = QTimer(self)
+        self._bandwidth_timer.setInterval(500)
+        self._bandwidth_timer.timeout.connect(self._refresh_bandwidth)
+        self._bandwidth_timer.start()
+
+        controller.state_changed.connect(lambda _s: self._refresh_status())
+        controller.recording_changed.connect(self._on_recording_changed)
+        controller.session_phase_changed.connect(lambda _p: self._refresh_status())
+
+        self._refresh_status()
+        self._refresh_bandwidth()
+
+    def _open_bandwidth_details(self) -> None:
+        log_user_action("Clicked Bandwidth details")
+        if self._bandwidth_dialog is None:
+            self._bandwidth_dialog = BandwidthDetailsDialog(self._ctrl, self)
+        self._bandwidth_dialog.show()
+        self._bandwidth_dialog.raise_()
+        self._bandwidth_dialog.activateWindow()
+
+    def _on_recording_changed(self, recording: bool) -> None:
+        if recording:
+            self._elapsed_timer.start()
+        else:
+            self._elapsed_timer.stop()
+        self._refresh_status()
+
+    def _refresh_bandwidth(self) -> None:
+        s = self._ctrl.bandwidth_sample()
+        self._bandwidth.setText(
+            f'<span style="color:#6B7280">'
+            f"{_fmt_bytes_per_s(s.bytes_per_second)} · "
+            f"{s.messages_per_second:.0f} msg/s · "
+            f"{s.channels_per_second:.0f} ch/s</span>"
+        )
+
+    def _refresh_status(self) -> None:
+        state = self._ctrl.state()
+        recording = self._ctrl.is_recording()
+        if not recording and self._elapsed_timer.isActive():
+            self._elapsed_timer.stop()
+
+        if recording:
+            elapsed = self._ctrl.recorder.elapsed_seconds()
+            if elapsed is not None:
+                m = int(elapsed) // 60
+                s = int(elapsed) % 60
+                elapsed_str = f"  {m}:{s:02d}"
+            else:
+                elapsed_str = ""
+            self._status.setText(
+                f'<span style="color:#d62728">⏺ Recording{elapsed_str}</span>'
+            )
+        elif state == SessionState.RUNNING:
+            phase = self._ctrl.session_phase()
+            if phase == "awaiting device metadata":
+                self._status.setText('<span style="color:#6B7280">◔ Awaiting Metadata</span>')
+            elif phase == "ready to record":
+                self._status.setText('<span style="color:#2ca02c">▶ Ready To Record</span>')
+            elif phase == "stopping":
+                self._status.setText('<span style="color:#6B7280">◷ Stopping</span>')
+            else:
+                self._status.setText('<span style="color:#2ca02c">▶ Streaming</span>')
+        elif state == SessionState.ERROR:
+            self._status.setText('<span style="color:#d62728">✕ Error</span>')
+        elif state == SessionState.STOPPED:
+            self._status.setText('<span style="color:#888888">◼ Stopped</span>')
+        else:
+            self._status.setText('<span style="color:#888888">○ Configured</span>')
+
+
+def _fmt_bytes_per_s(value: float) -> str:
+    """Human-readable bytes/second with a binary-ish scale."""
+    units = ("B/s", "KB/s", "MB/s", "GB/s")
+    v = float(value)
+    idx = 0
+    while v >= 1000.0 and idx < len(units) - 1:
+        v /= 1000.0
+        idx += 1
+    if idx == 0:
+        return f"{v:.0f} {units[idx]}"
+    return f"{v:.1f} {units[idx]}"

--- a/tools/data_forwarder_host/gui/widgets/host_metrics_label.py
+++ b/tools/data_forwarder_host/gui/widgets/host_metrics_label.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Status-bar label that periodically shows host CPU / RAM usage."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import QLabel, QWidget
+
+from data_forwarder_host.core.host_metrics import (
+    format_host_metrics,
+    format_host_metrics_tooltip,
+    sample_host_metrics,
+)
+
+
+class HostMetricsLabel(QLabel):
+    """A compact, self-refreshing host resource indicator.
+
+    Owns a single-shot-less :class:`QTimer` that re-samples every
+    ``interval_ms``. Sampling is non-blocking; any failure (e.g. ``psutil``
+    missing) simply blanks the label rather than disrupting the UI.
+    """
+
+    def __init__(self, parent: QWidget | None = None, *, interval_ms: int = 2000) -> None:
+        super().__init__(parent)
+        self.setObjectName("HostMetricsLabel")
+        # Prime cpu_percent so the first displayed value is meaningful rather
+        # than the 0.0 that the very first psutil.cpu_percent() call returns.
+        try:
+            sample_host_metrics()
+        except Exception:  # noqa: BLE001 - resource probing must never crash the UI
+            pass
+
+        self._timer = QTimer(self)
+        self._timer.setInterval(interval_ms)
+        self._timer.timeout.connect(self._refresh)
+        self._timer.start()
+        self._refresh()
+
+    def _refresh(self) -> None:
+        try:
+            metrics = sample_host_metrics()
+        except Exception:  # noqa: BLE001 - tolerate missing/unavailable psutil
+            self.setText("")
+            self.setToolTip("")
+            return
+        self.setText(format_host_metrics(metrics))
+        self.setToolTip(format_host_metrics_tooltip(metrics))

--- a/tools/data_forwarder_host/gui/widgets/log_panel.py
+++ b/tools/data_forwarder_host/gui/widgets/log_panel.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""App-wide rotating log view (bound via ``install_qt_handler``)."""
+
+from __future__ import annotations
+
+import logging
+
+from PySide6.QtCore import QObject, Signal
+from PySide6.QtWidgets import QPlainTextEdit, QVBoxLayout, QWidget
+
+from data_forwarder_host.utils.logging import install_qt_handler
+
+
+class _LogBridge(QObject):
+    """Marshals log records onto the GUI thread via a signal."""
+
+    record = Signal(str)
+
+
+class LogPanel(QWidget):
+    MAX_LINES = 2000
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._text = QPlainTextEdit()
+        self._text.setReadOnly(True)
+        self._text.setMaximumBlockCount(self.MAX_LINES)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._text)
+
+        self._bridge = _LogBridge()
+        self._bridge.record.connect(self._append)
+        install_qt_handler(self._on_record)
+
+    def _on_record(self, _record: logging.LogRecord, formatted: str) -> None:
+        # Always cross to the GUI thread.
+        self._bridge.record.emit(formatted)
+
+    def _append(self, line: str) -> None:
+        self._text.appendPlainText(line)

--- a/tools/data_forwarder_host/gui/widgets/pipeline_flow.py
+++ b/tools/data_forwarder_host/gui/widgets/pipeline_flow.py
@@ -1,0 +1,452 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Pipeline flow visualisation for the bandwidth-details window.
+
+:class:`PipelineFlowWidget` paints a left-to-right row of pipeline stages from a
+:class:`~data_forwarder_host.core.pipeline_metrics.PipelineSnapshot`:
+each stage is coloured by its queue utilisation (green → amber → red), shows a
+queue-fill gauge and a drop badge when it has discarded frames, and the detected
+bottleneck stage is emphasised. Animated ">"-style chevrons flow between stages
+at a speed that tracks each stage's output rate.
+
+The widget contains **no measurement logic** — it only renders the immutable
+pure structures it is handed, and :meth:`update_snapshot` repaints in place
+without rebuilding any child widgets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from time import monotonic
+
+from PySide6.QtCore import QEvent, QPoint, QPointF, QRectF, Qt, QTimer
+from PySide6.QtGui import (
+    QBrush,
+    QColor,
+    QFont,
+    QHelpEvent,
+    QPainter,
+    QPen,
+    QPolygonF,
+)
+from PySide6.QtWidgets import QSizePolicy, QToolTip, QWidget
+
+from data_forwarder_host.core.pipeline_metrics import (
+    PipelineSnapshot,
+    StageMetrics,
+    detect_bottleneck,
+    group_stages_by_process,
+)
+
+_GREEN = QColor(0x2E, 0x7D, 0x32)
+_AMBER = QColor(0xF9, 0xA8, 0x25)
+_RED = QColor(0xC6, 0x28, 0x28)
+
+# Human-readable explanations shown when the user hovers a pipeline stage.
+# Keyed by the stage's display name. A trailing default covers any
+# stage name without a specific entry.
+STAGE_DESCRIPTIONS: dict[str, str] = {
+    "Device": (
+        "Device: the sensor board producing samples. The rate shown is how fast "
+        "the device emits frames; drops here are samples the device discarded "
+        "before they ever reached the host."
+    ),
+    "Wire": (
+        "Wire: the transport link (USB/UART or BLE) carrying raw frames from the "
+        "device to this host."
+    ),
+    "Decode": (
+        "Decode: unframes and parses each transport packet into a structured "
+        "message (COBS de-framing and CBOR decode)."
+    ),
+    "Gate": (
+        "Gate: the back-pressure guard that limits how many sensor frames are in "
+        "flight to the GUI at once. Drops here are sensor frames shed to keep the "
+        "interface responsive; control frames are never dropped."
+    ),
+    "Plot Buffer": (
+        "Plot Buffer: the in-memory sample buffer feeding the live plots. Its "
+        "queue depth is the number of samples buffered for the next redraw."
+    ),
+    "Recorder": (
+        "Recorder: writes samples to the CSV recording while a capture is active. "
+        "Idle (zero rate) when not recording."
+    ),
+}
+
+_DEFAULT_DESCRIPTION = (
+    "Pipeline stage. Colour shows queue utilisation (green = idle, red = "
+    "saturated); a red badge marks dropped frames."
+)
+
+
+def stage_description(name: str) -> str:
+    """Return the hover description for a stage *name*.
+
+    Pure and deterministic so the description text can be computed without a
+    live widget or a synthesised tooltip event.
+    """
+    return STAGE_DESCRIPTIONS.get(name, _DEFAULT_DESCRIPTION)
+
+
+def _lerp(a: int, b: int, f: float) -> int:
+    return int(round(a + (b - a) * f))
+
+
+def _blend(c0: QColor, c1: QColor, f: float) -> QColor:
+    return QColor(
+        _lerp(c0.red(), c1.red(), f),
+        _lerp(c0.green(), c1.green(), f),
+        _lerp(c0.blue(), c1.blue(), f),
+    )
+
+
+def utilization_color(utilization: float) -> QColor:
+    """Map a queue utilisation in ``[0, 1]`` to a green→amber→red colour.
+
+    Pure and deterministic so the colour mapping can be computed without
+    inspecting painted pixels.
+    """
+    u = 0.0 if utilization < 0.0 else 1.0 if utilization > 1.0 else utilization
+    if u <= 0.5:
+        return _blend(_GREEN, _AMBER, u / 0.5)
+    return _blend(_AMBER, _RED, (u - 0.5) / 0.5)
+
+
+class PipelineFlowWidget(QWidget):
+    """Renders a :class:`PipelineSnapshot` as a coloured, animated stage row."""
+
+    _MIN_HEIGHT = 150
+    _STAGE_GAP = 28.0
+    #: Spacing between successive flow chevrons.
+    _CHEVRON_SPACING_PX = 18.0
+    #: Repaint cadence for smooth chevron motion (~33 FPS).
+    _ANIM_INTERVAL_MS = 30
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        self.setMinimumHeight(self._MIN_HEIGHT)
+        self._snapshot: PipelineSnapshot | None = None
+        self._bottleneck: StageMetrics | None = None
+        # Per-stage drop totals captured at the last "Clear counters & node
+        # warnings" press; subtracted from later snapshots so each stage's drop
+        # badge and red border clear until *new* frames are dropped.
+        self._raw_snapshot: PipelineSnapshot | None = None
+        self._drop_baseline: dict[str, int] = {}
+        # Per-connector accumulated chevron displacement (px), integrated as
+        # ``speed * dt`` each repaint. Storing the travelled distance — rather
+        # than recomputing ``absolute_time * speed`` — keeps the motion smooth
+        # when a connector's speed changes between frames (a varying stage rate
+        # would otherwise teleport the chevrons). Sized to the connector count.
+        self._flow_distance: list[float] = []
+        self._last_anim_t = monotonic()
+        # Hit-rects for the most recently painted stages, used to map a hover
+        # position to the stage under the cursor for tooltips.
+        self._stage_rects: list[tuple[QRectF, str]] = []
+        # Drive smooth chevron animation at a higher frame rate than the
+        # snapshot refresh, independent of when new data arrives.
+        self._anim_timer = QTimer(self)
+        self._anim_timer.setInterval(self._ANIM_INTERVAL_MS)
+        self._anim_timer.timeout.connect(self.update)
+        self._anim_timer.start()
+
+    # -- public API --------------------------------------------------------
+    @property
+    def snapshot(self) -> PipelineSnapshot | None:
+        """The most recently rendered snapshot (``None`` before first update)."""
+        return self._snapshot
+
+    @property
+    def bottleneck(self) -> StageMetrics | None:
+        """The bottleneck stage of the current snapshot, or ``None``."""
+        return self._bottleneck
+
+    def process_groups(self) -> tuple[tuple[str, tuple[int, ...]], ...]:
+        """Contiguous per-process stage groups of the current snapshot.
+
+        Mirrors exactly what :meth:`paintEvent` boxes and labels; empty before
+        the first snapshot.
+        """
+        if self._snapshot is None:
+            return ()
+        return group_stages_by_process(self._snapshot)
+
+    def update_snapshot(self, snapshot: PipelineSnapshot) -> None:
+        """Store *snapshot* and repaint in place (no widget-tree rebuild).
+
+        Drop totals are shown net of the baseline captured by the last
+        :meth:`clear_warnings`, so a stage that dropped before the reset is no
+        longer flagged until it drops again.
+        """
+        self._raw_snapshot = snapshot
+        adjusted = self._apply_drop_baseline(snapshot)
+        self._snapshot = adjusted
+        self._bottleneck = detect_bottleneck(adjusted)
+        self.update()
+
+    def clear_warnings(self) -> None:
+        """Zero the per-stage drop counters and clear red-border emphasis.
+
+        Captures the current per-stage drop totals as a baseline that is
+        subtracted from subsequent snapshots, so every stage's drop badge and the
+        bottleneck red border clear now and stay clear until *new* frames are
+        dropped beyond this point. Live queue-utilisation bottlenecks reappear on
+        the next snapshot if a stage is still saturated.
+        """
+        snap = self._raw_snapshot
+        self._drop_baseline = (
+            {st.name: st.drops_total for st in snap.stages} if snap is not None else {}
+        )
+        if snap is not None:
+            adjusted = self._apply_drop_baseline(snap)
+            self._snapshot = adjusted
+            self._bottleneck = detect_bottleneck(adjusted)
+        self.update()
+
+    def _apply_drop_baseline(self, snapshot: PipelineSnapshot) -> PipelineSnapshot:
+        """Return *snapshot* with per-stage drops reduced by the cleared baseline.
+
+        When no baseline is set the original object is returned unchanged, so the
+        common path allocates nothing and ``snapshot`` identity is preserved.
+        """
+        if not self._drop_baseline:
+            return snapshot
+        stages = tuple(
+            replace(
+                st,
+                drops_total=max(0, st.drops_total - self._drop_baseline.get(st.name, 0)),
+            )
+            for st in snapshot.stages
+        )
+        return PipelineSnapshot(stages=stages, wall_time_s=snapshot.wall_time_s)
+
+
+    def description_at(self, pos: QPoint | QPointF) -> str | None:
+        """Return the stage description under *pos*, or ``None`` if outside any.
+
+        Uses the hit-rects recorded by the last paint, so it reflects exactly
+        what is on screen.
+        """
+        pt = QPointF(pos)
+        for rect, name in self._stage_rects:
+            if rect.contains(pt):
+                return stage_description(name)
+        return None
+
+    def event(self, ev: QEvent) -> bool:  # noqa: N802 (Qt naming)
+        # Custom-painted stages have no child widgets, so tooltips are resolved
+        # by hit-testing the painted stage rects on demand.
+        if ev.type() == QEvent.Type.ToolTip and isinstance(ev, QHelpEvent):
+            text = self.description_at(ev.pos())
+            if text:
+                QToolTip.showText(ev.globalPos(), text, self)
+            else:
+                QToolTip.hideText()
+                ev.ignore()
+            return True
+        return super().event(ev)
+
+    # -- painting ----------------------------------------------------------
+    def paintEvent(self, event) -> None:  # noqa: N802 (Qt naming)
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        snap = self._snapshot
+        if snap is None or not snap.stages:
+            painter.end()
+            return
+
+        n = len(snap.stages)
+        w = float(self.width())
+        h = float(self.height())
+        total_gap = self._STAGE_GAP * (n - 1)
+        box_w = max(40.0, (w - total_gap - 8.0) / n)
+        # Reserve a strip at the bottom for the per-process group labels.
+        box_h = min(72.0, h - 60.0)
+        top = 8.0
+        # Time elapsed since the previous repaint, used to integrate the chevron
+        # displacement. Clamped so a large gap (widget hidden, first frame)
+        # cannot make the chevrons leap.
+        now = monotonic()
+        dt = now - self._last_anim_t
+        self._last_anim_t = now
+        if dt < 0.0 or dt > 0.25:
+            dt = 0.0
+
+        centers: list[float] = []
+        self._stage_rects = []
+        for i, stage in enumerate(snap.stages):
+            x = 4.0 + i * (box_w + self._STAGE_GAP)
+            rect = QRectF(x, top, box_w, box_h)
+            self._paint_stage(painter, rect, stage)
+            self._stage_rects.append((rect, stage.name))
+            centers.append(x + box_w)
+
+        # Flow chevrons between consecutive stages; each connector advances by
+        # its upstream stage's output-rate-derived speed, accumulated over time
+        # so a varying rate changes the speed without jumping the chevrons.
+        n_gaps = n - 1
+        if len(self._flow_distance) != n_gaps:
+            self._flow_distance = [0.0] * n_gaps
+        for i in range(n_gaps):
+            x0 = centers[i]
+            x1 = 4.0 + (i + 1) * (box_w + self._STAGE_GAP)
+            self._flow_distance[i] += flow_speed(snap.stages[i].out_rate) * dt
+            self._paint_flow(
+                painter, x0, x1, top + box_h / 2.0, self._flow_distance[i]
+            )
+
+        # Labelled boundary around each process's contiguous stages.
+        self._paint_process_groups(painter, snap, top, box_h)
+        painter.end()
+
+
+    def _paint_stage(self, painter: QPainter, rect: QRectF, stage: StageMetrics) -> None:
+        is_bottleneck = self._bottleneck is not None and stage.name == self._bottleneck.name
+        fill = utilization_color(stage.utilization)
+        painter.setBrush(QBrush(fill))
+        border = QPen(_RED if is_bottleneck else QColor(0x37, 0x47, 0x4F))
+        border.setWidth(3 if is_bottleneck else 1)
+        painter.setPen(border)
+        painter.drawRoundedRect(rect, 6.0, 6.0)
+
+        # Stage name.
+        painter.setPen(QPen(QColor(Qt.GlobalColor.white)))
+        name_font = QFont(painter.font())
+        name_font.setBold(True)
+        painter.setFont(name_font)
+        painter.drawText(rect, Qt.AlignmentFlag.AlignCenter, stage.name)
+
+        # Queue-fill gauge along the bottom edge.
+        gauge = QRectF(rect.left() + 4.0, rect.bottom() - 8.0, rect.width() - 8.0, 4.0)
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(QBrush(QColor(0, 0, 0, 60)))
+        painter.drawRect(gauge)
+        if stage.queue_capacity > 0:
+            filled = QRectF(gauge)
+            filled.setWidth(gauge.width() * stage.utilization)
+            painter.setBrush(QBrush(QColor(Qt.GlobalColor.white)))
+            painter.drawRect(filled)
+
+        # Drop badge.
+        if stage.is_dropping:
+            badge = QRectF(rect.right() - 16.0, rect.top() - 6.0, 22.0, 16.0)
+            painter.setBrush(QBrush(_RED))
+            painter.setPen(QPen(QColor(Qt.GlobalColor.white)))
+            painter.drawRoundedRect(badge, 8.0, 8.0)
+            small = QFont(painter.font())
+            small.setPointSizeF(max(6.0, small.pointSizeF() - 2.0))
+            small.setBold(True)
+            painter.setFont(small)
+            painter.drawText(badge, Qt.AlignmentFlag.AlignCenter, _fmt_drops(stage.drops_total))
+
+    def _paint_flow(
+        self, painter: QPainter, x0: float, x1: float, y: float,
+        distance: float,
+    ) -> None:
+        painter.setPen(QPen(QColor(0x90, 0xA4, 0xAE), 1))
+        painter.drawLine(QPointF(x0, y), QPointF(x1, y))
+        span = x1 - x0
+        if span <= 0:
+            return
+        # ">"-style chevrons march downstream; *distance* is the displacement
+        # already accumulated for this connector (integrated from the upstream
+        # output rate), so the motion stays smooth even when that rate varies.
+        # Rendered as a stroked polyline at a higher repaint cadence.
+        pen = QPen(QColor(0x29, 0xB6, 0xF6))
+        pen.setWidth(2)
+        pen.setCapStyle(Qt.PenCapStyle.RoundCap)
+        pen.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
+        painter.setPen(pen)
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        half_w = 4.0
+        half_h = 4.0
+        for d in chevron_offsets(span, distance, self._CHEVRON_SPACING_PX):
+            cx = x0 + d
+            chevron = QPolygonF([
+                QPointF(cx - half_w, y - half_h),
+                QPointF(cx, y),
+                QPointF(cx - half_w, y + half_h),
+            ])
+            painter.drawPolyline(chevron)
+
+
+    def _paint_process_groups(
+        self, painter: QPainter, snap: PipelineSnapshot, top: float, box_h: float,
+    ) -> None:
+        """Draw a dashed, labelled boundary around each process's stages."""
+        groups = group_stages_by_process(snap)
+        # Nothing to convey if every stage is unattributed and ungrouped.
+        if not groups or (len(groups) == 1 and groups[0][0] == "?"):
+            return
+        pad = 5.0
+        label_h = 14.0
+        box_pen = QPen(QColor(0xB0, 0xBE, 0xC5))
+        box_pen.setStyle(Qt.PenStyle.DashLine)
+        box_pen.setWidth(1)
+        label_font = QFont(painter.font())
+        label_font.setPointSizeF(max(7.0, label_font.pointSizeF() - 1.0))
+        label_font.setBold(True)
+        for proc, idxs in groups:
+            rects = [self._stage_rects[i][0] for i in idxs]
+            left = min(r.left() for r in rects) - pad
+            right = max(r.right() for r in rects) + pad
+            group_rect = QRectF(left, top - pad, right - left, box_h + 2 * pad)
+            painter.setBrush(Qt.BrushStyle.NoBrush)
+            painter.setPen(box_pen)
+            painter.drawRoundedRect(group_rect, 6.0, 6.0)
+            painter.setPen(QPen(QColor(0xCF, 0xD8, 0xDC)))
+            painter.setFont(label_font)
+            label_rect = QRectF(left, group_rect.bottom() + 1.0, right - left, label_h)
+            painter.drawText(label_rect, Qt.AlignmentFlag.AlignCenter, proc)
+
+
+
+def _fmt_drops(n: int) -> str:
+    if n >= 1000:
+        return f"{n / 1000:.0f}k"
+    return str(int(n))
+
+
+def _soft_log(rate: float) -> float:
+    # Maps 0→0, ~1→0.1, ~100→~0.46, ~1000→~0.69 for a gentle, bounded speed ramp.
+    from math import log10
+
+    if rate <= 0.0:
+        return 0.0
+    return min(1.0, log10(1.0 + rate) / 10.0)
+
+
+def flow_speed(out_rate: float) -> float:
+    """Chevron advance speed in px/s for an upstream stage's output rate.
+
+    Deliberately gentle and bounded — a stalled stage (zero rate) holds its
+    chevrons still, while a fast stage streams them only modestly quicker — so
+    the motion reads as "flow" without becoming a distraction. Pure so the speed
+    ramp can be computed without painting.
+    """
+    return 8.0 + 18.0 * _soft_log(max(0.0, out_rate))
+
+
+def chevron_offsets(
+    span: float, distance: float, spacing: float,
+) -> tuple[float, ...]:
+    """X offsets (in ``[0, span)``) of the chevrons at accumulated *distance*.
+
+    The chevrons march from the upstream stage toward the downstream one, evenly
+    spaced by ``spacing``; *distance* is the total displacement already travelled
+    (the caller integrates ``speed * dt`` over time, rather than multiplying an
+    absolute timestamp by the current speed) so a between-frame speed change only
+    changes the *rate* of advance and never the instantaneous position — the
+    flow stays continuous. Pure and deterministic so the animation can be
+    computed without a live repaint.
+    """
+    if span <= 0.0 or spacing <= 0.0:
+        return ()
+    start = distance % spacing
+    out: list[float] = []
+    d = start
+    while d < span:
+        out.append(d)
+        d += spacing
+    return tuple(out)

--- a/tools/data_forwarder_host/gui/widgets/recording_label_strip.py
+++ b/tools/data_forwarder_host/gui/widgets/recording_label_strip.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Prominent recording-label strip shown beside the charts.
+
+The recording label is a key field, so it is presented in its own clearly
+captioned strip adjacent to the charts rather than buried in the control-panel
+form. It writes through to :meth:`SessionController.set_label` and is disabled
+while a recording is active.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import QHBoxLayout, QLabel, QLineEdit, QWidget
+
+from data_forwarder_host.session.controller import SessionController
+
+
+class RecordingLabelStrip(QWidget):
+    """A captioned, prominent entry for the recording label."""
+
+    #: Emitted whenever the label text changes (so the Record button can be
+    #: re-evaluated by the control panel).
+    label_changed = Signal(str)
+
+    def __init__(self, controller: SessionController, parent=None) -> None:
+        super().__init__(parent)
+        self._ctrl = controller
+        self.setObjectName("recordingLabelStrip")
+        self.setStyleSheet(
+            "#recordingLabelStrip { background:palette(alternate-base); "
+            "border:1px solid palette(mid); border-radius:6px; }"
+        )
+
+        lay = QHBoxLayout(self)
+        lay.setContentsMargins(10, 6, 10, 6)
+        lay.setSpacing(10)
+
+        caption = QLabel("Recording label")
+        caption.setStyleSheet("font-weight:bold; color:palette(highlight);")
+        lay.addWidget(caption)
+
+        self._edit = QLineEdit()
+        self._edit.setText(controller.config.label)
+        self._edit.setPlaceholderText("required before recording")
+        self._edit.setToolTip(
+            "Recording label. Builds the CSV filename '{label}_{session}.csv'. "
+            "Allowed: letters, digits, '_', '-', '.', up to 64 chars."
+        )
+        self._edit.setMinimumHeight(36)
+        self._edit.setStyleSheet(
+            "QLineEdit { font-size: 14px; font-weight: bold; padding: 4px 6px; }"
+        )
+        lay.addWidget(self._edit, 1)
+
+        self._edit.textChanged.connect(self._on_text_changed)
+        controller.recording_changed.connect(self._on_recording_changed)
+
+    def focus_label(self) -> None:
+        """Give keyboard focus to the label entry.
+
+        Used so that when a session window opens, the text cursor waits in the
+        recording-label field and the user can type the label immediately
+        without first clicking it. Existing text (if any) is left intact.
+        """
+        self._edit.setFocus(Qt.FocusReason.OtherFocusReason)
+
+    def _on_text_changed(self, text: str) -> None:
+        self._ctrl.set_label(text.strip())
+        self.label_changed.emit(text)
+
+    def _on_recording_changed(self, recording: bool) -> None:
+        # The label is locked while a capture is live.
+        self._edit.setEnabled(not recording)

--- a/tools/data_forwarder_host/gui/widgets/save_banner.py
+++ b/tools/data_forwarder_host/gui/widgets/save_banner.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Always-on "last saved CSV" panel.
+
+A small permanent sub-window at the bottom of the session tab that reports the
+most recently saved CSV file. It is shown at all times (even before the first
+save, where it states that nothing has been saved yet). The saved path is
+selectable text so it can be copied with the cursor. Two actions are offered:
+**Open File** and **Open Containing Folder**. There is no dismiss control.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Qt, QUrl
+from PySide6.QtGui import QDesktopServices
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QStyle,
+    QWidget,
+)
+
+from data_forwarder_host.utils.open_path import open_containing_folder, open_file
+from data_forwarder_host.utils.logging import log_user_action
+
+_PLACEHOLDER = "No recording saved yet."
+
+
+class SaveBanner(QWidget):
+    """A permanent panel reporting the most recently saved CSV file."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._path: str | None = None
+
+        self.setObjectName("saveBanner")
+        self.setStyleSheet(
+            "#saveBanner { background:palette(alternate-base); "
+            "border:1px solid palette(mid); border-radius:6px; }"
+        )
+
+        lay = QHBoxLayout(self)
+        lay.setContentsMargins(10, 6, 10, 6)
+        lay.setSpacing(8)
+
+        self._label = QLabel(_PLACEHOLDER)
+        self._label.setStyleSheet("color:#2EA043;")
+        # The saved path must be selectable so the user can copy it with the
+        # cursor.
+        self._label.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+            | Qt.TextInteractionFlag.TextSelectableByKeyboard
+        )
+        self._label.setCursor(Qt.CursorShape.IBeamCursor)
+        lay.addWidget(self._label, 1)
+
+        self._btn_open = QPushButton("Open File")
+        self._btn_open.setIcon(
+            self.style().standardIcon(QStyle.StandardPixmap.SP_DialogYesButton)
+        )
+        self._btn_folder = QPushButton("Open Containing Folder")
+        self._btn_folder.setIcon(
+            self.style().standardIcon(QStyle.StandardPixmap.SP_DirOpenIcon)
+        )
+        lay.addWidget(self._btn_open)
+        lay.addWidget(self._btn_folder)
+
+        self._btn_open.clicked.connect(self._on_open_file)
+        self._btn_folder.clicked.connect(self._on_open_folder)
+
+        # No file saved yet: actions are disabled until the first save.
+        self._set_actions_enabled(False)
+        # Always visible — there is no dismiss control.
+        self.setVisible(True)
+
+    # ------------------------------------------------------------------
+    # Public
+    # ------------------------------------------------------------------
+
+    def show_saved(self, path: str) -> None:
+        """Record *path* as the last saved file and refresh the panel."""
+        self._path = path
+        self._label.setText(f"Saved: {path}")
+        self._set_actions_enabled(True)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _set_actions_enabled(self, enabled: bool) -> None:
+        self._btn_open.setEnabled(enabled)
+        self._btn_folder.setEnabled(enabled)
+
+    def _on_open_file(self) -> None:
+        log_user_action("Clicked Open File in the save panel")
+        path = self._path
+        if not path:
+            return
+        if QDesktopServices.openUrl(QUrl.fromLocalFile(path)):
+            return
+        if open_file(path):
+            return
+        QMessageBox.information(
+            self,
+            "Open File",
+            f"Could not launch a viewer automatically.\n\nThe file is saved at:\n{path}",
+        )
+
+    def _on_open_folder(self) -> None:
+        log_user_action("Clicked Open Containing Folder in the save panel")
+        path = self._path
+        if not path:
+            return
+        if open_containing_folder(path):
+            return
+        QMessageBox.information(
+            self,
+            "Open Containing Folder",
+            f"Could not open the folder automatically.\n\nThe file is saved at:\n{path}",
+        )

--- a/tools/data_forwarder_host/gui/widgets/session_log_panel.py
+++ b/tools/data_forwarder_host/gui/widgets/session_log_panel.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""SessionLogPanel — two collapsible log consoles for one session.
+
+Consoles (all collapsed by default, each capped at 1000 lines):
+
+``Channel ASCII``
+    One line per ``sensor_data`` message:
+    ``{t_host_ms}, {ch0}, {ch1}, …``
+
+``Decoded Frames``
+    Every decoded message's kind + raw dict, e.g.
+    ``[1234567] sensor_data  {'ts': 42, 'val': [0.1, 0.2], …}``
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import QPlainTextEdit, QVBoxLayout, QWidget
+
+from data_forwarder_host.gui.widgets.collapsible_section import CollapsibleSection
+from data_forwarder_host.session.controller import SessionController
+
+_MAX_LINES = 1000
+_FLUSH_MS = 100              # flush text consoles at most 10 × / s
+_TEXT_BUF_CAP = 2000         # max formatted text lines held between flushes
+
+
+# ---------------------------------------------------------------------------
+# Thin log console
+# ---------------------------------------------------------------------------
+
+
+class _LogConsole(QPlainTextEdit):
+    """Read-only, fixed-height plain-text console with its own scrollbar."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setReadOnly(True)
+        self.setMaximumBlockCount(_MAX_LINES)
+        self.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
+        # Fixed height: tall enough to show ~6 lines; internal scrollbar handles
+        # overflow.  The outer (session-tab) scroll area is shared with charts.
+        self.setMinimumHeight(100)
+        self.setMaximumHeight(220)
+
+
+# ---------------------------------------------------------------------------
+# SessionLogPanel
+# ---------------------------------------------------------------------------
+
+
+class SessionLogPanel(QWidget):
+    """Two collapsible log consoles wired to a ``SessionController``."""
+
+    def __init__(
+        self, controller: SessionController, parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        # ── Channel ASCII ───────────────────────────────────────────────
+        self._ascii = _LogConsole()
+        self._ascii.setPlaceholderText("No sensor_data messages yet — waiting for data…")
+        self._sec_ascii = CollapsibleSection("Channel ASCII", self._ascii, expanded=False)
+        layout.addWidget(self._sec_ascii)
+
+        # ── Decoded Frames ──────────────────────────────────────────────
+        self._frames = _LogConsole()
+        self._frames.setPlaceholderText("No decoded frames yet…")
+        self._sec_frames = CollapsibleSection("Decoded Frames", self._frames, expanded=False)
+        layout.addWidget(self._sec_frames)
+
+        # ── Wire signals ────────────────────────────────────────────────
+        controller.message_received.connect(self._on_message)
+        controller.state_changed.connect(self._on_state_changed)
+        controller.recording_changed.connect(self._on_recording_changed)
+        # ── Rate-limited log buffers ─────────────────────────────────────
+        # Decoded text arrives at transport speed (can be thousands of
+        # messages/s). Buffering it and flushing on a single timer turns a
+        # per-message append storm — the main long-run FPS sink — into at most
+        # one (multi-line) append per console every _FLUSH_MS, while still
+        # preserving the last _MAX_LINES of history.
+        self._ascii_buf: list[str] = []
+        self._frames_buf: list[str] = []
+        self._flush_timer = QTimer(self)
+        self._flush_timer.setInterval(_FLUSH_MS)
+        self._flush_timer.timeout.connect(self._flush_log_buffers)
+        self._flush_timer.start()
+
+    # ------------------------------------------------------------------
+    # Panel visibility (View ▸ Panels)
+    # ------------------------------------------------------------------
+
+    def set_channel_ascii_visible(self, on: bool) -> None:
+        self._sec_ascii.setVisible(on)
+
+    def set_decoded_frames_visible(self, on: bool) -> None:
+        self._sec_frames.setVisible(on)
+
+    # ------------------------------------------------------------------
+    # Layout state persistence
+    # ------------------------------------------------------------------
+
+    def get_layout_state(self) -> dict:
+        """Return expand/collapse states of all sections as a serialisable dict."""
+        return {
+            "ascii_expanded": self._sec_ascii.is_expanded(),
+            "frames_expanded": self._sec_frames.is_expanded(),
+        }
+
+    def apply_layout_state(self, state: dict) -> None:
+        """Restore expand/collapse states from a previously saved dict."""
+        if "ascii_expanded" in state:
+            self._sec_ascii.set_expanded(bool(state["ascii_expanded"]))
+        if "frames_expanded" in state:
+            self._sec_frames.set_expanded(bool(state["frames_expanded"]))
+
+    # ------------------------------------------------------------------
+    # Slots
+    # ------------------------------------------------------------------
+
+    def _on_state_changed(self, _state: object) -> None:
+        """Clear all consoles when a new stream starts."""
+        from data_forwarder_host.session.states import SessionState
+        if _state == SessionState.RUNNING:
+            self._ascii.clear()
+            self._frames.clear()
+            self._ascii_buf.clear()
+            self._frames_buf.clear()
+
+    def _on_recording_changed(self, recording: bool) -> None:
+        """Emit a one-line banner into the log consoles when recording toggles."""
+        banner = (
+            "───── RECORDING STARTED ─────"
+            if recording
+            else "───── RECORDING STOPPED ─────"
+        )
+        # Flush first so the banner lands after every message buffered so far,
+        # preserving chronological order with the coalesced text consoles.
+        self._flush_log_buffers()
+        self._ascii.appendPlainText(banner)
+        self._frames.appendPlainText(banner)
+
+    def _on_message(self, msg: object) -> None:
+        # msg is a DecodedMessage (avoid hard type import to keep the module
+        # importable in headless contexts where Qt may not be initialised yet)
+        kind = getattr(msg, "kind", None)
+        t_ms = getattr(msg, "t_host_ms", 0)
+        raw = getattr(msg, "raw", {})
+        channels = getattr(msg, "channels", None)
+
+        # ── Channel ASCII: only sensor_data rows ────────────────────────
+        if kind == "sensor_data" and channels is not None:
+            fields = [str(t_ms)] + [f"{v:.6g}" for v in channels]
+            self._ascii_buf.append(",".join(fields))
+            if len(self._ascii_buf) > _TEXT_BUF_CAP:
+                del self._ascii_buf[:-_TEXT_BUF_CAP]
+
+        # ── Decoded Frames: every message ───────────────────────────────
+        self._frames_buf.append(f"[{t_ms:>10}] {kind}  {raw!r}")
+        if len(self._frames_buf) > _TEXT_BUF_CAP:
+            del self._frames_buf[:-_TEXT_BUF_CAP]
+
+    def _flush_log_buffers(self) -> None:
+        """Drain the coalescing buffers into their consoles (timer-driven).
+
+        Each console gets at most one append per tick: the buffered text lines
+        are joined and appended in a single call so QPlainTextEdit relayouts
+        once instead of once per message.
+        """
+        if self._ascii_buf:
+            lines, self._ascii_buf = self._ascii_buf, []
+            self._ascii.appendPlainText("\n".join(lines))
+        if self._frames_buf:
+            lines, self._frames_buf = self._frames_buf, []
+            self._frames.appendPlainText("\n".join(lines))

--- a/tools/data_forwarder_host/gui/widgets/session_tab_widget.py
+++ b/tools/data_forwarder_host/gui/widgets/session_tab_widget.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Session tab strip with a browser-style "new tab" (+) button.
+
+:class:`SessionTabWidget` is a :class:`~PySide6.QtWidgets.QTabWidget` that hosts
+one tab per recording session and, like Google Chrome / Firefox, shows a small
+``+`` button immediately to the right of the last tab. The button is **not** a
+tab: it never holds page content, cannot be dragged, reordered or closed, and is
+shown **only while at least one session tab exists**. Clicking it emits
+:attr:`new_session_requested`; the owner connects that to its New-Session flow.
+
+The widget keeps the button glued to the right edge of the last tab as tabs are
+added, removed, renamed or the strip is resized, by repositioning it whenever
+the underlying tab bar re-lays-out.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QPoint, Qt, Signal
+from PySide6.QtWidgets import QTabBar, QTabWidget, QToolButton
+
+
+class _RelayoutTabBar(QTabBar):
+    """A :class:`QTabBar` that signals whenever its tab layout changes.
+
+    The ``+`` button position depends on the last tab's rectangle, which moves
+    on insert/remove/rename/resize. Qt recomputes that layout in
+    :meth:`tabLayoutChange` and :meth:`resizeEvent`; we surface both as a single
+    :attr:`relaid_out` signal so the owning :class:`SessionTabWidget` can keep
+    the button glued to the last tab.
+    """
+
+    relaid_out = Signal()
+
+    def tabLayoutChange(self) -> None:  # noqa: N802 (Qt override)
+        super().tabLayoutChange()
+        self.relaid_out.emit()
+
+    def resizeEvent(self, event) -> None:  # noqa: N802 (Qt override)
+        super().resizeEvent(event)
+        self.relaid_out.emit()
+
+
+class SessionTabWidget(QTabWidget):
+    """Tab widget whose trailing ``+`` button requests a new session.
+
+    Public interface:
+      * :attr:`new_session_requested` — emitted on a genuine ``+`` click.
+      * standard :class:`QTabWidget` API for adding/removing session tabs.
+
+    The ``+`` button is a child of the tab widget (not of the bar) so it stays
+    visible even when the bar is only as wide as its tabs, and it is hidden
+    whenever no tabs remain.
+    """
+
+    new_session_requested = Signal()
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        bar = _RelayoutTabBar(self)
+        self.setTabBar(bar)
+        bar.relaid_out.connect(self._reposition_plus)
+
+        self._plus = QToolButton(self)
+        self._plus.setText("+")
+        self._plus.setAutoRaise(True)
+        self._plus.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self._plus.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._plus.setToolTip("New session  (Ctrl+N)")
+        self._plus.clicked.connect(self.new_session_requested)
+        self._plus.hide()
+
+    # ------------------------------------------------------------------
+    # Plus-button placement
+    # ------------------------------------------------------------------
+    def _reposition_plus(self) -> None:
+        bar = self.tabBar()
+        n = bar.count()
+        if n == 0:
+            self._plus.hide()
+            return
+        last = bar.tabRect(n - 1)
+        if last.isNull() or last.isEmpty():
+            self._plus.hide()
+            return
+        side = max(16, last.height() - 6)
+        self._plus.setFixedSize(side, side)
+        top_left = QPoint(last.right() + 4, last.top() + (last.height() - side) // 2)
+        self._plus.move(bar.mapTo(self, top_left))
+        self._plus.show()
+        self._plus.raise_()
+
+    # Qt overrides that change the tab layout without going through the bar.
+    def tabInserted(self, index: int) -> None:  # noqa: N802 (Qt override)
+        super().tabInserted(index)
+        self._reposition_plus()
+
+    def tabRemoved(self, index: int) -> None:  # noqa: N802 (Qt override)
+        super().tabRemoved(index)
+        self._reposition_plus()
+
+    def resizeEvent(self, event) -> None:  # noqa: N802 (Qt override)
+        super().resizeEvent(event)
+        self._reposition_plus()

--- a/tools/data_forwarder_host/main.py
+++ b/tools/data_forwarder_host/main.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Top-level launcher: ``python3 main.py``.
+
+Equivalent to ``python -m data_forwarder_host`` and the ``data-forwarder-host``
+console script; all three delegate to :func:`data_forwarder_host.app.main`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def _run() -> int:
+    package_dir = os.path.dirname(os.path.abspath(__file__))
+    parent = os.path.dirname(package_dir)
+    # Bootstrap: ensure the package is importable even without an install, then
+    # repair sys.path so the ``platform/`` subpackage cannot shadow stdlib when
+    # launching from inside the package directory.
+    if parent not in sys.path:
+        sys.path.insert(0, parent)
+    from data_forwarder_host.utils.syspath import repair_launcher_path
+
+    repair_launcher_path()
+
+    from data_forwarder_host import main
+
+    return main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run())

--- a/tools/data_forwarder_host/pipeline/__init__.py
+++ b/tools/data_forwarder_host/pipeline/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Out-of-process source-acquisition pipeline.
+
+This Qt-free layer owns source reading + COBS/CBOR decode in a separate child
+process so the GUI process stays responsive regardless of backend load.
+It sits between ``source``/``protocol`` and ``session`` and must never
+import ``gui``.
+"""
+
+from __future__ import annotations

--- a/tools/data_forwarder_host/pipeline/child_main.py
+++ b/tools/data_forwarder_host/pipeline/child_main.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Child-process entry point for out-of-process acquisition.
+
+:func:`source_child_main` is the **module-level** target the GUI process launches
+with the ``spawn`` start method. It rebuilds the concrete :class:`Source` and the
+COBS/CBOR decoder from the picklable :class:`ChildSpec`, wraps the boundary queue
+in a :class:`_QueueSink`, and runs the pure :func:`run_source_loop`. No Qt is
+imported here and every argument that crosses the boundary is picklable.
+
+The outbound backlog is tracked with a shared integer counter rather than
+``Queue.qsize()`` because ``qsize`` is not implemented on macOS — the counter is
+incremented by the child on each :class:`FrameBatch` enqueued and decremented by
+the GUI host as batches are consumed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from data_forwarder_host.pipeline.drop_policy import BoundaryDropPolicy
+from data_forwarder_host.pipeline.ipc import (
+    OPENED,
+    STOPPED,
+    ChildSpec,
+    FrameBatch,
+    Lifecycle,
+)
+from data_forwarder_host.pipeline.source_loop import run_source_loop
+
+log = logging.getLogger(__name__)
+
+
+class _QueueSink:
+    """Adapts a multiprocessing queue + shared counter to the loop's sink API.
+
+    ``put`` enqueues an envelope and, for a :class:`FrameBatch`, bumps the shared
+    pending counter; ``qsize`` returns that counter (the GUI-process backlog in
+    batches), falling back to ``0`` where neither is available.
+    """
+
+    def __init__(self, queue: Any, pending: Any | None = None) -> None:
+        self._q = queue
+        self._pending = pending
+
+    def put(self, item: Any) -> None:
+        if self._pending is not None and isinstance(item, FrameBatch):
+            with self._pending.get_lock():
+                self._pending.value += 1
+        self._q.put(item)
+
+    def qsize(self) -> int:
+        if self._pending is not None:
+            return int(self._pending.value)
+        try:
+            return int(self._q.qsize())
+        except (NotImplementedError, OSError):
+            return 0
+
+
+def source_child_main(spec: ChildSpec, queue: Any, pending: Any, stop: Any) -> None:
+    """Spawn-target: build the real source/decoder and run the acquisition loop."""
+    # Imported lazily so the child only pays for what it uses and the module's
+    # import graph stays Qt-free.
+    from data_forwarder_host.protocol.cobs_cbor_v1 import CobsCborV1
+    from data_forwarder_host.source import source_for_kind
+
+    try:
+        source = source_for_kind(spec.source_kind)(**spec.source_params)
+    except Exception as exc:  # bad config is terminal for the child
+        log.exception("child failed to build source")
+        sink = _QueueSink(queue, pending)
+        from data_forwarder_host.pipeline.ipc import FAILED
+
+        sink.put(Lifecycle(FAILED, str(exc)))
+        sink.put(Lifecycle(STOPPED))
+        return
+
+    decoder = CobsCborV1(expect_crc=spec.expect_crc)
+    sink = _QueueSink(queue, pending)
+    policy = BoundaryDropPolicy(spec.max_pending)
+    run_source_loop(
+        source=source,
+        decoder=decoder,
+        sink=sink,
+        drop_policy=policy,
+        should_run=lambda: not stop.is_set(),
+        batch_max=spec.batch_max,
+    )
+
+
+def _demo_child(spec: ChildSpec, queue: Any, pending: Any, stop: Any) -> None:
+    """A hardware-free spawn target: a demo entry point for the process host.
+
+    Emits a small fixed number of synthetic :class:`FrameBatch` envelopes
+    bracketed by lifecycle events, so a real spawned child can be exercised
+    without a serial port or BLE radio.
+    """
+    from data_forwarder_host.protocol.base import DecodedMessage
+
+    sink = _QueueSink(queue, pending)
+    sink.put(Lifecycle(OPENED))
+    for i in range(3):
+        if stop.is_set():
+            break
+        msg = DecodedMessage(
+            kind="sensor_data", t_host_ms=i, t_host_utc="z", t_device_ms=i,
+            seq=i, label=None, channels=(float(i),), raw={},
+        )
+        sink.put(FrameBatch((msg,)))
+    sink.put(Lifecycle(STOPPED))

--- a/tools/data_forwarder_host/pipeline/drop_policy.py
+++ b/tools/data_forwarder_host/pipeline/drop_policy.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Boundary drop policy for the source-acquisition child.
+
+When the GUI process falls behind, the outbound queue between the child and the
+GUI grows. Rather than let it grow without bound (the original freeze), the child
+sheds load at the boundary: once the queue is at capacity it drops ``sensor_data``
+frames, but **never** control/metadata frames (e.g. ``session_info``) — that
+guarantee is the same one made in-process, now enforced at the process
+boundary. The policy is pure and deterministic: it reads the current queue depth
+and decides keep/drop, counting drops and reporting the rising edge of each
+dropping episode so a single overflow event can be surfaced per episode.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: Kind string of the only droppable message class.
+SENSOR_DATA = "sensor_data"
+
+
+@dataclass(frozen=True, slots=True)
+class DropDecision:
+    """Outcome of evaluating one message against the policy."""
+
+    keep: bool
+    #: ``True`` only on the transition *into* a dropping episode (rising edge).
+    overflow_edge: bool = False
+
+
+class BoundaryDropPolicy:
+    """Queue-depth-based keep/drop decision that protects control frames.
+
+    Parameters
+    ----------
+    max_pending
+        The outbound queue depth at or above which ``sensor_data`` frames are
+        dropped. Control frames are kept regardless of depth.
+    """
+
+    def __init__(self, max_pending: int) -> None:
+        self._max = max(1, int(max_pending))
+        self._dropped = 0
+        self._active = False
+
+    def evaluate(self, kind: str, pending: int) -> DropDecision:
+        """Decide whether to keep a message of *kind* given *pending* queue depth."""
+        # Control/metadata frames are never dropped at the boundary.
+        if kind != SENSOR_DATA:
+            return DropDecision(keep=True)
+        if pending < self._max:
+            # Back below the limit ends the current dropping episode.
+            self._active = False
+            return DropDecision(keep=True)
+        # At/over capacity: drop this sensor frame.
+        self._dropped += 1
+        edge = not self._active
+        self._active = True
+        return DropDecision(keep=False, overflow_edge=edge)
+
+    @property
+    def max_pending(self) -> int:
+        return self._max
+
+    @property
+    def dropped(self) -> int:
+        """Total ``sensor_data`` frames dropped since the policy was created."""
+        return self._dropped
+
+    @property
+    def is_dropping(self) -> bool:
+        """``True`` while inside an active dropping episode."""
+        return self._active

--- a/tools/data_forwarder_host/pipeline/inbox.py
+++ b/tools/data_forwarder_host/pipeline/inbox.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Consumer-paced, bounded frame inbox at the GUI boundary.
+
+The inbox decouples frame *production* (an I/O worker thread draining the
+out-of-process queue) from frame *consumption* (the GUI thread, when it is
+ready). Producers :meth:`append` decoded frames; the consumer :meth:`drain`s up
+to a budget it chooses. This inverts the previous push-flood — the GUI is the
+client that pulls, the inbox is the server that buffers and, when the GUI cannot
+keep up, drops the *oldest* ``sensor_data`` frames and counts them.
+
+Invariants:
+
+* **Control/metadata frames are never dropped** — they live in a separate
+  priority lane and are always returned first by :meth:`drain`.
+* The ``sensor_data`` lane is **bounded**: appending beyond ``capacity`` evicts
+  the oldest sensor frame and increments :attr:`dropped`.
+* The structure holds no Qt and performs no I/O, so it is fully isolated
+  and safe to call from any thread (guarded by a single lock).
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+from typing import Callable, Iterable
+
+from data_forwarder_host.protocol.base import DecodedMessage
+
+#: Default maximum number of buffered ``sensor_data`` frames before the inbox
+#: starts dropping the oldest. A few thousand frames bounds memory while
+#: absorbing momentary bursts between GUI drain ticks.
+DEFAULT_CAPACITY = 4096
+
+#: Default number of ``sensor_data`` frames the GUI processes per drain tick.
+#: At the ~50 Hz drain cadence this is a ~20 000 frames/s lossless ceiling;
+#: above that the inbox sheds the surplus (counted) so the GUI stays responsive.
+DEFAULT_BUDGET = 400
+
+
+def _default_is_control(msg: DecodedMessage) -> bool:
+    """Treat everything that is not ``sensor_data`` as a control frame."""
+
+    return getattr(msg, "kind", "") != "sensor_data"
+
+
+class FrameInbox:
+    """Thread-safe bounded buffer pulled by the GUI at its own cadence.
+
+    Parameters
+    ----------
+    capacity
+        Maximum number of buffered ``sensor_data`` frames; older ones are
+        dropped (and counted) on overflow.
+    is_control
+        Predicate selecting the never-dropped priority lane. Defaults to
+        "anything that is not ``sensor_data``".
+    """
+
+    def __init__(
+        self,
+        capacity: int = DEFAULT_CAPACITY,
+        *,
+        is_control: Callable[[DecodedMessage], bool] | None = None,
+    ) -> None:
+        if capacity < 1:
+            raise ValueError("capacity must be >= 1")
+        self._capacity = int(capacity)
+        self._is_control = is_control or _default_is_control
+        self._sensor: deque[DecodedMessage] = deque()
+        self._control: deque[DecodedMessage] = deque()
+        self._lock = threading.Lock()
+        self._dropped = 0
+
+    def append(self, messages: Iterable[DecodedMessage]) -> None:
+        """Add frames produced by the worker thread.
+
+        Control frames go to the unbounded priority lane; ``sensor_data`` frames
+        go to the bounded lane, evicting and counting the oldest on overflow.
+        """
+
+        with self._lock:
+            for msg in messages:
+                if self._is_control(msg):
+                    self._control.append(msg)
+                    continue
+                self._sensor.append(msg)
+                if len(self._sensor) > self._capacity:
+                    self._sensor.popleft()
+                    self._dropped += 1
+
+    def drain(self, budget: int) -> list[DecodedMessage]:
+        """Return up to ``budget`` sensor frames plus *all* pending control frames.
+
+        Called by the GUI when it is ready. Control frames are returned first
+        (FIFO), then sensor frames (FIFO) up to ``budget``; any remaining sensor
+        frames stay buffered for the next tick.
+        """
+
+        if budget < 0:
+            raise ValueError("budget must be >= 0")
+        with self._lock:
+            out: list[DecodedMessage] = []
+            while self._control:
+                out.append(self._control.popleft())
+            taken = 0
+            while self._sensor and taken < budget:
+                out.append(self._sensor.popleft())
+                taken += 1
+            return out
+
+    @property
+    def dropped(self) -> int:
+        """Total number of ``sensor_data`` frames dropped on overflow."""
+
+        with self._lock:
+            return self._dropped
+
+    @property
+    def capacity(self) -> int:
+        """Maximum buffered ``sensor_data`` frames before dropping starts."""
+
+        return self._capacity
+
+    def pending(self) -> int:
+        """Number of frames currently buffered (control + sensor)."""
+
+        with self._lock:
+            return len(self._control) + len(self._sensor)
+
+    def pending_sensor(self) -> int:
+        """Number of buffered ``sensor_data`` frames awaiting drain."""
+
+        with self._lock:
+            return len(self._sensor)
+
+    def clear(self) -> None:
+        """Discard all buffered frames and reset the drop counter."""
+
+        with self._lock:
+            self._sensor.clear()
+            self._control.clear()
+            self._dropped = 0

--- a/tools/data_forwarder_host/pipeline/ipc.py
+++ b/tools/data_forwarder_host/pipeline/ipc.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Picklable envelopes that cross the source-process boundary.
+
+Everything the acquisition child sends to the GUI process travels as one of
+these small, immutable, **picklable** dataclasses. No Qt object ever crosses the
+boundary, and the ``spawn`` start method (used so behaviour matches Windows and
+macOS) requires every payload to pickle cleanly — both invariants must hold for
+every payload. Consumers dispatch on the concrete envelope type.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from data_forwarder_host.protocol.base import (
+    DecodedMessage,
+    DecodeError,
+    DecodeStats,
+)
+
+#: Lifecycle event names carried by :class:`Lifecycle`.
+OPENED = "opened"
+FAILED = "failed"
+STOPPED = "stopped"
+
+
+@dataclass(frozen=True, slots=True)
+class ChildSpec:
+    """Picklable description the GUI sends to the child to build its source.
+
+    Carries only plain, picklable data (no Qt, no open handles) so it survives
+    the ``spawn`` boundary. ``max_pending`` is the outbound backlog (in batches)
+    at or above which the child sheds ``sensor_data`` frames.
+    """
+
+    source_kind: str
+    source_params: dict[str, Any] = field(default_factory=dict)
+    expect_crc: bool = True
+    batch_max: int = 256
+    max_pending: int = 64
+
+
+
+@dataclass(frozen=True, slots=True)
+class FrameBatch:
+    """A batch of successfully decoded messages.
+
+    Frames are shipped in batches rather than one-per-message so the GUI thread
+    pays a single cross-thread hand-off per batch instead of per frame — the key
+    to keeping the GUI responsive under a flood.
+    """
+
+    messages: tuple[DecodedMessage, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class DecodeErrors:
+    """Decode errors drained from the child's decoder since the last report."""
+
+    errors: tuple[DecodeError, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class StatsUpdate:
+    """A snapshot of the child decoder's running :class:`DecodeStats`."""
+
+    stats: DecodeStats = field(default_factory=DecodeStats)
+
+
+@dataclass(frozen=True, slots=True)
+class RawByteCount:
+    """Number of raw transport bytes the child received (for bandwidth meters).
+
+    Only the *count* crosses the boundary, never the bytes themselves — shipping
+    the raw payload would defeat the point of offloading the GUI process.
+    """
+
+    n_bytes: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class Overflow:
+    """Rising-edge marker: the child began dropping ``sensor_data`` frames."""
+
+    dropped_total: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class Lifecycle:
+    """A child lifecycle transition (:data:`OPENED`/:data:`FAILED`/:data:`STOPPED`)."""
+
+    event: str
+    detail: str = ""
+
+
+#: Union of every envelope type that may appear on the boundary queue.
+Envelope = (
+    FrameBatch | DecodeErrors | StatsUpdate | RawByteCount | Overflow | Lifecycle
+)

--- a/tools/data_forwarder_host/pipeline/process_host.py
+++ b/tools/data_forwarder_host/pipeline/process_host.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""GUI-side host for the acquisition child process.
+
+:class:`SourceProcessHost` owns the ``spawn`` multiprocessing context, the
+boundary queue, the shared backlog counter and the stop event, and launches the
+child running :func:`source_child_main`. It is **Qt-free** — the session-layer
+QThread worker calls :meth:`poll` to drain envelopes and re-emit Qt signals — so
+this stays in the ``pipeline`` layer. The context and child target are injectable
+so the host's drain/backlog/stop logic can run without a real OS
+process, serial port or BLE radio.
+"""
+
+from __future__ import annotations
+
+import logging
+import multiprocessing
+import os
+from queue import Empty
+from typing import Any, Callable
+
+from data_forwarder_host.pipeline.child_main import source_child_main
+from data_forwarder_host.pipeline.ipc import ChildSpec, FrameBatch
+
+log = logging.getLogger(__name__)
+
+#: Default blocking timeout (seconds) for a single :meth:`SourceProcessHost.poll`.
+DEFAULT_POLL_TIMEOUT = 0.05
+
+#: Setting this environment variable forces single-process (in-GUI) acquisition.
+SINGLE_PROCESS_ENV = "DFH_SINGLE_PROCESS"
+
+
+def process_mode_enabled() -> bool:
+    """True unless out-of-process acquisition is disabled via the environment.
+
+    Out-of-process acquisition is the default so the GUI stays
+    responsive regardless of backend load; set ``DFH_SINGLE_PROCESS``
+    to fall back to the legacy in-GUI :class:`IoWorker` path.
+    """
+    return os.environ.get(SINGLE_PROCESS_ENV, "").strip().lower() in ("", "0", "false", "no")
+
+
+class SourceProcessHost:
+    """Launches and drains the out-of-process acquisition child.
+
+    Parameters
+    ----------
+    spec
+        Picklable description of the source/decoder the child must build.
+    ctx
+        A multiprocessing context. Defaults to the ``spawn`` context so behaviour
+        matches Windows/macOS even on Linux. Injectable by callers.
+    target
+        The child entry point. Defaults to :func:`source_child_main`. Injectable
+        by callers that need a custom entry point.
+    """
+
+    def __init__(
+        self,
+        spec: ChildSpec,
+        *,
+        ctx: Any | None = None,
+        target: Callable[..., None] | None = None,
+    ) -> None:
+        self._spec = spec
+        self._ctx = ctx or multiprocessing.get_context("spawn")
+        self._target = target or source_child_main
+        self._queue = self._ctx.Queue()
+        self._pending = self._ctx.Value("i", 0)
+        self._stop = self._ctx.Event()
+        self._proc: Any | None = None
+
+    # -- lifecycle ---------------------------------------------------------
+    def start(self) -> None:
+        """Spawn the child process."""
+        if self._proc is not None:
+            return
+        self._proc = self._ctx.Process(
+            target=self._target,
+            args=(self._spec, self._queue, self._pending, self._stop),
+            daemon=True,
+        )
+        self._proc.start()
+
+    def request_stop(self) -> None:
+        """Ask the child to finish its loop (idempotent)."""
+        try:
+            self._stop.set()
+        except Exception:
+            log.exception("failed to set child stop event")
+
+    def join(self, timeout: float = 2.0) -> None:
+        """Wait up to *timeout* seconds for the child to exit."""
+        if self._proc is not None:
+            self._proc.join(timeout)
+
+    def is_alive(self) -> bool:
+        return self._proc is not None and self._proc.is_alive()
+
+    # -- draining ----------------------------------------------------------
+    def poll(self, timeout: float = DEFAULT_POLL_TIMEOUT) -> list[Any]:
+        """Return all envelopes currently available, blocking up to *timeout*.
+
+        Blocks for at most *timeout* waiting for the first envelope, then drains
+        everything else already queued without blocking. Consuming a
+        :class:`FrameBatch` decrements the shared backlog counter so the child's
+        drop policy sees the GUI catching up.
+        """
+        out: list[Any] = []
+        try:
+            out.append(self._queue.get(timeout=timeout))
+        except Empty:
+            return out
+        while True:
+            try:
+                out.append(self._queue.get_nowait())
+            except Empty:
+                break
+        consumed = sum(1 for it in out if isinstance(it, FrameBatch))
+        if consumed:
+            with self._pending.get_lock():
+                self._pending.value = max(0, self._pending.value - consumed)
+        return out
+
+    @property
+    def backlog(self) -> int:
+        """Current outbound backlog in batches (frames buffered for the GUI)."""
+        return int(self._pending.value)

--- a/tools/data_forwarder_host/pipeline/source_loop.py
+++ b/tools/data_forwarder_host/pipeline/source_loop.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""The pure source-acquisition loop run by the child process.
+
+:func:`run_source_loop` reads byte chunks from a source, feeds them through the
+COBS/CBOR decoder, applies the boundary :class:`BoundaryDropPolicy`, and pushes
+**batched** decoded frames (plus decode-error, stats, raw-byte-count, overflow
+and lifecycle envelopes) onto an outbound sink. It is written against duck-typed
+collaborators — a ``source`` (open/is_open/chunks/close), a ``decoder``
+(feed/errors_drained/stats), an outbound ``sink`` (put/qsize), and a ``should_run``
+predicate — so the whole loop can run with in-process fakes, no real OS
+process, serial port or BLE radio required. The real child entry point
+(``child_main``) merely builds the concrete collaborators and calls this.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterator
+from typing import Any, Protocol
+
+from data_forwarder_host.pipeline.drop_policy import BoundaryDropPolicy
+from data_forwarder_host.pipeline.ipc import (
+    FAILED,
+    OPENED,
+    STOPPED,
+    DecodeErrors,
+    FrameBatch,
+    Lifecycle,
+    Overflow,
+    RawByteCount,
+    StatsUpdate,
+)
+
+log = logging.getLogger(__name__)
+
+#: Default maximum frames per outbound batch.
+DEFAULT_BATCH_MAX = 256
+#: Emit a stats snapshot every this many processed chunks.
+_STATS_EVERY_CHUNKS = 32
+
+
+class _Sink(Protocol):
+    def put(self, item: Any) -> None: ...
+    def qsize(self) -> int: ...
+
+
+class _SourceLike(Protocol):
+    @property
+    def is_open(self) -> bool: ...
+    def open(self) -> None: ...
+    def close(self) -> None: ...
+    def chunks(self) -> Iterator[bytes]: ...
+
+
+class _DecoderLike(Protocol):
+    def feed(self, chunk: bytes) -> Iterator[Any]: ...
+    def errors_drained(self) -> Iterator[Any]: ...
+    def stats(self) -> Any: ...
+
+
+def run_source_loop(
+    *,
+    source: _SourceLike,
+    decoder: _DecoderLike,
+    sink: _Sink,
+    drop_policy: BoundaryDropPolicy,
+    should_run: Callable[[], bool],
+    batch_max: int = DEFAULT_BATCH_MAX,
+) -> None:
+    """Run the read→decode→drop→batch loop until the source ends or stop is asked.
+
+    Lifecycle envelopes bracket the run: :data:`OPENED` after a successful open,
+    then either :data:`FAILED` (open/loop error, with detail) or :data:`STOPPED`
+    on a clean finish. The outbound queue depth (``sink.qsize()``) is the
+    back-pressure signal handed to *drop_policy* for each ``sensor_data`` frame.
+    """
+    try:
+        if not source.is_open:
+            source.open()
+    except Exception as exc:  # open failure is terminal
+        log.exception("source open failed in child loop")
+        sink.put(Lifecycle(FAILED, str(exc)))
+        sink.put(Lifecycle(STOPPED))
+        return
+
+    sink.put(Lifecycle(OPENED))
+    batch: list[Any] = []
+
+    def flush() -> None:
+        if batch:
+            sink.put(FrameBatch(tuple(batch)))
+            batch.clear()
+
+    try:
+        chunk_count = 0
+        for chunk in source.chunks():
+            if not should_run():
+                break
+            if not chunk:
+                continue
+            sink.put(RawByteCount(len(chunk)))
+            for msg in decoder.feed(chunk):
+                decision = drop_policy.evaluate(msg.kind, sink.qsize())
+                if decision.overflow_edge:
+                    sink.put(Overflow(drop_policy.dropped))
+                if not decision.keep:
+                    continue
+                batch.append(msg)
+                if len(batch) >= batch_max:
+                    flush()
+            errs = tuple(decoder.errors_drained())
+            if errs:
+                # Flush frames first so error/frame ordering is preserved.
+                flush()
+                sink.put(DecodeErrors(errs))
+            chunk_count += 1
+            if chunk_count % _STATS_EVERY_CHUNKS == 0:
+                flush()
+                sink.put(StatsUpdate(decoder.stats()))
+    except Exception as exc:
+        log.exception("source child loop crashed")
+        flush()
+        sink.put(Lifecycle(FAILED, str(exc)))
+    finally:
+        flush()
+        # A final stats snapshot so the GUI sees the closing counts.
+        try:
+            sink.put(StatsUpdate(decoder.stats()))
+        except Exception:
+            log.exception("final stats snapshot failed")
+        try:
+            source.close()
+        except Exception:
+            log.exception("source.close() failed in child loop")
+        sink.put(Lifecycle(STOPPED))

--- a/tools/data_forwarder_host/platform/__init__.py
+++ b/tools/data_forwarder_host/platform/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""OS-specific adapters (serial port enumeration, access-error diagnostics)."""

--- a/tools/data_forwarder_host/platform/base.py
+++ b/tools/data_forwarder_host/platform/base.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Platform adapter base class and shared helpers.
+
+The Nordic / SEGGER detection heuristics (``NRF_HINTS``, ``_looks_like_nrf``,
+``_vid_pid``, ``_describe_port``, ``_short_port``) originated in the original
+prototype serial receiver.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class SerialPortInfo:
+    """Lightweight, transport-agnostic description of a serial port."""
+
+    device: str
+    description: str | None = None
+    manufacturer: str | None = None
+    product: str | None = None
+    serial_number: str | None = None
+    vid: int | None = None
+    pid: int | None = None
+    location: str | None = None
+    interface: str | None = None
+    hwid: str | None = None
+    looks_like_nrf: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class JLinkInfo:
+    """Description of a J-Link probe (currently a stub for v1)."""
+
+    serial: str
+    product: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Nordic / SEGGER detection helpers (verbatim from the prototype)
+# ---------------------------------------------------------------------------
+
+# Substrings (case-insensitive) suggesting "this is a Nordic / SEGGER device".
+NRF_HINTS: tuple[str, ...] = ("nordic", "segger", "j-link", "jlink", "nrf")
+
+
+def _looks_like_nrf(p: Any) -> bool:
+    """Heuristic: does this port look like a Nordic / SEGGER device?"""
+    haystack = " ".join(
+        s for s in (p.manufacturer, p.description, p.product) if s
+    ).lower()
+    return any(h in haystack for h in NRF_HINTS)
+
+
+def _vid_pid(p: Any) -> str | None:
+    if p.vid is not None and p.pid is not None:
+        return f"{p.vid:04x}:{p.pid:04x}"
+    return None
+
+
+def _describe_port(p: Any, indent: str = "    ") -> str:
+    """Multi-line, detailed description of a serial port."""
+    lines = [f"{p.device}"]
+
+    def add(label: str, value: str | None) -> None:
+        if value:
+            lines.append(f"{indent}  {label:<14}{value}")
+
+    add("description:", p.description if p.description and p.description != "n/a" else None)
+    add("manufacturer:", p.manufacturer)
+    add("product:", p.product)
+    add("serial:", p.serial_number)
+    add("vid:pid:", _vid_pid(p))
+    add("interface:", getattr(p, "interface", None))
+    add("location:", getattr(p, "location", None))
+    add("hwid:", p.hwid if p.hwid and p.hwid != "n/a" else None)
+    return "\n".join(indent + l if i else l for i, l in enumerate(lines))
+
+
+def _short_port(p: Any) -> str:
+    """One-line port summary for inline messages."""
+    bits = [p.device]
+    if p.description and p.description != "n/a":
+        bits.append(p.description)
+    extras = []
+    if p.manufacturer:
+        extras.append(p.manufacturer)
+    vp = _vid_pid(p)
+    if vp:
+        extras.append(f"VID:PID={vp}")
+    if p.serial_number:
+        extras.append(f"SN={p.serial_number}")
+    if extras:
+        bits.append("(" + ", ".join(extras) + ")")
+    return "  ".join(bits)
+
+
+# ---------------------------------------------------------------------------
+# Platform adapter ABC
+# ---------------------------------------------------------------------------
+
+
+class PlatformAdapter(ABC):
+    """Abstract per-OS adapter exposing serial / J-Link enumeration."""
+
+    name: str
+
+    @abstractmethod
+    def list_serial_ports(self) -> list[SerialPortInfo]:
+        """Enumerate currently-attached serial ports."""
+
+    @abstractmethod
+    def list_jlink_devices(self) -> list[JLinkInfo]:
+        """Enumerate attached J-Link probes (stub in v1)."""
+
+    @abstractmethod
+    def diagnose_access_error(self, exc: BaseException) -> str:
+        """Return a user-friendly diagnostic for a transport-access failure."""
+
+
+def serial_port_from_pyserial(p: Any) -> SerialPortInfo:
+    """Convert a ``serial.tools.list_ports`` entry to a ``SerialPortInfo``."""
+    return SerialPortInfo(
+        device=p.device,
+        description=p.description if p.description and p.description != "n/a" else None,
+        manufacturer=p.manufacturer,
+        product=p.product,
+        serial_number=p.serial_number,
+        vid=p.vid,
+        pid=p.pid,
+        location=getattr(p, "location", None),
+        interface=getattr(p, "interface", None),
+        hwid=p.hwid if p.hwid and p.hwid != "n/a" else None,
+        looks_like_nrf=_looks_like_nrf(p),
+    )

--- a/tools/data_forwarder_host/platform/factory.py
+++ b/tools/data_forwarder_host/platform/factory.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Platform-adapter factory."""
+
+from __future__ import annotations
+
+import sys
+
+from data_forwarder_host.platform.base import PlatformAdapter
+from data_forwarder_host.platform.linux import LinuxPlatform
+from data_forwarder_host.platform.macos import MacosPlatform
+from data_forwarder_host.platform.windows import WindowsPlatform
+
+
+def detect_platform() -> PlatformAdapter:
+    """Return the ``PlatformAdapter`` matching the running OS."""
+    if sys.platform.startswith("linux"):
+        return LinuxPlatform()
+    if sys.platform == "win32":
+        return WindowsPlatform()
+    if sys.platform == "darwin":
+        return MacosPlatform()
+    # Unknown POSIX-ish OS — fall back to the Linux adapter; its diagnostics
+    # still tend to make sense.
+    return LinuxPlatform()

--- a/tools/data_forwarder_host/platform/linux.py
+++ b/tools/data_forwarder_host/platform/linux.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Linux platform adapter."""
+
+from __future__ import annotations
+
+import errno
+import os
+
+import serial.tools.list_ports
+
+from data_forwarder_host.platform.base import (
+    JLinkInfo,
+    PlatformAdapter,
+    SerialPortInfo,
+    serial_port_from_pyserial,
+)
+
+
+class LinuxPlatform(PlatformAdapter):
+    """Adapter for Linux hosts."""
+
+    name = "linux"
+
+    def list_serial_ports(self) -> list[SerialPortInfo]:
+        return [serial_port_from_pyserial(p) for p in serial.tools.list_ports.comports()]
+
+    def list_jlink_devices(self) -> list[JLinkInfo]:
+        # TODO: integrate pylink/JLink enumeration in a future revision.
+        return []
+
+    def diagnose_access_error(self, exc: BaseException) -> str:
+        eno = getattr(exc, "errno", None)
+        if eno == errno.EACCES:
+            return (
+                f"Permission denied: {exc}\n"
+                f"On Linux, add your user to the 'dialout' group:\n"
+                f"  sudo usermod -aG dialout {os.environ.get('USER', '$USER')}\n"
+                f"Then log out and back in."
+            )
+        if eno == errno.ENOENT:
+            return f"No such device: {exc}\nIs the device plugged in? Try `ls /dev/ttyACM* /dev/ttyUSB*`."
+        if eno == errno.EBUSY:
+            return f"Device is busy: {exc}\nAnother program may be holding the port open."
+        return str(exc)

--- a/tools/data_forwarder_host/platform/macos.py
+++ b/tools/data_forwarder_host/platform/macos.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""macOS platform adapter."""
+
+from __future__ import annotations
+
+import errno
+
+import serial.tools.list_ports
+
+from data_forwarder_host.platform.base import (
+    JLinkInfo,
+    PlatformAdapter,
+    SerialPortInfo,
+    serial_port_from_pyserial,
+)
+
+
+class MacosPlatform(PlatformAdapter):
+    """Adapter for macOS hosts."""
+
+    name = "macos"
+
+    def list_serial_ports(self) -> list[SerialPortInfo]:
+        return [serial_port_from_pyserial(p) for p in serial.tools.list_ports.comports()]
+
+    def list_jlink_devices(self) -> list[JLinkInfo]:
+        # TODO: integrate pylink/JLink enumeration in a future revision.
+        return []
+
+    def diagnose_access_error(self, exc: BaseException) -> str:
+        eno = getattr(exc, "errno", None)
+        if eno == errno.EACCES:
+            return (
+                f"Permission denied: {exc}\n"
+                f"On macOS, prefer the /dev/cu.* device node rather than /dev/tty.*\n"
+                f"and ensure no other tool is holding the port."
+            )
+        if eno == errno.EBUSY:
+            return f"Device is busy: {exc}\nAnother program may be holding the port open."
+        return str(exc)

--- a/tools/data_forwarder_host/platform/windows.py
+++ b/tools/data_forwarder_host/platform/windows.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Windows platform adapter."""
+
+from __future__ import annotations
+
+import serial.tools.list_ports
+
+from data_forwarder_host.platform.base import (
+    JLinkInfo,
+    PlatformAdapter,
+    SerialPortInfo,
+    serial_port_from_pyserial,
+)
+
+
+class WindowsPlatform(PlatformAdapter):
+    """Adapter for Windows hosts."""
+
+    name = "windows"
+
+    def list_serial_ports(self) -> list[SerialPortInfo]:
+        return [serial_port_from_pyserial(p) for p in serial.tools.list_ports.comports()]
+
+    def list_jlink_devices(self) -> list[JLinkInfo]:
+        # TODO: integrate pylink/JLink enumeration in a future revision.
+        return []
+
+    def diagnose_access_error(self, exc: BaseException) -> str:
+        text = str(exc).lower()
+        if "access is denied" in text or "permissiondenied" in text:
+            return (
+                f"Access denied: {exc}\n"
+                f"Another program (for example a serial terminal, IDE or RTT viewer)\n"
+                f"may already have the COM port open. Close it and retry."
+            )
+        if "filenotfound" in text or "cannot find" in text:
+            return f"COM port not found: {exc}\nUnplug/replug the device or check Device Manager."
+        return str(exc)

--- a/tools/data_forwarder_host/protocol/__init__.py
+++ b/tools/data_forwarder_host/protocol/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Protocol layer — the single COBS + CBOR v1 decoder.
+
+There is exactly one protocol; no registry, no ``(name, version)`` keying.
+"""
+
+from __future__ import annotations
+
+from data_forwarder_host.protocol.base import (
+    DecodedMessage,
+    DecodeError,
+    DecodeErrorKind,
+    DecodeStats,
+)
+from data_forwarder_host.protocol.cobs_cbor_v1 import CobsCborV1
+
+__all__ = [
+    "DecodedMessage",
+    "DecodeError",
+    "DecodeErrorKind",
+    "DecodeStats",
+    "CobsCborV1",
+]

--- a/tools/data_forwarder_host/protocol/base.py
+++ b/tools/data_forwarder_host/protocol/base.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Shared protocol data contracts (single COBS/CBOR v1 protocol).
+
+There is exactly one protocol, so these are plain data types — no decoder
+ABC, no registry, no ``(name, version)`` selection layer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class DecodedMessage:
+    """One successfully decoded application-level message.
+
+    Parameters
+    ----------
+    kind
+        One of ``"sensor_data"``, ``"session_info"`` or ``"unknown"``.
+    t_host_ms
+        Host monotonic milliseconds at decode time.
+    t_host_utc
+        ISO-8601 UTC timestamp at decode time, microsecond precision.
+    t_device_ms
+        Optional ``ts`` field from the device, in device milliseconds.
+    seq
+        Optional ``seq`` field from the device.
+    label
+        Optional ``lbl`` field from the device.
+    channels
+        Optional ``val`` field from the device (per-channel sample tuple).
+    raw
+        Full decoded Python object (used for session-info and debugging).
+    """
+
+    kind: str
+    t_host_ms: int
+    t_host_utc: str
+    t_device_ms: int | None
+    seq: int | None
+    label: str | None
+    channels: tuple[float, ...] | None
+    raw: dict[str, Any]
+
+
+@dataclass
+class DecodeStats:
+    """Running counters maintained by a ``ProtocolDecoder``.
+
+    Alongside the frame *counts* the decoder also accumulates the real number
+    of bytes seen per reception category, so the bandwidth details
+    view can report how much data — not just how many frames — arrived in each
+    category. For decoded frames the byte size is the COBS-decoded frame
+    length; for COBS failures it is the length of the raw on-wire chunk that
+    could not be decoded.
+    """
+
+    frames_ok: int = 0
+    cobs_errors: int = 0
+    crc_errors: int = 0
+    malformed: int = 0
+    cbor_errors: int = 0
+
+    bytes_ok: int = 0
+    bytes_cobs: int = 0
+    bytes_crc: int = 0
+    bytes_malformed: int = 0
+    bytes_cbor: int = 0
+
+    @property
+    def frames_bad(self) -> int:
+        return self.cobs_errors + self.crc_errors + self.malformed + self.cbor_errors
+
+    @property
+    def bytes_bad(self) -> int:
+        return self.bytes_cobs + self.bytes_crc + self.bytes_malformed + self.bytes_cbor
+
+
+class DecodeErrorKind(Enum):
+    COBS = auto()
+    CRC = auto()
+    MALFORMED = auto()
+    CBOR = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class DecodeError:
+    """A single decode failure surfaced to the per-session ``ErrorLog``."""
+
+    kind: DecodeErrorKind
+    detail: str
+    context: dict[str, Any] = field(default_factory=dict)

--- a/tools/data_forwarder_host/protocol/cobs_cbor_v1.py
+++ b/tools/data_forwarder_host/protocol/cobs_cbor_v1.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""COBS + CBOR v1 decoder.
+
+A thin stateful wrapper around the verbatim framing primitives in
+``data_forwarder_host.protocol.framing``.
+"""
+
+from __future__ import annotations
+
+import traceback
+from collections.abc import Iterable
+from typing import Any
+
+import cbor2
+from cobs import cobs
+
+from data_forwarder_host.protocol.base import (
+    DecodedMessage,
+    DecodeError,
+    DecodeErrorKind,
+    DecodeStats,
+)
+from data_forwarder_host.protocol.framing import (
+    BAD_CRC,
+    crc16_ccitt,
+    extract_cbor,
+)
+from data_forwarder_host.utils.timeutil import host_monotonic_ms, utc_iso8601_now
+
+# Cap the raw bytestream stored in First Failure Data Capture context so a
+# pathological frame cannot bloat the error log.
+_FFDC_MAX_RAW = 512
+
+
+class CobsCborV1:
+    """Stateful decoder for the device's COBS + CBOR framing.
+
+    The single, fixed protocol: frames are COBS-delimited (``0x00``), carry a
+    2-byte little-endian length prefix and an optional CRC-16/CCITT, and wrap a
+    CBOR map. See :mod:`data_forwarder_host.protocol.framing` (verbatim port).
+    """
+
+    def __init__(self, *, expect_crc: bool = True) -> None:
+        self._expect_crc = expect_crc
+        self._stats = DecodeStats()
+        self._errors: list[DecodeError] = []
+        # Persistent raw-byte accumulator between 0x00 COBS delimiters.
+        self._buf = bytearray()
+
+    # ------------------------------------------------------------------
+    # ProtocolDecoder API
+    # ------------------------------------------------------------------
+
+    def feed(self, chunk: bytes) -> Iterable[DecodedMessage]:
+        """Process one raw chunk; yield fully decoded messages."""
+        if not chunk:
+            return
+        for b in chunk:
+            if b == 0x00:
+                if self._buf:
+                    raw = bytes(self._buf)
+                    try:
+                        frame = bytes(cobs.decode(raw))
+                    except cobs.DecodeError:
+                        self._stats.cobs_errors += 1
+                        self._stats.bytes_cobs += len(raw)
+                        self._errors.append(
+                            DecodeError(
+                                DecodeErrorKind.COBS,
+                                "COBS decode failure",
+                                context={
+                                    "raw": raw[:_FFDC_MAX_RAW],
+                                    "raw_len": len(raw),
+                                    "expected": "valid COBS-encoded frame",
+                                    "actual": (
+                                        "chunk could not be COBS-decoded "
+                                        f"({len(raw)} bytes between delimiters)"
+                                    ),
+                                    "traceback": traceback.format_exc(),
+                                },
+                            )
+                        )
+                        self._buf.clear()
+                        continue
+                    self._buf.clear()
+                    yield from self._process_frame(frame)
+            else:
+                self._buf.append(b)
+
+    def _process_frame(self, frame: bytes) -> Iterable[DecodedMessage]:
+        payload = extract_cbor(frame, expect_crc=self._expect_crc)
+        if payload is None:
+            self._stats.malformed += 1
+            self._stats.bytes_malformed += len(frame)
+            self._errors.append(
+                DecodeError(
+                    DecodeErrorKind.MALFORMED,
+                    f"frame too short (got {len(frame)} bytes)",
+                    context={
+                        "raw": frame[:_FFDC_MAX_RAW],
+                        "raw_len": len(frame),
+                        "expected": (
+                            "at least 2-byte length prefix + payload"
+                            + (" + 2-byte CRC" if self._expect_crc else "")
+                        ),
+                        "actual": f"{len(frame)} byte(s) total",
+                    },
+                )
+            )
+            return
+        if payload is BAD_CRC:
+            self._stats.crc_errors += 1
+            self._stats.bytes_crc += len(frame)
+            length = int.from_bytes(frame[:2], "little")
+            end = 2 + length
+            rx_crc = int.from_bytes(frame[end:end + 2], "little")
+            calc_crc = crc16_ccitt(frame[2:end])
+            self._errors.append(
+                DecodeError(
+                    DecodeErrorKind.CRC,
+                    "CRC-16 mismatch",
+                    context={
+                        "raw": frame[:_FFDC_MAX_RAW],
+                        "raw_len": len(frame),
+                        "expected": f"CRC-16/CCITT 0x{calc_crc:04X} (computed over payload)",
+                        "actual": f"received CRC 0x{rx_crc:04X}",
+                    },
+                )
+            )
+            return
+        try:
+            obj = cbor2.loads(payload)
+        except cbor2.CBORDecodeError as exc:
+            self._stats.cbor_errors += 1
+            self._stats.bytes_cbor += len(frame)
+            self._errors.append(
+                DecodeError(
+                    DecodeErrorKind.CBOR,
+                    f"CBOR decode error: {exc}",
+                    context={
+                        "raw": bytes(payload)[:_FFDC_MAX_RAW],
+                        "raw_len": len(payload),
+                        "expected": "well-formed CBOR map",
+                        "actual": f"{type(exc).__name__}: {exc}",
+                        "traceback": traceback.format_exc(),
+                    },
+                )
+            )
+            return
+        self._stats.frames_ok += 1
+        self._stats.bytes_ok += len(frame)
+        yield self._classify(obj)
+
+    def stats(self) -> DecodeStats:
+        return self._stats
+
+    def reset(self) -> None:
+        self._stats = DecodeStats()
+        self._errors.clear()
+        self._buf = bytearray()
+
+    def errors_drained(self) -> Iterable[DecodeError]:
+        out, self._errors = self._errors, []
+        return out
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _classify(obj: Any) -> DecodedMessage:
+        t_host_ms = host_monotonic_ms()
+        t_host_utc = utc_iso8601_now()
+
+        if not isinstance(obj, dict):
+            return DecodedMessage(
+                kind="unknown",
+                t_host_ms=t_host_ms,
+                t_host_utc=t_host_utc,
+                t_device_ms=None,
+                seq=None,
+                label=None,
+                channels=None,
+                raw={"_": obj},
+            )
+
+        msg_type = obj.get("t")
+        if msg_type == "sd":
+            d = obj.get("d") if isinstance(obj.get("d"), dict) else {}
+            vals = d.get("val") if isinstance(d, dict) else None
+            channels: tuple[float, ...] | None
+            if isinstance(vals, (list, tuple)):
+                try:
+                    channels = tuple(float(v) for v in vals)
+                except (TypeError, ValueError):
+                    channels = None
+            else:
+                channels = None
+            return DecodedMessage(
+                kind="sensor_data",
+                t_host_ms=t_host_ms,
+                t_host_utc=t_host_utc,
+                t_device_ms=_as_int(d.get("ts")) if isinstance(d, dict) else None,
+                seq=_as_int(d.get("seq")) if isinstance(d, dict) else None,
+                label=_as_label(d.get("lbl")) if isinstance(d, dict) else None,
+                channels=channels,
+                raw=obj,
+            )
+
+        # Anything that is not "sd" is treated as session-info / metadata.
+        return DecodedMessage(
+            kind="session_info" if msg_type else "unknown",
+            t_host_ms=t_host_ms,
+            t_host_utc=t_host_utc,
+            t_device_ms=None,
+            seq=None,
+            label=None,
+            channels=None,
+            raw=obj,
+        )
+
+
+def _as_int(v: Any) -> int | None:
+    if isinstance(v, bool):  # bool is subclass of int — exclude
+        return None
+    if isinstance(v, int):
+        return v
+    return None
+
+
+def _as_label(v: Any) -> str | None:
+    """Normalise the per-sample label field.
+
+    The device sends ``lbl`` as a ``uint`` where ``0`` means "unlabeled"
+    (see samples/data_forwarder/cddl). Map a non-zero integer to its decimal
+    string; accept a plain string verbatim; treat everything else as unlabeled.
+    """
+    if isinstance(v, bool):
+        return None
+    if isinstance(v, int):
+        return None if v == 0 else str(v)
+    if isinstance(v, str):
+        return v or None
+    return None

--- a/tools/data_forwarder_host/protocol/framing.py
+++ b/tools/data_forwarder_host/protocol/framing.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Framing primitives (COBS framing helpers for the data-forwarder protocol)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+from cobs import cobs
+
+
+# ---------------------------------------------------------------------------
+# COBS framing helpers
+# ---------------------------------------------------------------------------
+
+
+def crc16_ccitt(data: bytes, init: int = 0xFFFF) -> int:
+    # Matches Zephyr's crc16_ccitt() — reflected (LSB-first) variant, poly 0x1021.
+    # NOT the same as CRC-16/CCITT-FALSE (MSB-first); Zephyr uses the reflected form.
+    crc = init
+    for b in data:
+        e = (crc ^ b) & 0xFF
+        f = (e ^ (e << 4)) & 0xFF
+        crc = ((crc >> 8) ^ (f << 8) ^ (f << 3) ^ (f >> 4)) & 0xFFFF
+    return crc
+
+
+COBS_ERROR: Any = object()  # sentinel for COBS decode failures
+BAD_CRC: Any = object()     # sentinel for CRC mismatches
+
+
+def cobs_frame_iter(byte_source: Iterable[bytes]) -> Iterator[Any]:
+    """Yield COBS-decoded raw frames (LEN + CBOR + optional CRC) or COBS_ERROR."""
+    buf = bytearray()
+    for chunk in byte_source:
+        for b in chunk:
+            if b == 0x00:
+                if buf:
+                    try:
+                        yield bytes(cobs.decode(bytes(buf)))
+                    except cobs.DecodeError:
+                        yield COBS_ERROR  # visible in the bad counter, not silently lost
+                    buf.clear()
+            else:
+                buf.append(b)
+
+
+def extract_cbor(frame: bytes, expect_crc: bool) -> Any:
+    """Return CBOR payload, None (malformed), or BAD_CRC."""
+    if len(frame) < 2:
+        return None
+    length = int.from_bytes(frame[:2], "little")
+    end = 2 + length
+    if expect_crc:
+        if len(frame) < end + 2:
+            return None
+        rx_crc = int.from_bytes(frame[end:end + 2], "little")
+        if rx_crc != crc16_ccitt(frame[2:end]):
+            return BAD_CRC
+    elif len(frame) < end:
+        return None
+    return frame[2:end]

--- a/tools/data_forwarder_host/pyproject.toml
+++ b/tools/data_forwarder_host/pyproject.toml
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "data-forwarder-host"
+version = "0.1.0"
+description = "Cross-platform host GUI that receives, visualises, records and exports sensor data forwarded from an nRF device."
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "LicenseRef-Nordic-5-Clause" }
+authors = [{ name = "Nordic Semiconductor ASA" }]
+keywords = ["nordic", "nrf", "sensor", "edge-ai", "data-forwarder"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering",
+]
+dependencies = [
+    "cbor2>=5.6",
+    "pyserial>=3.5",
+    "cobs>=1.2",
+    "numpy>=1.26",
+    "platformdirs>=4.2",
+    "bleak>=0.21",
+    "psutil>=5.9",
+    "PySide6>=6.6",
+]
+
+[project.optional-dependencies]
+# Developer tooling (linters, formatter, type checker). Not needed to run
+# the app. Install the development environment from the package directory with:
+#   pip install -e ".[dev]"
+dev = [
+    "black>=24.3",
+    "ruff>=0.4",
+    "mypy>=1.10",
+]
+
+[project.scripts]
+data-forwarder-host = "data_forwarder_host.app:main"
+
+# The package directory IS the project root (flat layout): the import package
+# ``data_forwarder_host`` maps to ``.`` and every subpackage is listed
+# explicitly so build tools never pick up sibling dirs (``_other``, caches,
+# the ``recordings`` output dir) as top-level packages.
+[tool.setuptools]
+package-dir = { "data_forwarder_host" = "." }
+packages = [
+    "data_forwarder_host",
+    "data_forwarder_host.core",
+    "data_forwarder_host.gui",
+    "data_forwarder_host.gui.dialogs",
+    "data_forwarder_host.gui.widgets",
+    "data_forwarder_host.pipeline",
+    "data_forwarder_host.platform",
+    "data_forwarder_host.protocol",
+    "data_forwarder_host.session",
+    "data_forwarder_host.source",
+    "data_forwarder_host.utils",
+]
+
+[tool.black]
+line-length = 100
+target-version = ["py312"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "B", "UP", "N", "SIM"]
+ignore = ["E501"]  # handled by Black
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+files = [
+    "platform",
+    "source",
+    "protocol",
+    "core",
+    "session",
+    "utils",
+]
+
+[[tool.mypy.overrides]]
+module = "data_forwarder_host.gui.*"
+strict = false
+strict_optional = true

--- a/tools/data_forwarder_host/requirements.txt
+++ b/tools/data_forwarder_host/requirements.txt
@@ -1,0 +1,10 @@
+# Runtime install for data-forwarder-host.
+#
+# Single source of truth: dependencies are declared in pyproject.toml. This file
+# only installs the package (editable), so the dependency list lives in exactly
+# one place and cannot drift. The GUI (PySide6) is a base dependency, so it is
+# always installed.
+#
+#   pip install -r requirements.txt
+#
+-e .

--- a/tools/data_forwarder_host/scripts/build_linux_binary.sh
+++ b/tools/data_forwarder_host/scripts/build_linux_binary.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+# Build a single self-contained Linux executable for the Data Forwarder Host.
+#
+# The result is ONE file, dist/data-forwarder-host, that bundles the Python
+# interpreter and every dependency (PySide6/Qt6, numpy, bleak, ...). Copy it to
+# any reasonably recent x86_64 Ubuntu machine and run it directly — nothing has
+# to be installed there.
+#
+# Usage:
+#   ./scripts/build_linux_binary.sh
+#
+# Notes:
+#   * Run on the OLDEST Ubuntu you intend to support: glibc is forward- but not
+#     backward-compatible, so a binary built on Ubuntu 22.04 runs on 22.04+ but
+#     a binary built on 24.04 may not run on 22.04.
+#   * Requires a working Python 3.12 with `venv` + internet access for the
+#     one-time dependency download.
+set -euo pipefail
+
+# Resolve the package directory (parent of this scripts/ dir) regardless of CWD.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PKG_DIR"
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+BUILD_VENV="${BUILD_VENV:-$PKG_DIR/.build-venv}"
+
+echo ">> Using interpreter: $($PYTHON_BIN --version)"
+
+# 1. Isolated build environment (kept out of git via .gitignore).
+#    A venv is only reused if it actually works: a leftover/foreign venv (e.g.
+#    one copied from another machine) has launcher scripts whose shebang points
+#    at a path that does not exist here ("pip: cannot execute: required file not
+#    found"), so we validate `python -m pip` and rebuild from scratch otherwise.
+venv_is_usable() {
+    [ -x "$BUILD_VENV/bin/python" ] && "$BUILD_VENV/bin/python" -m pip --version >/dev/null 2>&1
+}
+if ! venv_is_usable; then
+    if [ -e "$BUILD_VENV" ]; then
+        echo ">> Existing build venv is unusable (stale/foreign) — recreating"
+        rm -rf "$BUILD_VENV"
+    fi
+    echo ">> Creating build venv at $BUILD_VENV"
+    # Prefer stdlib venv; fall back to `virtualenv` on distros that ship Python
+    # without the venv/ensurepip module (e.g. minimal Debian/Ubuntu installs).
+    if "$PYTHON_BIN" -c "import venv, ensurepip" 2>/dev/null; then
+        "$PYTHON_BIN" -m venv "$BUILD_VENV"
+    elif command -v virtualenv >/dev/null 2>&1; then
+        virtualenv -p "$PYTHON_BIN" "$BUILD_VENV"
+    else
+        echo "!! Neither 'python -m venv' nor 'virtualenv' is available." >&2
+        echo "   Install one of:  apt install python3-venv   |   pip install --user virtualenv" >&2
+        exit 1
+    fi
+fi
+# shellcheck disable=SC1091
+source "$BUILD_VENV/bin/activate"
+
+# 2. Install the app's runtime deps (from pyproject.toml) + PyInstaller.
+echo ">> Installing runtime dependencies and PyInstaller"
+python -m pip install --upgrade pip wheel >/dev/null
+python -m pip install "." "pyinstaller>=6.6"
+
+# 3. Clean previous artefacts and build from the spec.
+echo ">> Building single-file binary"
+rm -rf build dist
+pyinstaller --noconfirm --clean data_forwarder_host.spec
+
+BIN="$PKG_DIR/dist/data-forwarder-host"
+if [ -x "$BIN" ]; then
+    echo ""
+    echo ">> Done. Single-file binary:"
+    echo "     $BIN"
+    ls -lh "$BIN" | awk '{print "     size: "$5}'
+    echo ">> Run it with:  $BIN"
+else
+    echo "!! Build finished but $BIN was not produced." >&2
+    exit 1
+fi

--- a/tools/data_forwarder_host/scripts/freeze_entry.py
+++ b/tools/data_forwarder_host/scripts/freeze_entry.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Entry point used when building the standalone (frozen) binary.
+
+This is the script PyInstaller turns into the single-file executable. It is
+deliberately separate from ``main.py`` / ``__main__.py`` because a frozen build
+has one extra, non-negotiable requirement:
+
+``multiprocessing.freeze_support()`` **must** be the very first thing that runs.
+
+The application launches its acquisition backend in a child process using the
+``spawn`` start method (see ``pipeline/process_host.py``). With ``spawn`` the
+child is started by *re-executing this same binary*. ``freeze_support()`` detects
+that re-execution, runs the child worker, and exits — *without* falling through
+to ``main()``. Omitting it makes every spawned child start a brand-new GUI,
+producing an endless cascade of windows (the classic PyInstaller + multiprocessing
+bug).
+
+The source-tree ``sys.path`` repair done by the other launchers is unnecessary
+here: in a frozen build the package is imported from the embedded archive, not
+from the package directory, so the ``platform`` subpackage cannot shadow stdlib.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+
+
+def _run() -> int:
+    from data_forwarder_host.app import main
+
+    return main()
+
+
+if __name__ == "__main__":
+    # MUST be first — handles the re-executed `spawn` child process.
+    multiprocessing.freeze_support()
+    raise SystemExit(_run())

--- a/tools/data_forwarder_host/scripts/repro_freeze.py
+++ b/tools/data_forwarder_host/scripts/repro_freeze.py
@@ -1,0 +1,242 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Headless flood reproduction for the Data Forwarder Host GUI freeze.
+
+This drives synthetic, high-rate ``sensor_data`` frames through a **real**
+:class:`SessionController` and the **real** live GUI widgets
+(:class:`CombinedPlot`, :class:`ChartsPanel`, :class:`SessionLogPanel`,
+:class:`BandwidthDetailsDialog`) running on the ``offscreen`` Qt platform — i.e.
+the exact GUI-thread code path the app uses, minus the window manager.
+
+The sequence numbers are deliberately given **large forward gaps** to mimic the
+frames the GUI inbox drops when it is overloaded (see ``FrameInbox`` /
+``_drain_inbox``): under real overload the GUI never sees the dropped frames, so
+the frames it *does* see have gaps in ``seq`` — and those gaps are fed straight
+into the transport-loss detector by ``SessionController._process_message``.
+
+The always-on :mod:`slow_span` instrumentation prints ``slow-span ...`` lines to
+stdout whenever any GUI-thread span exceeds its threshold, so the precise span
+that blocks the UI thread is *proven*, not guessed. Peak RSS and the loss
+detector's pending backlog are reported at the end to corroborate the OOM.
+
+Usage::
+
+    QT_QPA_PLATFORM=offscreen \\
+    PYTHONPATH=/workspaces/edge-ai/edge-ai/tools \\
+    /workspaces/edge-ai/.venv/bin/python \\
+    edge-ai/tools/data_forwarder_host/scripts/repro_freeze.py [options]
+
+Options:
+    --seconds N       wall-clock duration to flood for (default 12)
+    --rate N          frames delivered per drain tick (default 400)
+    --interval-ms N   drain tick period in ms (default 8, matching MAX_DRAIN_MS)
+    --gap N           seq numbers skipped between ticks = simulated inbox drops
+                      (default 2000; use 0 for a clean, no-loss baseline)
+    --channels N      number of channels per frame (default 3)
+    --clean           shortcut for --gap 0 (no simulated drops)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import math
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+
+def _rss_mb() -> float:
+    """Resident set size of this process in MiB (Linux ``/proc`` based)."""
+    try:
+        with open("/proc/self/statm", encoding="ascii") as fh:
+            resident_pages = int(fh.read().split()[1])
+        return resident_pages * os.sysconf("SC_PAGE_SIZE") / (1024 * 1024)
+    except Exception:
+        import resource
+
+        # ru_maxrss is KiB on Linux.
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seconds", type=float, default=12.0)
+    parser.add_argument("--rate", type=int, default=400)
+    parser.add_argument("--interval-ms", type=int, default=8)
+    parser.add_argument("--gap", type=int, default=2000)
+    parser.add_argument("--channels", type=int, default=3)
+    parser.add_argument("--clean", action="store_true")
+    args = parser.parse_args(argv)
+    if args.clean:
+        args.gap = 0
+
+    # Offscreen so no display is needed; must be set before any Qt import.
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+    # Send slow-span (and everything on data_forwarder_host.debug) to stdout.
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="%(asctime)s %(name)s %(message)s",
+        stream=sys.stdout,
+    )
+
+    import data_forwarder_host.utils.slow_span as ss
+
+    from PySide6.QtCore import QTimer
+    from PySide6.QtWidgets import QApplication
+
+    from data_forwarder_host.gui.widgets.bandwidth_details import (
+        BandwidthDetailsDialog,
+    )
+    from data_forwarder_host.gui.widgets.charts_panel import ChartsPanel
+    from data_forwarder_host.gui.widgets.combined_plot import CombinedPlot
+    from data_forwarder_host.gui.widgets.session_log_panel import SessionLogPanel
+    from data_forwarder_host.protocol.base import DecodedMessage
+    from data_forwarder_host.session.config import SessionConfig, SourceSpec
+    from data_forwarder_host.session.controller import SessionController
+
+    app = QApplication.instance() or QApplication([])
+
+    n_ch = args.channels
+    # loss_confirmation_window deliberately long-ish (2 s) so that, when we
+    # generate losses faster than they expire, the detector's pending set
+    # grows — exactly the condition that makes its per-frame sweep expensive.
+    config = SessionConfig(
+        tag="repro",
+        source=SourceSpec(kind="ble"),
+        plot_window_seconds=10.0,
+        bandwidth_window_seconds=10.0,
+        loss_confirmation_window_seconds=2.0,
+    )
+    # use_process=True => the controller builds no GUI-side source and we never
+    # call start(), so no child process is spawned; we inject frames directly
+    # into the same _process_message slot the live session would drive.
+    ctrl = SessionController(config, use_process=True)
+
+    # Real live widgets, wired exactly as the session window wires them.
+    combined = CombinedPlot(ctrl.data_model)
+    charts = ChartsPanel(ctrl.data_model)
+    logs = SessionLogPanel(ctrl)
+    bw = BandwidthDetailsDialog(ctrl)
+    for w in (combined, charts, logs, bw):
+        w.resize(900, 400)
+        w.show()
+    # Expand the per-channel section so those charts also refresh each tick.
+    try:
+        charts._channels_section.set_expanded(True)  # noqa: SLF001
+    except Exception:
+        pass
+    app.processEvents()
+
+    # Establish channel metadata so the model locks channel names/buffers and
+    # the controller marks metadata ready (otherwise sensor_data is rejected by
+    # _validate_sensor_data before it ever reaches the loss detector).
+    now_utc = datetime.now(timezone.utc).isoformat()
+    session_info = DecodedMessage(
+        kind="session_info",
+        t_host_ms=0,
+        t_host_utc=now_utc,
+        t_device_ms=0,
+        seq=None,
+        label=None,
+        channels=None,
+        raw={
+            "t": "si",
+            "d": {
+                "ch_n": [f"ch{i}" for i in range(n_ch)],
+                "ch": n_ch,
+                "sid": 1,
+                "hz": 200,
+                "st": 0,
+                "dr": 0,
+                "name": "repro",
+            },
+        },
+    )
+    ctrl._process_message(session_info)  # noqa: SLF001
+    app.processEvents()
+    assert ctrl.metadata_ready, "session_info rejected — repro would not exercise the real path"
+
+    state = {
+        "seq": 0,
+        "t_dev": 0,
+        "sent": 0,
+        "ticks": 0,
+        "peak_rss": _rss_mb(),
+        "t0": time.monotonic(),
+    }
+    sample_period_ms = 5  # 200 Hz
+
+    def pump() -> None:
+        # One drain-tick's worth of frames, delivered synchronously like the
+        # real GUI drain loop. A forward gap is then opened in ``seq`` to mimic
+        # the frames the inbox dropped to stay responsive.
+        with ss.slow_span("repro.tick", extra=f"n={args.rate} gap={args.gap}"):
+            for _ in range(args.rate):
+                seq = state["seq"]
+                t_dev = state["t_dev"]
+                vals = tuple(
+                    math.sin((t_dev / 1000.0) * (1.0 + i) * 2.0) + 0.01 * (seq % 7)
+                    for i in range(n_ch)
+                )
+                msg = DecodedMessage(
+                    kind="sensor_data",
+                    t_host_ms=t_dev,
+                    t_host_utc=now_utc,
+                    t_device_ms=t_dev,
+                    seq=seq,
+                    label=None,
+                    channels=vals,
+                    raw={},
+                )
+                ctrl._process_message(msg)  # noqa: SLF001
+                state["seq"] = seq + 1
+                state["t_dev"] = t_dev + sample_period_ms
+            # Simulate the inbox having dropped ``gap`` frames between ticks:
+            # advance both the sequence cursor and the device clock past them.
+            if args.gap:
+                state["seq"] += args.gap
+                state["t_dev"] += args.gap * sample_period_ms
+        state["sent"] += args.rate
+        state["ticks"] += 1
+        rss = _rss_mb()
+        if rss > state["peak_rss"]:
+            state["peak_rss"] = rss
+
+    timer = QTimer()
+    timer.setInterval(args.interval_ms)
+    timer.timeout.connect(pump)
+    timer.start()
+
+    def finish() -> None:
+        timer.stop()
+        app.quit()
+
+    QTimer.singleShot(int(args.seconds * 1000), finish)
+
+    print(
+        f"[repro] flooding mode={'CLEAN' if args.gap == 0 else 'LOSSY'} "
+        f"rate={args.rate}/tick interval={args.interval_ms}ms gap={args.gap} "
+        f"channels={n_ch} for {args.seconds}s — watch for 'slow-span' lines…",
+        flush=True,
+    )
+    app.exec()
+
+    elapsed = time.monotonic() - state["t0"]
+    pending = ctrl._seq_tracker.pending_count  # noqa: SLF001
+    fps = state["sent"] / elapsed if elapsed else 0.0
+    print(
+        "\n[repro] done: "
+        f"sent={state['sent']} frames in {elapsed:.1f}s "
+        f"({fps:,.0f} frames/s) over {state['ticks']} ticks | "
+        f"seq_tracker.pending={pending:,} | "
+        f"peak_rss={state['peak_rss']:.0f} MiB",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/data_forwarder_host/session/__init__.py
+++ b/tools/data_forwarder_host/session/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Session management — ForwardingSession, SessionController, SessionManager."""

--- a/tools/data_forwarder_host/session/config.py
+++ b/tools/data_forwarder_host/session/config.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""SessionConfig and SourceSpec (validation included).
+
+A session is configured with a single data source, a recording label, and a
+per-session output directory. There is no protocol or sink configuration — the
+protocol is the single fixed COBS/CBOR v1 and output is a single CSV file.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+from data_forwarder_host.source.base import RoleMode
+
+# Supported source kinds (UART implemented, BLE NUS declared).
+_SOURCE_KINDS = {"uart", "ble"}
+
+
+class ConfigError(ValueError):
+    """Raised when a ``SessionConfig`` fails ``validate()``."""
+
+
+@dataclass(frozen=True, slots=True)
+class SourceSpec:
+    kind: str                          # "uart" | "ble"
+    role: RoleMode = RoleMode.LISTENER
+    params: dict[str, Any] = field(default_factory=dict)
+
+
+# Tag and label share the same character set so both are safe in a filename.
+_TAG_RE = re.compile(r"^[A-Za-z0-9_\-\.]{1,64}$")
+
+
+@dataclass(frozen=True, slots=True)
+class SessionConfig:
+    tag: str
+    source: SourceSpec
+    label: str = ""                    # recording label (G4); builds CSV filename
+    output_dir: str = ""               # per-session CSV output directory (F4)
+    expect_crc: bool = True            # single-protocol option
+    plot_window_seconds: float = 10.0
+    # Trailing window for the live bandwidth monitor. Defaults to the
+    # plot window and is adjustable only from the session window, not the
+    # New Session dialog.
+    bandwidth_window_seconds: float = 10.0
+    # Grace period (seconds) a missing sensor_data sequence number is awaited
+    # before it is confirmed a transport loss. Adjustable live from
+    # the error panel; reordered/late frames arriving within it are not losses.
+    loss_confirmation_window_seconds: float = 1.0
+    layout_state: dict = field(default_factory=dict)
+    config_version: int = 2
+
+    # ------------------------------------------------------------------
+    # Factory helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def with_auto_tag(cls, *, source: SourceSpec, **kwargs: Any) -> "SessionConfig":
+        tag = f"{source.kind}-{uuid.uuid4().hex[:6]}"
+        return cls(tag=tag, source=source, **kwargs)  # type: ignore[arg-type]
+
+    def with_tag(self, tag: str) -> "SessionConfig":
+        return replace(self, tag=tag)
+
+    # ------------------------------------------------------------------
+    # Recording label (G4)
+    # ------------------------------------------------------------------
+
+    def has_recording_label(self) -> bool:
+        """Return ``True`` if a valid, non-empty recording label is defined.
+
+        The Record action is enabled only when this is true.
+        """
+        lbl = self.label.strip() if self.label else ""
+        return bool(lbl) and bool(_TAG_RE.match(lbl))
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def validate(self) -> None:
+        errs: list[str] = []
+
+        tag = self.tag.strip() if self.tag else ""
+        if not tag:
+            errs.append("tag must not be empty")
+        elif not _TAG_RE.match(tag):
+            errs.append(f"tag must match [A-Za-z0-9_-.]{{1,64}} (got {self.tag!r})")
+
+        if self.source.kind not in _SOURCE_KINDS:
+            errs.append(f"unknown source kind: {self.source.kind!r}")
+        if self.source.kind == "uart" and not self.source.params.get("port"):
+            errs.append("uart source requires a 'port' parameter")
+
+        if self.label.strip() and not _TAG_RE.match(self.label.strip()):
+            errs.append(
+                f"label must match [A-Za-z0-9_-.]{{1,64}} (got {self.label!r})"
+            )
+
+        if not (1.0 <= self.plot_window_seconds <= 600.0):
+            errs.append(
+                f"plot_window_seconds must be in [1, 600] (got {self.plot_window_seconds})"
+            )
+
+        if not (0.1 <= self.bandwidth_window_seconds <= 600.0):
+            errs.append(
+                f"bandwidth_window_seconds must be in [0.1, 600] (got {self.bandwidth_window_seconds})"
+            )
+
+        if not (0.05 <= self.loss_confirmation_window_seconds <= 30.0):
+            errs.append(
+                "loss_confirmation_window_seconds must be in [0.05, 30] "
+                f"(got {self.loss_confirmation_window_seconds})"
+            )
+
+        if errs:
+            raise ConfigError(
+                "invalid session configuration:\n  - " + "\n  - ".join(errs)
+            )
+
+
+# ---------------------------------------------------------------------------
+# Serialization helpers
+# ---------------------------------------------------------------------------
+
+def config_to_dict(config: "SessionConfig") -> "dict[str, Any]":
+    """Serialize *config* to a plain JSON-compatible dict."""
+    return {
+        "config_version": config.config_version,
+        "tag": config.tag,
+        "source": {
+            "kind": config.source.kind,
+            "role": config.source.role.name,
+            "params": dict(config.source.params),
+        },
+        "label": config.label,
+        "output_dir": config.output_dir,
+        "expect_crc": config.expect_crc,
+        "plot_window_seconds": config.plot_window_seconds,
+        "bandwidth_window_seconds": config.bandwidth_window_seconds,
+        "loss_confirmation_window_seconds": config.loss_confirmation_window_seconds,
+        "layout_state": dict(config.layout_state),
+    }
+
+
+def config_from_dict(d: "dict[str, Any]") -> "SessionConfig":
+    """Reconstruct a :class:`SessionConfig` from a serialized dict."""
+    s = d["source"]
+    return SessionConfig(
+        tag=d["tag"],
+        source=SourceSpec(
+            kind=s["kind"],
+            role=RoleMode[s.get("role", "LISTENER")],
+            params=dict(s.get("params", {})),
+        ),
+        label=str(d.get("label", "")),
+        output_dir=str(d.get("output_dir", "")),
+        expect_crc=bool(d.get("expect_crc", True)),
+        plot_window_seconds=float(d.get("plot_window_seconds", 10.0)),
+        bandwidth_window_seconds=float(d.get("bandwidth_window_seconds", 10.0)),
+        loss_confirmation_window_seconds=float(
+            d.get("loss_confirmation_window_seconds", 1.0)
+        ),
+        layout_state=dict(d.get("layout_state", {})),
+        config_version=int(d.get("config_version", 2)),
+    )

--- a/tools/data_forwarder_host/session/controller.py
+++ b/tools/data_forwarder_host/session/controller.py
@@ -1,0 +1,1005 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""SessionController — wires the session state machine, data model, recorder,
+error log and CSV output for a single forwarding session.
+
+There is no sink subsystem and no backend/frontend separation: the
+:class:`~data_forwarder_host.session.forwarding.ForwardingSession` owns the I/O
+worker directly and is the sole writer of ``SessionState``.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+import uuid
+from collections import deque
+from dataclasses import replace as dc_replace
+from pathlib import Path
+from time import monotonic
+
+from PySide6.QtCore import QObject, QTimer, Signal, Slot
+
+from data_forwarder_host.core.csv_writer import RecordingCsvDump, write_recording_csv
+from data_forwarder_host.core.bandwidth import BandwidthMeter, BandwidthSample
+from data_forwarder_host.core.data_model import DataModel
+from data_forwarder_host.core.error_log import ErrorCategory, ErrorLog
+from data_forwarder_host.core.metadata import build_metadata_text
+from data_forwarder_host.core.recorder import CsvDumpJob, Recorder, Recording
+from data_forwarder_host.core.sequence_tracker import SequenceGapTracker
+from data_forwarder_host.protocol.base import DecodedMessage
+from data_forwarder_host.protocol.cobs_cbor_v1 import CobsCborV1
+from data_forwarder_host.session.config import SessionConfig
+from data_forwarder_host.session.forwarding import ForwardingSession
+from data_forwarder_host.session.states import SessionState
+from data_forwarder_host.utils.debug_stream import DebugStream, debug_stream_enabled
+from data_forwarder_host.source import source_for_kind
+from data_forwarder_host.utils.paths import default_recordings_dir
+from data_forwarder_host.utils.slow_span import slow_span
+log = logging.getLogger(__name__)
+
+# A confirmed-loss batch with at most this many sequence numbers is journalled
+# one entry per number (useful diagnostic detail); larger batches collapse into
+# a single coalesced summary event so a transport flood cannot stall the GUI by
+# emitting thousands of journal entries at once.
+_TRANSPORT_LOSS_DETAIL_LIMIT = 64
+
+# A confirmed sequence-gap is recorded as a TRANSPORT loss immediately (so the
+# event journal stays truthful), but it is held out of the *Host BT* pipeline
+# attribution for this long so the producer-side drop count ("dr", which arrives
+# asynchronously in a later session_info) has time to catch up. Without the hold
+# a device-caused drop briefly shows under Host BT and then jumps to the Device
+# stage once "dr" updates; the hold lets the host-vs-device split settle first.
+_LOSS_RECONCILE_WINDOW_S = 2.0
+
+
+class SessionController(QObject):
+    """Façade for one forwarding session, exposing Qt signals for the GUI."""
+
+    # --- Public Qt signals (GUI widgets subscribe to these) ---
+    state_changed = Signal(object)              # SessionState
+    message_received = Signal(object)           # DecodedMessage
+    error_occurred = Signal(str)
+    recording_changed = Signal(bool)            # is_recording
+    recording_saved = Signal(str)               # path to written CSV
+    recording_save_started = Signal()           # CSV dump began (lock buttons)
+    recording_save_progress = Signal(int, int)  # rows_written, total (-1 if unknown)
+    recording_save_failed = Signal(str)         # CSV dump error message
+    recording_empty = Signal()                  # recording had zero sensor rows
+    session_info_received = Signal(object)      # raw session-info envelope
+    session_info_mismatch = Signal(str, bool)   # detail, has_buffered_data
+    session_phase_changed = Signal(str)         # created/awaiting/ready/recording/...
+    stats_updated = Signal(object)              # DecodeStats
+    raw_bytes_received = Signal(bytes)          # raw chunk as received
+    bandwidth_window_changed = Signal(float)    # effective bandwidth window (s)
+    session_sampling_changed = Signal(float, int)  # hz, channel count (session_info)
+
+    def __init__(
+        self,
+        config: SessionConfig,
+        parent: QObject | None = None,
+        prepared_source: object | None = None,
+        use_process: bool = False,
+    ) -> None:
+        super().__init__(parent)
+        config.validate()
+        self._id = uuid.uuid4().hex[:8]
+        self._config = config
+
+        # ErrorLog first — all other components bind to it.
+        self.error_log = ErrorLog(self)
+
+        # DataModel: rolling GUI-side buffers for live plots (GUI thread only).
+        self.data_model = DataModel(
+            plot_window_seconds=config.plot_window_seconds,
+            error_log=self.error_log,
+            parent=self,
+        )
+
+        # Recorder: RAM-first + spill-to-disk capture (gated on recording).
+        self.recorder = Recorder(
+            session_id=self._id,
+            session_tag=config.tag,
+            error_log=self.error_log,
+            parent=self,
+        )
+        self.recorder.started.connect(lambda: self.recording_changed.emit(True))
+        self.recorder.stopped.connect(lambda _r: self.recording_changed.emit(False))
+        # Cap idle live-buffer retention while not recording.
+        self.recorder.started.connect(lambda: self.data_model.set_recording(True))
+        self.recorder.stopped.connect(
+            lambda _r: self.data_model.set_recording(False)
+        )
+
+        # Source + decoder + forwarding session (single fixed protocol).
+        # A *prepared_source* is a live source already opened in the New Session
+        # dialog (connection / port reservation happens there, not at start);
+        # the freshly created session adopts it. Reopened/saved sessions get a
+        # fresh source rebuilt from the serializable config and (re)connect at
+        # start.
+        #
+        # In out-of-process mode acquisition runs in a
+        # separate OS process that rebuilds the source from the config, so no
+        # GUI-side source is built. Any prepared_source must be released first
+        # so the child can reopen the same port/device.
+        if use_process:
+            if prepared_source is not None:
+                try:
+                    prepared_source.close()
+                except Exception:
+                    log.exception("failed to release prepared source for process mode")
+            source = None
+        elif prepared_source is not None:
+            source = prepared_source
+        else:
+            source_cls = source_for_kind(config.source.kind)
+            source = source_cls(**config.source.params)
+        decoder = CobsCborV1(expect_crc=config.expect_crc)
+        self._session = ForwardingSession(
+            config=config,
+            source=source,
+            decoder=decoder,
+            error_log=self.error_log,
+            parent=self,
+            use_process=use_process,
+        )
+        # IoWorker runs in a QThread; these connections are delivered to the
+        # GUI thread via QueuedConnection automatically.
+        self._session.state_changed.connect(self._on_state_changed)
+        self._session.message_received.connect(self._process_message)
+        self._session.error_occurred.connect(self.error_occurred)
+        self._session.stats_updated.connect(self.stats_updated)
+        self._session.raw_bytes.connect(self.raw_bytes_received)
+        # Out-of-process path reports raw bytes as a count, not the payload.
+        self._session.raw_byte_count.connect(self._on_raw_byte_count_for_bandwidth)
+
+        # Live throughput meter over a trailing window. Fed with raw
+        # received byte counts and decoded sensor_data message events.
+        self.bandwidth = BandwidthMeter(config.bandwidth_window_seconds)
+        self.raw_bytes_received.connect(self._on_raw_bytes_for_bandwidth)
+
+        # Transport message-loss detector: watches sensor_data
+        # sequence numbers and confirms a gap as a TRANSPORT loss only if the
+        # missing number has not arrived within the loss confirmation window.
+        self._seq_tracker = SequenceGapTracker(
+            window_seconds=config.loss_confirmation_window_seconds,
+            on_loss=self._on_transport_loss,
+        )
+        # Sweep on a timer so pending losses are confirmed even when the stream
+        # pauses; cadence is a fraction of the window (clamped to a sane range).
+        self._seq_sweep_timer = QTimer(self)
+        self._seq_sweep_timer.timeout.connect(self._seq_sweep_tick)
+        self._apply_seq_sweep_interval()
+        self._seq_sweep_timer.start()
+        # Aggregate transport losses already surfaced (see _flush_untracked_losses).
+        self._untracked_loss_reported: int = 0
+        # Reconcile hold for Host-BT attribution: every confirmed TRANSPORT loss
+        # is parked here with the time it was confirmed and the device-drop
+        # observation epoch at that moment. A parked loss is only "released" into
+        # the Host-BT-attributed total once a newer device-drop ("dr") reading
+        # has arrived (the producer-drop information covering that gap's period
+        # is now in hand), so a device-caused drop is netted onto the Device
+        # stage without ever flashing under Host BT. When the device never
+        # reports "dr" there is nothing to reconcile against, so the reconcile
+        # window acts as a time-based fallback instead. ``_loss_clock`` is
+        # injectable so the fallback can be driven deterministically.
+        self._loss_clock = monotonic
+        self._transport_loss_pending: deque[tuple[float, int, int]] = deque()
+        self._transport_loss_released: int = 0
+        # Monotonic count of valid device-drop readings observed via session_info;
+        # gates the reconcile release above. Never reset, so it cannot run
+        # backwards and strand a parked loss.
+        self._dr_observation_epoch: int = 0
+
+        # Recording-stop CSV dump runs incrementally off the event loop so a
+        # large save never freezes the GUI. While a dump is in flight
+        # the Record/Stop buttons stay locked.
+        self._csv_dump_job: CsvDumpJob | None = None
+        self._saving_csv: bool = False
+        # Tracks whether automatic cyclic GC was paused for the current
+        # recording so it is resumed exactly once, on whichever stop path runs.
+        self._gc_suspended_for_recording: bool = False
+
+        self._session_info_baseline: dict | None = None
+        self._expected_channel_count: int | None = None
+        # Latest sampling rate (Hz) and channel count from session_info. Updated
+        # on every valid session_info so it tracks a varying producer frequency.
+        self._latest_sampling: tuple[float, int] | None = None
+        self._metadata_ready: bool = False
+        self._record_on_metadata_pending: bool = False
+        self._pending_mismatch_recording: Recording | None = None
+        # Baseline of the producer-side drop count ("dr"); captured from the
+        # first valid session_info so its real-time delta can be surfaced as a
+        # PRODUCER_DROP statistic without treating it as a session mismatch.
+        # ``_dr_baseline`` anchors the cumulative-since-startup figure
+        # (PRODUCER_DROP_TOTAL); ``_dr_reset_baseline`` anchors the since-reset
+        # figure (PRODUCER_DROP) and is re-anchored at each reset moment.
+        self._dr_baseline: int | None = None
+        self._dr_latest: int | None = None
+        self._dr_reset_baseline: int | None = None
+        self._phase: str = "created"
+        self.session_phase_changed.emit(self._phase)
+
+        # Opt-in, rate-limited diagnostics stream (off unless DFH_DEBUG_STREAM is
+        # set). Surfaces the metrics that drive long-run slowdowns so the root
+        # cause can be confirmed from logs without a heavy on-screen panel.
+        self._debug_stream: DebugStream | None = None
+        if debug_stream_enabled():
+            self._debug_stream = DebugStream(self._debug_metrics, parent=self)
+            self._debug_stream.start()
+
+    def _debug_metrics(self) -> dict:
+        """Snapshot the runtime metrics that drive long-run slowdowns."""
+        gc0, gc1, gc2 = gc.get_count()
+        return {
+            "tag": self._config.tag,
+            "rec": int(self.recorder.is_recording()),
+            "spill": int(self.recorder.using_spill),
+            "ram_rows": self.recorder.buffered_rows,
+            "ram_mb": round(self.recorder.buffered_bytes / 1e6, 1),
+            "buf_max": self.data_model.max_buffer_size,
+            "msg_s": round(
+                self.bandwidth.sample(
+                    self.data_model.channel_count
+                ).messages_per_second,
+                1,
+            ),
+            "gc0": gc0,
+            "gc1": gc1,
+            "gc2": gc2,
+            "dropped": self._session.dropped_frames(),
+            "inbox": self._session.inbox_pending(),
+            "tick_gap_ms": round(self._session.drain_gap_ms(), 1),
+        }
+
+    # ------------------------------------------------------------------
+    # Identity
+    # ------------------------------------------------------------------
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def config(self) -> SessionConfig:
+        return self._config
+
+    def current_config(self) -> SessionConfig:
+        """Return a config snapshot reflecting the current plot/bandwidth windows."""
+        return dc_replace(
+            self._config,
+            plot_window_seconds=self.data_model.plot_window_seconds,
+            bandwidth_window_seconds=self.bandwidth.window_seconds,
+        )
+
+    def set_label(self, label: str) -> None:
+        """Update the recording label (gates the Record action)."""
+        self._config = dc_replace(self._config, label=label)
+
+    def set_output_dir(self, output_dir: str) -> None:
+        self._config = dc_replace(self._config, output_dir=output_dir)
+
+    def set_bandwidth_window_seconds(self, seconds: float) -> None:
+        """Update the live bandwidth measurement window.
+
+        The bandwidth window starts equal to the plot window at session
+        creation and is adjustable from the session window or the bandwidth
+        details sub-window; the change is broadcast via
+        :attr:`bandwidth_window_changed` so both controls stay in sync.
+        """
+        seconds = float(seconds)
+        if seconds == self.bandwidth.window_seconds:
+            return
+        self.bandwidth.set_window_seconds(seconds)
+        self.bandwidth_window_changed.emit(self.bandwidth.window_seconds)
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    def state(self) -> SessionState:
+        return self._session.state()
+
+    def is_recording(self) -> bool:
+        return self.recorder.is_recording()
+
+    def is_saving(self) -> bool:
+        """True while a recording-stop CSV dump is still being written."""
+        return self._saving_csv
+
+    def dropped_frames(self) -> int:
+        """Frames dropped by the host in-flight gate under overload."""
+        return self._session.dropped_frames()
+
+    def can_record(self) -> bool:
+        """Record action is enabled only when a valid label is defined (G4)."""
+        return self._config.has_recording_label()
+
+    def metadata_ready(self) -> bool:
+        return self._metadata_ready
+
+    def can_begin_recording(self) -> bool:
+        return self.can_record() and self._metadata_ready
+
+    def session_phase(self) -> str:
+        return self._phase
+
+    def describe_source(self) -> str:
+        return self._session.describe_source()
+
+    def describe_protocol(self) -> str:
+        return self._session.describe_protocol()
+
+    def bandwidth_sample(self) -> BandwidthSample:
+        """Return the current throughput rates over the configured window."""
+        return self.bandwidth.sample(self.data_model.channel_count)
+
+    def latest_sampling_info(self) -> tuple[float, int] | None:
+        """Latest ``(sampling_rate_hz, channel_count)`` from session_info, if any."""
+        return self._latest_sampling
+
+    def loss_confirmation_window_seconds(self) -> float:
+        """Current transport loss confirmation window (seconds)."""
+        return self._seq_tracker.window_seconds
+
+    def set_loss_confirmation_window_seconds(self, seconds: float) -> None:
+        """Change the transport loss confirmation window live."""
+        if seconds <= 0:
+            return
+        self._config = dc_replace(
+            self._config, loss_confirmation_window_seconds=float(seconds)
+        )
+        self._seq_tracker.set_window_seconds(float(seconds))
+        self._apply_seq_sweep_interval()
+
+    def _apply_seq_sweep_interval(self) -> None:
+        """Sweep at a quarter of the window, clamped to [50, 1000] ms."""
+        ms = int(self._seq_tracker.window_seconds * 1000 / 4)
+        self._seq_sweep_timer.setInterval(max(50, min(1000, ms)))
+
+    def _seq_sweep_tick(self) -> None:
+        """Timer slot: confirm due losses, then flush any aggregate overflow.
+
+        Under extreme sustained loss the detector caps how many missing numbers
+        it tracks individually; the surplus is counted in aggregate. We surface
+        that surplus here as coalesced TRANSPORT losses so the totals stay
+        truthful without the per-frame cost or unbounded memory that tracking
+        every number individually would impose.
+        """
+        self._seq_tracker.sweep()
+        self._flush_untracked_losses()
+        self._release_reconciled_losses()
+
+    def _hold_transport_loss(self, count: int) -> None:
+        """Park ``count`` confirmed losses for device-drop reconciliation.
+
+        The losses are recorded as TRANSPORT events immediately elsewhere; this
+        only defers when they become attributable to the Host BT stage. Each
+        batch is tagged with the current device-drop observation epoch so it can
+        be released once a newer ``dr`` reading has had a chance to claim it.
+        """
+        if count > 0:
+            self._transport_loss_pending.append(
+                (self._loss_clock(), count, self._dr_observation_epoch)
+            )
+
+    def _release_reconciled_losses(self) -> None:
+        """Release parked losses the device-drop count has had a chance to claim.
+
+        While the device reports ``dr`` a batch is released only once a newer
+        ``dr`` observation has arrived (``epoch`` advanced past the batch's parked
+        epoch), so a device-caused gap nets onto the Device stage instead of
+        flashing under Host BT. When the device never reports ``dr`` there is
+        nothing to reconcile against, so the fixed reconcile window is used as a
+        fallback. Entries are FIFO and both the epoch and the timestamp are
+        non-decreasing along the queue, so a stop at the head stops the sweep.
+        """
+        now = self._loss_clock()
+        epoch = self._dr_observation_epoch
+        reconciled_against_drops = self._dr_baseline is not None
+        pending = self._transport_loss_pending
+        while pending:
+            confirmed_at, count, parked_epoch = pending[0]
+            if reconciled_against_drops:
+                if epoch <= parked_epoch:
+                    break
+            elif now - confirmed_at < _LOSS_RECONCILE_WINDOW_S:
+                break
+            self._transport_loss_released += count
+            pending.popleft()
+
+    def host_attributed_transport_loss(self) -> int:
+        """Confirmed TRANSPORT losses the device-drop count has had a chance to claim.
+
+        Recently confirmed losses are withheld from the Host BT pipeline figure
+        until a newer producer-drop (``dr``) reading has arrived to claim any
+        device-caused gaps (or, for sources without ``dr``, until the reconcile
+        window elapses); the raw TRANSPORT event total is unaffected.
+        """
+        self._release_reconciled_losses()
+        return self._transport_loss_released
+
+    def producer_drop_count(self) -> int:
+        """Live since-reset producer-drop count (the ``dr`` delta).
+
+        Mirrors the ``PRODUCER_DROP`` statistic but without the error summary's
+        1 Hz coalescing, so the bandwidth pipeline view nets Host-BT loss against
+        the same up-to-date device-drop figure that gates the reconcile release —
+        preventing a device drop from briefly showing under Host BT while the
+        coalesced summary catches up.
+        """
+        if self._dr_latest is None or self._dr_baseline is None:
+            return 0
+        reset_base = (
+            self._dr_reset_baseline
+            if self._dr_reset_baseline is not None
+            else self._dr_baseline
+        )
+        return self._dr_latest - reset_base
+
+    def _flush_untracked_losses(self) -> None:
+        total = self._seq_tracker.untracked_loss_count
+        delta = total - self._untracked_loss_reported
+        if delta <= 0:
+            return
+        self._untracked_loss_reported = total
+        self.error_log.add_bulk(
+            ErrorCategory.TRANSPORT,
+            delta,
+            f"{delta} sensor_data frame(s) confirmed lost in aggregate under "
+            "heavy transport loss (exceeded the loss-tracker capacity)",
+        )
+        self._hold_transport_loss(delta)
+
+    def _on_transport_loss(self, seqs: list[int]) -> None:
+        """Record confirmed missing sequence numbers as TRANSPORT losses.
+
+        Reporting is coalesced: a single confirmation can carry many sequence
+        numbers (up to the loss tracker's bounded capacity), and emitting one
+        journal event per number would itself stall the GUI. A small batch is
+        logged number-by-number for diagnostic detail; a large batch collapses
+        into one summary event while still advancing the loss count correctly.
+        """
+        n = len(seqs)
+        if n == 0:
+            return
+        if n <= _TRANSPORT_LOSS_DETAIL_LIMIT:
+            with slow_span("transport_loss.fanout", extra=f"n={n}"):
+                for seq in seqs:
+                    self.error_log.add(
+                        ErrorCategory.TRANSPORT,
+                        f"sensor_data sequence {seq} not received within the loss "
+                        f"confirmation window ({self._seq_tracker.window_seconds:g} s)",
+                        seq=seq,
+                    )
+            self._hold_transport_loss(n)
+            return
+        lo, hi = seqs[0], seqs[-1]
+        self.error_log.add_bulk(
+            ErrorCategory.TRANSPORT,
+            n,
+            f"{n} sensor_data frames not received within the loss confirmation "
+            f"window ({self._seq_tracker.window_seconds:g} s); "
+            f"sequence range {lo}..{hi}",
+        )
+        self._hold_transport_loss(n)
+
+    # ------------------------------------------------------------------
+    # User commands
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Open the device channel and start streaming/listening.
+
+        This is invoked automatically when the session tab opens so the
+        device channel is reserved and ``session_info`` is observed without
+        waiting for the user to press Record. Recording (CSV capture) is a
+        separate action started via :meth:`start_recording`.
+        """
+        self.data_model.clear()
+        self._session_info_baseline = None
+        self._expected_channel_count = None
+        self._metadata_ready = False
+        self._pending_mismatch_recording = None
+        self._record_on_metadata_pending = False
+        self._dr_baseline = None
+        self._dr_latest = None
+        self._dr_reset_baseline = None
+        self._session.start()
+        self._set_phase("awaiting device metadata")
+
+    def stop(self) -> None:
+        """Stop the I/O session (auto-stops an active recording first)."""
+        self._set_phase("stopping")
+        if self.is_recording():
+            try:
+                self.stop_recording()
+            except Exception:
+                log.exception("auto stop_recording on stop() failed")
+        self._session.stop()
+        self._record_on_metadata_pending = False
+
+    def reset(self) -> None:
+        """Return from ERROR to CONFIGURED."""
+        self._session.reset()
+        self._set_phase("created")
+
+    @Slot(object)
+    def _on_state_changed(self, state: SessionState) -> None:
+        self.state_changed.emit(state)
+        if state == SessionState.RUNNING:
+            # A fresh stream: forget any stale sequence baseline so the first
+            # message of the new run only sets the baseline (no spurious losses).
+            self._seq_tracker.reset()
+            if self.is_recording():
+                self._set_phase("recording")
+            elif self._metadata_ready:
+                self._set_phase("ready to record")
+            else:
+                self._set_phase("awaiting device metadata")
+        elif state == SessionState.STOPPED:
+            self._set_phase("closed")
+        elif state == SessionState.ERROR:
+            self._set_phase("closed")
+        elif state == SessionState.CONFIGURED:
+            self._set_phase("created")
+        # If the source halted on its own while recording, finalise.
+        if state in (SessionState.STOPPED, SessionState.ERROR) and self.is_recording():
+            log.warning("session halted (state=%s) while recording; auto-stopping", state)
+            try:
+                self.stop_recording()
+            except Exception:
+                log.exception("auto stop_recording after halt failed")
+
+    # ------------------------------------------------------------------
+    # Recording
+    # ------------------------------------------------------------------
+
+    def start_recording(self) -> None:
+        """Begin recording to RAM/disk. Requires a valid label."""
+        if not self.can_record():
+            raise RuntimeError("a recording label must be defined before recording")
+        if not self._metadata_ready:
+            raise RuntimeError("session metadata not received yet")
+        # Clear stale error statistics so this recording's panel shows only
+        # events that happen during the new capture.
+        self.error_log.clear()
+        # Recording start is a reset moment: the error log was just cleared, so
+        # every category restarts from zero. The producer drop count is split in
+        # two — PRODUCER_DROP_TOTAL preserves the cumulative-since-startup figure
+        # while the since-reset PRODUCER_DROP restarts from zero at
+        # this reset moment.
+        self._mark_producer_drop_reset()
+        self.recorder.start(channel_names=self.data_model.channel_names)
+        # Pause automatic cyclic GC for the capture window so the growing
+        # recorder heap is not repeatedly rescanned (see
+        # _suspend_gc_for_recording).
+        self._suspend_gc_for_recording()
+        # Arm the chart marker so the next recorded sample fixes the start
+        # moment on the live plots.
+        self.data_model.begin_recording_marker()
+        self._set_phase("recording")
+
+    def stop_recording(self) -> Recording:
+        """Finalise the current recording and write the CSV file.
+
+        The CSV is written incrementally off the event loop: this
+        returns as soon as capture has stopped, having *started* the dump; the
+        ``recording_save_started`` / ``recording_save_progress`` /
+        ``recording_saved`` / ``recording_save_failed`` signals report its
+        lifecycle so the GUI can show a progress bar and keep the Record/Stop
+        buttons locked until the save completes.
+        """
+        self._set_phase("stopping")
+        rec = self.recorder.stop()
+        # Capture has ended: re-enable automatic GC and reclaim any cycles
+        # created during the window (idempotent across every stop path).
+        self._resume_gc_after_recording()
+        self.data_model.end_recording_marker()
+        if not self._recording_has_rows(rec):
+            self.recording_empty.emit()
+            if self.state() == SessionState.RUNNING and self._metadata_ready:
+                self._set_phase("ready to record")
+            return rec
+        self._start_csv_dump(rec)
+        return rec
+
+    def _suspend_gc_for_recording(self) -> None:
+        """Pause automatic cyclic GC for the duration of a recording.
+
+        The recorder accumulates a large, steadily growing heap of GC-tracked
+        row tuples while capturing. With automatic generational collection left
+        on, every generation-2 pass rescans that whole growing heap, producing
+        latency spikes that get worse the longer the recording runs. Suspending
+        automatic collection for the bounded recording window removes those
+        rescans; it is re-enabled (with a manual collection to reclaim any
+        cycles created in the window) when the recording ends. Idempotent, and
+        only takes ownership when GC was actually enabled to begin with.
+
+        This targets recording-time GC overhead specifically; it does not affect
+        GUI-consumer or chart-render cost while no recording is in progress.
+        """
+        if self._gc_suspended_for_recording:
+            return
+        if gc.isenabled():
+            gc.disable()
+            self._gc_suspended_for_recording = True
+
+    def _resume_gc_after_recording(self) -> None:
+        """Re-enable automatic GC after a recording and reclaim any cycles.
+
+        Safe to call on every recording-end path (normal stop, cancel, and the
+        auto-stop on a session halt); a no-op when GC was not suspended, so GC
+        is never left disabled once no recording is active.
+        """
+        if not self._gc_suspended_for_recording:
+            return
+        self._gc_suspended_for_recording = False
+        gc.enable()
+        gc.collect()
+
+    def _start_csv_dump(self, rec: Recording) -> None:
+        """Begin a non-blocking CSV dump of *rec*."""
+        output_dir = self._config.output_dir or str(default_recordings_dir())
+        try:
+            dump = RecordingCsvDump(
+                rec,
+                label=self._config.label,
+                output_dir=output_dir,
+                metadata_text=self._build_metadata_text(rec),
+            )
+        except Exception as exc:
+            log.exception("failed to start recording CSV dump")
+            self.error_occurred.emit(f"failed to write CSV: {exc}")
+            self._finish_save_phase()
+            return
+        job = CsvDumpJob(dump, parent=self)
+        self._csv_dump_job = job
+        self._saving_csv = True
+        job.progress.connect(self.recording_save_progress)
+        job.finished.connect(self._on_csv_dump_finished)
+        job.failed.connect(self._on_csv_dump_failed)
+        self.recording_save_started.emit()
+        job.start()
+
+    @Slot(str)
+    def _on_csv_dump_finished(self, path: str) -> None:
+        self._csv_dump_job = None
+        self._saving_csv = False
+        self.recording_saved.emit(path)
+        self._finish_save_phase()
+
+    @Slot(str)
+    def _on_csv_dump_failed(self, message: str) -> None:
+        self._csv_dump_job = None
+        self._saving_csv = False
+        log.error("recording CSV dump failed: %s", message)
+        self.error_occurred.emit(f"failed to write CSV: {message}")
+        self.recording_save_failed.emit(message)
+        self._finish_save_phase()
+
+    def _finish_save_phase(self) -> None:
+        if self.state() == SessionState.RUNNING and self._metadata_ready:
+            self._set_phase("ready to record")
+
+    @staticmethod
+    def _recording_has_rows(rec: Recording) -> bool:
+        for _ in rec.storage.iter_rows():
+            return True
+        return False
+
+    def _write_csv(self, rec: Recording) -> Path:
+        output_dir = self._config.output_dir or str(default_recordings_dir())
+        return write_recording_csv(
+            rec,
+            label=self._config.label,
+            output_dir=output_dir,
+            metadata_text=self._build_metadata_text(rec),
+        )
+
+    def _build_metadata_text(self, rec: Recording) -> str | None:
+        """Render the ``.txt`` session-metadata sidecar for *rec* (best-effort).
+
+        Bundles transport/device, host OS/timestamps, ``session_info`` and the
+        channel/error layout so the CSV ships with a self-describing companion.
+        A failure here must never block the CSV dump, so it degrades to *None*.
+        """
+        try:
+            return build_metadata_text(
+                rec,
+                label=self._config.label,
+                source_kind=self._config.source.kind,
+                source_params=dict(self._config.source.params),
+                source_description=self._session.describe_source(),
+                protocol_description=self._session.describe_protocol(),
+            )
+        except Exception:
+            log.exception("failed to build recording metadata sidecar")
+            return None
+
+    def cancel_recording(self) -> None:
+        """Stop the current recording WITHOUT writing a CSV and drop its data."""
+        if self.is_recording():
+            try:
+                self.recorder.stop()
+            except Exception:
+                log.exception("recorder.stop() during cancel failed")
+        self._resume_gc_after_recording()
+        # A cancelled recording produced no saved file, so remove both markers
+        # rather than leaving a start/stop pair on the charts.
+        self.data_model.clear_recording_markers()
+        self.recorder.cleanup_spill()
+        if self.state() == SessionState.RUNNING and self._metadata_ready:
+            self._set_phase("ready to record")
+
+    def save_pending_mismatch_recording(self) -> Path | None:
+        rec = self._pending_mismatch_recording
+        if rec is None:
+            return None
+        path = self._write_csv(rec)
+        self.recording_saved.emit(str(path))
+        self._pending_mismatch_recording = None
+        return path
+
+    def drop_pending_mismatch_recording(self) -> None:
+        self._pending_mismatch_recording = None
+        self.recorder.cleanup_spill()
+
+    def shutdown(self) -> None:
+        """Shut down the recorder and session cleanly."""
+        self._set_phase("closing")
+        try:
+            if self.is_recording():
+                self.stop_recording()
+        finally:
+            self._session.shutdown()
+
+    # ------------------------------------------------------------------
+    # GUI-thread message processing
+    # ------------------------------------------------------------------
+
+    @Slot(bytes)
+    def _on_raw_bytes_for_bandwidth(self, chunk: bytes) -> None:
+        self.bandwidth.add_bytes(len(chunk))
+
+    @Slot(int)
+    def _on_raw_byte_count_for_bandwidth(self, n_bytes: int) -> None:
+        self.bandwidth.add_bytes(int(n_bytes))
+
+    @Slot(object)
+    def _process_message(self, msg: DecodedMessage) -> None:
+        """Update DataModel and Recorder — always on the GUI thread."""
+        if msg.kind == "session_info":
+            # Establish/validate the metadata baseline FIRST so that any slot
+            # connected to session_info_received observes the up-to-date
+            # metadata_ready / phase state.
+            self._process_session_info(msg)
+            self.session_info_received.emit(msg.raw)
+            # Propagate the validated metadata to the live plots so charts are
+            # labelled with the device channel names (ch_n), not generic ch0/ch1.
+            if self._metadata_ready:
+                self.data_model.on_message(msg)
+            self.recorder.set_session_info(msg.raw, self.data_model.channel_names)
+            self.message_received.emit(msg)
+            return
+
+        if msg.kind == "sensor_data":
+            if not self._validate_sensor_data(msg):
+                self.message_received.emit(msg)
+                return
+            with slow_span("process_message.bandwidth"):
+                with slow_span("process_message.bw.meter"):
+                    self.bandwidth.add_message()
+                # Feed the transport-loss detector with this message's sequence
+                # number so missing numbers can be confirmed after the grace
+                # window. The observe() call also sweeps due losses, which can
+                # synchronously fan out error events — measured separately so a
+                # slow span here is attributable, not assumed.
+                with slow_span("process_message.bw.seq_observe"):
+                    self._seq_tracker.observe(msg.seq)
+
+        with slow_span("process_message.data_model"):
+            self.data_model.on_message(msg)
+        with slow_span("process_message.recorder"):
+            self.recorder.on_message(msg)
+        with slow_span("process_message.emit"):
+            self.message_received.emit(msg)
+
+    def _process_session_info(self, msg: DecodedMessage) -> None:
+        normalized = self._normalize_session_info(msg.raw)
+        if normalized is None:
+            self.error_log.add(
+                ErrorCategory.SESSION_INFO_INVALID,
+                "invalid session_info payload (missing required fields or invalid ch_n)",
+            )
+            return
+
+        # Track the producer-side drop count ("dr"). It legitimately increments
+        # over the session, so it is excluded from the mismatch comparison and
+        # instead surfaced as a real-time PRODUCER_DROP delta.
+        self._track_drop_count(msg.raw)
+
+        # Surface the sampling rate (Hz) and channel count to interested views
+        # (e.g. the bandwidth details window). Re-emitted on every valid
+        # session_info so a varying producer frequency is reflected live.
+        hz = float(normalized["d"]["hz"])
+        ch_count = len(normalized["d"]["ch_n"])
+        sampling = (hz, ch_count)
+        if sampling != self._latest_sampling:
+            self._latest_sampling = sampling
+            self.session_sampling_changed.emit(hz, ch_count)
+
+        if self._session_info_baseline is None:
+            self._session_info_baseline = normalized
+            self._metadata_ready = True
+            self._expected_channel_count = len(normalized["d"]["ch_n"])
+            if self.state() == SessionState.RUNNING and not self.is_recording():
+                self._set_phase("ready to record")
+            if (
+                self._record_on_metadata_pending
+                and self.state() == SessionState.RUNNING
+                and not self.is_recording()
+                and self.can_begin_recording()
+            ):
+                try:
+                    self.start_recording()
+                    self._record_on_metadata_pending = False
+                except Exception as exc:
+                    log.exception("auto start_recording on session_info failed")
+                    self.error_occurred.emit(f"could not start recording: {exc}")
+            return
+
+        if normalized != self._session_info_baseline:
+            # Only a change to the session identity (sid) or the channel set
+            # (ch_n) terminates the session; all other fields (hz, st, name, …)
+            # may vary and merely update the read-only Session Info display.
+            # dr is already excluded upstream.
+            if self._critical_identity(normalized) != self._critical_identity(
+                self._session_info_baseline
+            ):
+                self._handle_session_info_mismatch()
+            else:
+                # Non-critical drift: adopt the new values as the live baseline
+                # so the displayed metadata reflects the latest device payload.
+                self._session_info_baseline = normalized
+
+    @staticmethod
+    def _critical_identity(normalized: dict) -> tuple:
+        """Return the (sid, ch_n) pair that must stay constant."""
+        d = normalized.get("d", {}) if isinstance(normalized, dict) else {}
+        return (d.get("sid"), tuple(d.get("ch_n", ())))
+
+    def _track_drop_count(self, raw: dict) -> None:
+        """Record the real-time delta of the producer ``dr`` drop count.
+
+        The first valid value establishes the baseline; every subsequent value
+        updates the absolute ``PRODUCER_DROP`` count to ``dr - baseline`` so the
+        Error & Loss Analysis reflects drops accumulated since startup.
+        """
+        d = raw.get("d") if isinstance(raw, dict) else None
+        if not isinstance(d, dict):
+            return
+        dr = d.get("dr")
+        if not isinstance(dr, int) or isinstance(dr, bool):
+            return
+        if self._dr_baseline is None:
+            self._dr_baseline = dr
+        if self._dr_reset_baseline is None:
+            self._dr_reset_baseline = dr
+        self._dr_latest = dr
+        # A fresh device-drop reading: any device-caused gap up to this point is
+        # now reflected in ``dr``, so parked Host-BT losses may be reconciled.
+        self._dr_observation_epoch += 1
+        self._refresh_producer_drop_counts()
+
+    def _mark_producer_drop_reset(self) -> None:
+        """Re-anchor the since-reset producer-drop figure at a reset moment.
+
+        The cumulative ``PRODUCER_DROP_TOTAL`` is unaffected; the since-reset
+        ``PRODUCER_DROP`` restarts from zero at the latest observed drop count.
+        """
+        if self._dr_latest is not None:
+            self._dr_reset_baseline = self._dr_latest
+        self._refresh_producer_drop_counts()
+
+    def _refresh_producer_drop_counts(self) -> None:
+        """Update both producer drop-count statistics from the latest ``dr``.
+
+        ``PRODUCER_DROP_TOTAL`` is ``dr - startup_baseline`` (cumulative since
+        the session started); ``PRODUCER_DROP`` is
+        ``dr - reset_baseline`` (since the last reset moment).
+        """
+        if self._dr_latest is None or self._dr_baseline is None:
+            return
+        reset_base = (
+            self._dr_reset_baseline
+            if self._dr_reset_baseline is not None
+            else self._dr_baseline
+        )
+        self.error_log.set_count(
+            ErrorCategory.PRODUCER_DROP_TOTAL, self._dr_latest - self._dr_baseline
+        )
+        self.error_log.set_count(
+            ErrorCategory.PRODUCER_DROP, self._dr_latest - reset_base
+        )
+
+    def _handle_session_info_mismatch(self) -> None:
+        detail = (
+            "session_info changed after baseline was established; "
+            "session is being terminated"
+        )
+        self.error_log.add(ErrorCategory.SESSION_INFO_MISMATCH, detail)
+        self._record_on_metadata_pending = False
+
+        has_buffered_data = False
+        if self.is_recording():
+            try:
+                rec = self.recorder.stop()
+                has_buffered_data = self._recording_has_rows(rec)
+                if has_buffered_data:
+                    self._pending_mismatch_recording = rec
+            except Exception:
+                log.exception("failed to stop recording after session_info mismatch")
+
+        self.session_info_mismatch.emit(detail, has_buffered_data)
+        self._session.fail(detail)
+
+    def _validate_sensor_data(self, msg: DecodedMessage) -> bool:
+        if msg.seq is None or msg.t_device_ms is None or msg.channels is None:
+            self.error_log.add(
+                ErrorCategory.SENSOR_DATA_INVALID,
+                "sensor_data missing one or more required fields: seq, ts, val",
+            )
+            return False
+
+        if self._expected_channel_count is None:
+            # session_info not received yet — wait for metadata before ingesting.
+            return False
+
+        if len(msg.channels) != self._expected_channel_count:
+            self.error_log.add(
+                ErrorCategory.SENSOR_DATA_INVALID,
+                "sensor_data val count does not match session_info ch_n length",
+                expected=self._expected_channel_count,
+                got=len(msg.channels),
+            )
+            return False
+        return True
+
+    @staticmethod
+    def _normalize_session_info(raw: dict) -> dict | None:
+        if not isinstance(raw, dict) or raw.get("t") != "si":
+            return None
+        d = raw.get("d") if isinstance(raw.get("d"), dict) else None
+        if d is None:
+            return None
+        # "ch_n" carries the channel labels and must be a non-empty list of
+        # non-empty strings (the chart/CSV column names depend on it).
+        ch_n = d.get("ch_n")
+        if not isinstance(ch_n, (list, tuple)) or not ch_n:
+            return None
+        if not all(isinstance(name, str) and name for name in ch_n):
+            return None
+
+        # "ch" is the channel count; when present it must agree with ch_n.
+        ch = d.get("ch")
+        if ch is not None and (not isinstance(ch, int) or isinstance(ch, bool) or ch != len(ch_n)):
+            return None
+
+        required = ("sid", "hz", "st", "dr", "name")
+        if any(key not in d for key in required):
+            return None
+
+        nd = dict(d)
+        nd.pop("ch", None)  # redundant field; rely on ch_n names only
+        # "dr" (producer drop count) legitimately increments during a session,
+        # so it is excluded from the constant-metadata mismatch check.
+        nd.pop("dr", None)
+        nd["ch_n"] = tuple(ch_n)
+        return {"t": "si", "d": nd}
+
+    def _set_phase(self, phase: str) -> None:
+        if phase == self._phase:
+            return
+        self._phase = phase
+        self.session_phase_changed.emit(phase)

--- a/tools/data_forwarder_host/session/forwarding.py
+++ b/tools/data_forwarder_host/session/forwarding.py
@@ -1,0 +1,590 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Forwarding session — the 5-state machine + I/O worker.
+
+``ForwardingSession`` is the **sole writer** of :class:`SessionState`. It owns
+an :class:`IoWorker` that runs on a ``QThread``, pulls bytes from the data
+source, feeds the single COBS/CBOR v1 decoder, and emits decoded messages.
+
+State machine (5 states):
+
+* ``CONFIGURED`` → ``RUNNING``   — opening the source is an entry action of RUNNING
+* ``RUNNING``    → ``STOPPED``   — stopping the source is an entry action of STOPPED
+* any state      → ``ERROR``
+* ``ERROR``      → ``CONFIGURED`` — via :meth:`reset`
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from time import monotonic
+from typing import Any, Callable
+
+from PySide6.QtCore import QObject, QThread, QTimer, Signal, Slot
+
+from data_forwarder_host.core.error_log import ErrorCategory, ErrorLog
+from data_forwarder_host.pipeline.inbox import DEFAULT_BUDGET, FrameInbox
+from data_forwarder_host.pipeline.ipc import ChildSpec
+from data_forwarder_host.pipeline.process_host import SourceProcessHost
+from data_forwarder_host.protocol.base import (
+    DecodedMessage,
+    DecodeError,
+    DecodeErrorKind,
+    DecodeStats,
+)
+from data_forwarder_host.protocol.cobs_cbor_v1 import CobsCborV1
+from data_forwarder_host.session.config import SessionConfig
+from data_forwarder_host.session.process_worker import ProcessIoWorker
+from data_forwarder_host.session.states import SessionState, can_transition
+from data_forwarder_host.source.base import Source
+from data_forwarder_host.utils.slow_span import slow_span
+
+log = logging.getLogger(__name__)
+
+
+_DECODE_ERR_TO_CATEGORY = {
+    DecodeErrorKind.COBS: ErrorCategory.COBS,
+    DecodeErrorKind.CRC: ErrorCategory.CRC,
+    DecodeErrorKind.MALFORMED: ErrorCategory.MALFORMED,
+    DecodeErrorKind.CBOR: ErrorCategory.CBOR,
+}
+
+
+class InFlightGate:
+    """Bounded in-flight counter for host-side ingestion backpressure.
+
+    The decoded ``sensor_data`` frames cross from the I/O worker thread to the
+    GUI thread via a queued Qt signal. If the producer streams faster than the
+    GUI thread can process, that queue grows without bound and the whole
+    application freezes (an observed failure mode). This gate caps the number
+    of frames *in flight* — emitted by the worker but not yet processed by the
+    GUI thread. The worker calls :meth:`try_acquire` before emitting a frame;
+    once the bound is reached it returns ``False`` and the frame is dropped
+    instead of blocking. The GUI thread calls :meth:`release` once it has
+    finished processing a frame. The class is pure (no Qt) and thread-safe.
+    """
+
+    def __init__(self, max_in_flight: int) -> None:
+        self._max = max(1, int(max_in_flight))
+        self._in_flight = 0
+        self._dropped = 0
+        self._lock = threading.Lock()
+
+    def try_acquire(self) -> bool:
+        """Reserve a slot for one frame; ``False`` (and count a drop) if full."""
+        with self._lock:
+            if self._in_flight >= self._max:
+                self._dropped += 1
+                return False
+            self._in_flight += 1
+            return True
+
+    def release(self) -> None:
+        """Mark one in-flight frame as processed, freeing its slot."""
+        with self._lock:
+            if self._in_flight > 0:
+                self._in_flight -= 1
+
+    @property
+    def max_in_flight(self) -> int:
+        return self._max
+
+    @property
+    def in_flight(self) -> int:
+        with self._lock:
+            return self._in_flight
+
+    @property
+    def dropped(self) -> int:
+        """Total frames dropped since this gate was created."""
+        with self._lock:
+            return self._dropped
+
+
+class IoWorker(QObject):
+    """Pulls bytes from the source, feeds the decoder, emits messages."""
+
+    message = Signal(object)            # DecodedMessage
+    decode_errors = Signal(list)        # list[DecodeError]
+    stats = Signal(object)              # DecodeStats
+    raw_bytes = Signal(bytes)           # raw chunk as received from the source
+    overflow = Signal()                 # host ingestion overflow (frames dropped)
+    failed = Signal(str)
+    stopped = Signal()
+
+    def __init__(
+        self,
+        source: Source,
+        decoder: CobsCborV1,
+        gate: InFlightGate | None = None,
+    ) -> None:
+        super().__init__()
+        self._source = source
+        self._decoder = decoder
+        self._gate = gate
+        self._running = True
+        # Rising-edge latch so a sustained overflow surfaces a single event
+        # rather than one per dropped frame.
+        self._overflow_active = False
+
+    @Slot()
+    def run(self) -> None:
+        # Opening the source is an entry action of the RUNNING state. A source
+        # already opened in the New Session dialog (connect-in-dialog hand-off)
+        # is adopted as-is: open() is idempotent for both
+        # sources, but we skip it explicitly so a hand-off is unambiguous.
+        try:
+            if not self._source.is_open:
+                self._source.open()
+        except Exception as exc:
+            self.failed.emit(str(exc))
+            self.stopped.emit()   # MUST emit so _on_worker_stopped cleans up the thread
+            return
+
+        try:
+            tick = 0
+            for chunk in self._source.chunks():
+                if not self._running:
+                    break
+                if not chunk:
+                    continue
+                self.raw_bytes.emit(bytes(chunk))
+                for msg in self._decoder.feed(chunk):
+                    self._emit_message(msg)
+                errs = list(self._decoder.errors_drained())
+                if errs:
+                    self.decode_errors.emit(errs)
+                tick += 1
+                if (tick & 0x1F) == 0:
+                    self.stats.emit(self._decoder.stats())
+        except Exception as exc:
+            log.exception("IoWorker crashed")
+            self.failed.emit(str(exc))
+        finally:
+            try:
+                self._source.close()
+            except Exception:
+                log.exception("source.close() failed in IoWorker")
+            self.stopped.emit()
+
+    def _emit_message(self, msg: DecodedMessage) -> None:
+        """Emit a decoded message, applying host-side backpressure.
+
+        High-rate ``sensor_data`` frames are gated through :class:`InFlightGate`
+        so a flooding producer cannot grow the GUI thread's event queue without
+        bound. When the bound is reached the frame is dropped and a single
+        ``overflow`` event is surfaced on the rising edge. Control messages
+        (e.g. ``session_info``) are never dropped — they are rare and carry
+        metadata the rest of the pipeline depends on.
+        """
+        if self._gate is not None and msg.kind == "sensor_data":
+            if not self._gate.try_acquire():
+                if not self._overflow_active:
+                    self._overflow_active = True
+                    self.overflow.emit()
+                return
+            self._overflow_active = False
+        self.message.emit(msg)
+
+    @Slot()
+    def request_stop(self) -> None:
+        self._running = False
+        # Also close the source here to unblock reads when no bytes are flowing.
+        # Without this, generators that only yield on data can remain blocked
+        # indefinitely and the UI appears stuck in RUNNING.
+        try:
+            self._source.close()
+        except Exception:
+            log.exception("source.close() failed in request_stop")
+
+
+class ForwardingSession(QObject):
+    """State-machine wrapper around a (source, decoder, I/O thread).
+
+    Sole writer of :class:`SessionState` via :meth:`_set_state`.
+    """
+
+    state_changed = Signal(object)              # SessionState
+    message_received = Signal(object)           # DecodedMessage
+    session_info = Signal(object)               # DecodedMessage
+    error_occurred = Signal(str)
+    stats_updated = Signal(object)              # DecodeStats
+    raw_bytes = Signal(bytes)                   # raw chunk as received
+    raw_byte_count = Signal(int)                # raw byte count (process path)
+
+    # Max decoded sensor_data frames allowed in flight from the I/O worker to
+    # the GUI thread before excess frames are dropped (host-side backpressure).
+    MAX_IN_FLIGHT = 2048
+
+    # GUI-paced pull cadence for the out-of-process path: the GUI
+    # thread drains at most ``PULL_BUDGET`` sensor frames from the inbox every
+    # ``PULL_INTERVAL_MS`` so its per-tick work — and therefore CPU — is bounded
+    # regardless of how fast the child produces. The event loop services paint
+    # and input events between ticks, so a flood can never hang the UI.
+    PULL_INTERVAL_MS = 20
+    PULL_BUDGET = DEFAULT_BUDGET
+
+    # Hard wall-clock cap (ms) on how long a single drain tick may run on the
+    # GUI thread. Even if per-frame processing is unexpectedly slow, the tick
+    # stops at this deadline and hands control back to the event loop, so the
+    # UI can never freeze. Frames are drained in small chunks so the deadline
+    # is checked frequently.
+    MAX_DRAIN_MS = 8.0
+    _DRAIN_CHUNK = 64
+
+    def __init__(
+        self,
+        *,
+        config: SessionConfig,
+        source: Source | None,
+        decoder: CobsCborV1,
+        error_log: ErrorLog,
+        parent: QObject | None = None,
+        use_process: bool = False,
+        process_host_factory: Callable[[ChildSpec], Any] | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._config = config
+        self._source = source
+        self._decoder = decoder
+        self._error_log = error_log
+        self._state: SessionState = SessionState.CONFIGURED
+        self._thread: QThread | None = None
+        self._worker: QObject | None = None
+        self._gate: InFlightGate | None = None
+        self._use_process = use_process
+        self._process_host_factory = process_host_factory
+        # Consumer-paced pull boundary (process path only).
+        self._inbox: FrameInbox | None = None
+        self._pull_timer: QTimer | None = None
+        self._inbox_drops_reported = 0
+        # Diagnostics: largest gap (ms) observed between drain ticks since the
+        # last sample. The timer is meant to fire every ``PULL_INTERVAL_MS``; a
+        # large gap proves the GUI event loop was starved (the freeze symptom).
+        self._last_drain_ts: float | None = None
+        self._drain_max_gap_ms = 0.0
+
+        self._error_log.bind_state_provider(self.state)
+
+    # ------------------------------------------------------------------
+    # State (sole writer)
+    # ------------------------------------------------------------------
+
+    def state(self) -> SessionState:
+        return self._state
+
+    def _set_state(self, new_state: SessionState) -> None:
+        if not can_transition(self._state, new_state):
+            log.warning("rejected transition %s -> %s", self._state, new_state)
+            return
+        if new_state == self._state:
+            return
+        self._state = new_state
+        self.state_changed.emit(new_state)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        if self._state not in (SessionState.CONFIGURED, SessionState.STOPPED):
+            return
+        if self._use_process:
+            self._start_process()
+            return
+        self._decoder.reset()
+        self._gate = InFlightGate(self.MAX_IN_FLIGHT)
+        self._worker = IoWorker(self._source, self._decoder, gate=self._gate)
+        self._thread = QThread()
+        self._worker.moveToThread(self._thread)
+        self._thread.started.connect(self._worker.run)
+        self._worker.message.connect(self._on_message)
+        self._worker.decode_errors.connect(self._on_decode_errors)
+        self._worker.stats.connect(self.stats_updated)
+        self._worker.raw_bytes.connect(self.raw_bytes)
+        self._worker.overflow.connect(self._on_ingestion_overflow)
+        self._worker.failed.connect(self._on_failed)
+        self._worker.stopped.connect(self._on_worker_stopped)
+        self._thread.start()
+        # Opening the source is the entry action of RUNNING.
+        self._set_state(SessionState.RUNNING)
+
+    def _start_process(self) -> None:
+        """Start acquisition in a separate OS process.
+
+        The child rebuilds the source/decoder from the serializable config and
+        ships decoded frames in batches, so a flood cannot grow the GUI thread's
+        event queue (the in-flight gate is unnecessary here — back-pressure lives
+        in the child's drop policy).
+        """
+        spec = ChildSpec(
+            source_kind=self._config.source.kind,
+            source_params=dict(self._config.source.params),
+            expect_crc=self._config.expect_crc,
+        )
+        factory = self._process_host_factory or SourceProcessHost
+        host = factory(spec)
+        # The worker thread appends decoded frames straight into this inbox
+        # (no per-batch Qt signal), and the GUI thread pulls from it on a timer.
+        # This keeps the GUI event loop free of high-frequency
+        # cross-thread traffic, so a flood cannot freeze the UI.
+        self._inbox = FrameInbox()
+        self._inbox_drops_reported = 0
+        worker = ProcessIoWorker(host, inbox=self._inbox)
+        self._worker = worker
+        self._thread = QThread()
+        worker.moveToThread(self._thread)
+        self._thread.started.connect(worker.run)
+        # NOTE: worker.messages is intentionally NOT connected — frames flow via
+        # the inbox. Only low-frequency control/metadata signals use Qt.
+        worker.decode_errors.connect(self._on_decode_errors)
+        worker.stats.connect(self.stats_updated)
+        worker.raw_byte_count.connect(self.raw_byte_count)
+        worker.overflow.connect(self._on_ingestion_overflow)
+        worker.failed.connect(self._on_failed)
+        worker.stopped.connect(self._on_worker_stopped)
+        # GUI-thread pull timer (owned by this session, runs on the GUI thread).
+        self._pull_timer = QTimer(self)
+        self._pull_timer.setInterval(self.PULL_INTERVAL_MS)
+        self._pull_timer.timeout.connect(self._drain_inbox)
+        self._pull_timer.start()
+        self._thread.start()
+        self._set_state(SessionState.RUNNING)
+
+    def stop(self) -> None:
+        if self._state != SessionState.RUNNING:
+            return
+        if self._worker is not None:
+            # Stop request must run on the worker thread to release the read loop.
+            self._worker.request_stop()
+        if self._thread is not None:
+            self._thread.quit()
+            self._thread.wait(2000)
+        # Drain whatever the inbox still holds, then stop the pull timer so no
+        # frames are stranded and the timer does not outlive the session.
+        self._drain_inbox()
+        self._stop_pull_timer()
+        # Reflect user intent in the UI immediately even if worker teardown
+        # completes slightly later.
+        if self._state == SessionState.RUNNING:
+            self._set_state(SessionState.STOPPED)
+
+    def reset(self) -> None:
+        """Allowed only from ERROR — return to CONFIGURED."""
+        if self._state != SessionState.ERROR:
+            return
+        self._set_state(SessionState.CONFIGURED)
+
+    def fail(self, message: str) -> None:
+        """Force the session into ERROR and stop I/O.
+
+        Used for controller-side fatal validation failures (for example,
+        session metadata changing mid-session).
+        """
+        self._error_log.add(ErrorCategory.TRANSPORT, message)
+        if self._worker is not None:
+            try:
+                self._worker.request_stop()
+            except Exception:
+                log.exception("failed to stop worker during fail()")
+        self._set_state(SessionState.ERROR)
+        self.error_occurred.emit(message)
+
+    def shutdown(self) -> None:
+        try:
+            self.stop()
+        finally:
+            try:
+                if self._source is not None:
+                    self._source.close()
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    # Worker signals
+    # ------------------------------------------------------------------
+
+    @Slot(object)
+    def _on_message(self, msg: DecodedMessage) -> None:
+        self._error_log.note_message()
+        self.message_received.emit(msg)
+        if msg.kind == "session_info":
+            self.session_info.emit(msg)
+        # Processing of a gated sensor_data frame is complete (all slots ran
+        # synchronously on this thread); free its in-flight slot so the worker
+        # can admit the next frame.
+        if self._gate is not None and msg.kind == "sensor_data":
+            self._gate.release()
+
+    @Slot(list)
+    def _on_messages(self, batch: list[DecodedMessage]) -> None:
+        """Buffer a batch from the out-of-process worker.
+
+        This runs on the GUI thread (queued from the worker) but does **no**
+        per-frame pipeline work: it only appends the batch to the bounded
+        :class:`FrameInbox`. The actual per-frame fan-out happens later, paced,
+        in :meth:`_drain_inbox`. Appending is O(batch) and cheap, so even a
+        flood of batches cannot starve the event loop here. If the inbox has
+        not been created (defensive), fall back to direct emission.
+        """
+        if self._inbox is not None:
+            self._inbox.append(batch)
+            return
+        for msg in batch:
+            self._error_log.note_message()
+            self.message_received.emit(msg)
+            if msg.kind == "session_info":
+                self.session_info.emit(msg)
+
+    @Slot()
+    def _drain_inbox(self) -> None:
+        """GUI-paced pull: process frames under a strict per-tick time budget.
+
+        The GUI thread is the *client* that pulls when it is ready; the inbox is
+        the *server* that buffered the frames and counted any it had to drop.
+        The drain is bounded **by wall-clock time**
+        (``MAX_DRAIN_MS``) as well as by ``PULL_BUDGET`` frames, so no matter how
+        expensive per-frame processing is, a single tick can never occupy the
+        event loop long enough to freeze the UI — it always returns control so
+        paint/input events run. Control frames are always returned (never
+        dropped); surplus sensor frames are dropped at the inbox and reported.
+        """
+        inbox = self._inbox
+        if inbox is None:
+            return
+        now = monotonic()
+        if self._last_drain_ts is not None:
+            gap_ms = (now - self._last_drain_ts) * 1000.0
+            if gap_ms > self._drain_max_gap_ms:
+                self._drain_max_gap_ms = gap_ms
+        self._last_drain_ts = now
+        dropped_total = inbox.dropped
+        if dropped_total > self._inbox_drops_reported:
+            delta = dropped_total - self._inbox_drops_reported
+            self._inbox_drops_reported = dropped_total
+            # Coalesced into a single event whose count reflects the number of
+            # frames dropped (not the number of overflow episodes), so the
+            # RECORDER_OVERFLOW total is frame-accurate and can be netted out of
+            # the Host BT transport-loss attribution: a frame dropped at the GUI
+            # inbox was already delivered by the host Bluetooth stack, so its
+            # sequence gap must not be blamed on Host BT.
+            self._error_log.add_bulk(
+                ErrorCategory.RECORDER_OVERFLOW,
+                delta,
+                f"GUI inbox dropped {delta} sensor frame(s) to stay responsive",
+            )
+        deadline = monotonic() + (self.MAX_DRAIN_MS / 1000.0)
+        processed = 0
+        with slow_span("drain_inbox") as span:
+            while processed < self.PULL_BUDGET:
+                want = min(self._DRAIN_CHUNK, self.PULL_BUDGET - processed)
+                chunk = inbox.drain(want)
+                if not chunk:
+                    break
+                with slow_span("drain_inbox.emit_loop", extra=f"n={len(chunk)}"):
+                    for msg in chunk:
+                        self._error_log.note_message()
+                        self.message_received.emit(msg)
+                        if msg.kind == "session_info":
+                            self.session_info.emit(msg)
+                processed += len(chunk)
+                if monotonic() >= deadline:
+                    break
+            span.note(f"processed={processed}")
+
+    @Slot()
+    def _on_ingestion_overflow(self) -> None:
+        # Host could not keep up; frames are being dropped to keep the UI
+        # responsive. Surfaced as a single RECORDER_OVERFLOW event per episode.
+        self._error_log.add(
+            ErrorCategory.RECORDER_OVERFLOW,
+            "host ingestion overflow; dropping frames to keep the UI responsive",
+        )
+
+    @Slot(list)
+    def _on_decode_errors(self, errs: list[DecodeError]) -> None:
+        for e in errs:
+            cat = _DECODE_ERR_TO_CATEGORY.get(e.kind, ErrorCategory.MALFORMED)
+            self._error_log.add(cat, e.detail, **e.context)
+
+    @Slot(str)
+    def _on_failed(self, message: str) -> None:
+        self._error_log.add(ErrorCategory.TRANSPORT, message)
+        self._set_state(SessionState.ERROR)
+        self.error_occurred.emit(message)
+
+    @Slot()
+    def _on_worker_stopped(self) -> None:
+        # Stopping the source is the entry action of STOPPED.
+        # Drain any frames still buffered before tearing the timer down.
+        self._drain_inbox()
+        self._stop_pull_timer()
+        if self._state == SessionState.RUNNING:
+            self._set_state(SessionState.STOPPED)
+        self._worker = None
+        if self._thread is not None:
+            self._thread.quit()
+            self._thread.wait(2000)
+            self._thread = None
+
+    def _stop_pull_timer(self) -> None:
+        """Stop and discard the GUI-paced pull timer if running."""
+        if self._pull_timer is not None:
+            self._pull_timer.stop()
+            self._pull_timer = None
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    def config(self) -> SessionConfig:
+        return self._config
+
+    def dropped_frames(self) -> int:
+        """Total sensor_data frames dropped by host-side backpressure.
+
+        Combines the in-process in-flight gate (legacy single-process path) and
+        the GUI inbox (process path).
+        """
+        gate_drops = self._gate.dropped if self._gate is not None else 0
+        inbox_drops = self._inbox.dropped if self._inbox is not None else 0
+        return gate_drops + inbox_drops
+
+    def inbox_pending(self) -> int:
+        """Frames currently buffered in the GUI pull inbox (process path)."""
+        return self._inbox.pending() if self._inbox is not None else 0
+
+    def drain_gap_ms(self, *, reset: bool = True) -> float:
+        """Largest gap (ms) between drain ticks since the last call.
+
+        A value far above ``PULL_INTERVAL_MS`` means the GUI event loop was
+        starved between ticks — the fingerprint of a freeze. Reading it
+        optionally resets the high-water mark so each sample is fresh.
+        """
+        gap = self._drain_max_gap_ms
+        if reset:
+            self._drain_max_gap_ms = 0.0
+        return gap
+
+    def stats(self) -> DecodeStats:
+        return self._decoder.stats()
+
+    def describe_source(self) -> str:
+        if self._config.source.kind == "uart":
+            p = self._config.source.params
+            return f"uart:{p.get('port', '?')}@{p.get('baudrate', 115200)}"
+        if self._config.source.kind == "ble":
+            return f"ble:{self._config.source.params.get('address', '?')}"
+        return self._config.source.kind
+
+    def describe_protocol(self) -> str:
+        crc = self._config.expect_crc
+        return f"cobs-cbor v1 (expect_crc={'true' if crc else 'false'})"
+
+    def describe_session_info(self) -> dict[str, Any]:
+        return {
+            "tag": self._config.tag,
+            "source": self.describe_source(),
+            "protocol": self.describe_protocol(),
+        }

--- a/tools/data_forwarder_host/session/manager.py
+++ b/tools/data_forwarder_host/session/manager.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""App-level SessionController registry."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QObject, Signal
+
+from data_forwarder_host.session.config import SessionConfig
+from data_forwarder_host.session.controller import SessionController
+
+
+class SessionManager(QObject):
+    """Owns ``SessionController`` instances by id."""
+
+    session_created = Signal(str)               # session_id
+    session_closed = Signal(str)                # session_id
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._sessions: dict[str, SessionController] = {}
+
+    def create(
+        self,
+        config: SessionConfig,
+        prepared_source: object | None = None,
+        use_process: bool = False,
+    ) -> SessionController:
+        ctrl = SessionController(
+            config,
+            parent=self,
+            prepared_source=prepared_source,
+            use_process=use_process,
+        )
+        self._sessions[ctrl.id] = ctrl
+        self.session_created.emit(ctrl.id)
+        return ctrl
+
+    def close(self, session_id: str) -> None:
+        ctrl = self._sessions.pop(session_id, None)
+        if ctrl is None:
+            return
+        try:
+            ctrl.shutdown()
+        finally:
+            self.session_closed.emit(session_id)
+            ctrl.deleteLater()
+
+    def get(self, session_id: str) -> SessionController:
+        return self._sessions[session_id]
+
+    def all(self) -> list[SessionController]:
+        return list(self._sessions.values())
+
+    def shutdown_all(self) -> None:
+        for sid in list(self._sessions.keys()):
+            self.close(sid)

--- a/tools/data_forwarder_host/session/process_worker.py
+++ b/tools/data_forwarder_host/session/process_worker.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Qt worker that drains the out-of-process source host.
+
+:class:`ProcessIoWorker` runs on a ``QThread`` and is the GUI-process counterpart
+of the in-process :class:`IoWorker`. Each tick it drains a batch of picklable
+envelopes from a :class:`SourceProcessHost` and re-emits them as Qt signals. The
+crucial difference from :class:`IoWorker` is that decoded frames are re-emitted
+**as a batch** (one :pyattr:`messages` emission per drained group) rather than
+one signal per frame — so a flood in the child cannot grow the GUI thread's event
+queue without bound and lock up the UI.
+
+The host is injectable so this worker can run without spawning a real
+process.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from PySide6.QtCore import QObject, Signal, Slot
+
+from data_forwarder_host.pipeline.ipc import (
+    FAILED,
+    STOPPED,
+    DecodeErrors,
+    FrameBatch,
+    Lifecycle,
+    Overflow,
+    RawByteCount,
+    StatsUpdate,
+)
+from data_forwarder_host.pipeline.process_host import SourceProcessHost
+
+log = logging.getLogger(__name__)
+
+
+class ProcessIoWorker(QObject):
+    """Polls a :class:`SourceProcessHost` and re-emits batched Qt signals."""
+
+    messages = Signal(list)          # list[DecodedMessage] (one batch)
+    decode_errors = Signal(list)     # list[DecodeError]
+    stats = Signal(object)           # DecodeStats
+    raw_byte_count = Signal(int)     # raw transport bytes received by the child
+    overflow = Signal()              # child began dropping frames
+    failed = Signal(str)
+    stopped = Signal()
+
+    def __init__(
+        self,
+        host: SourceProcessHost,
+        *,
+        poll_timeout: float = 0.05,
+        inbox: Any | None = None,
+    ) -> None:
+        super().__init__()
+        self._host = host
+        self._poll_timeout = poll_timeout
+        self._running = True
+        # When set, decoded frames are appended **directly** into this
+        # thread-safe FrameInbox from the worker thread instead of being
+        # re-emitted as a Qt signal per poll group. This removes *all*
+        # high-frequency cross-thread Qt traffic from the hot path, so a flood
+        # in the child can never starve the GUI event loop.
+        self._inbox = inbox
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            self._host.start()
+        except Exception as exc:
+            log.exception("failed to start source process")
+            self.failed.emit(str(exc))
+            self.stopped.emit()
+            return
+
+        try:
+            while self._running:
+                envelopes = self._host.poll(self._poll_timeout)
+                if not envelopes:
+                    continue
+                if self._dispatch(envelopes):
+                    break  # child reported STOPPED
+        except Exception as exc:
+            log.exception("ProcessIoWorker crashed")
+            self.failed.emit(str(exc))
+        finally:
+            self._host.request_stop()
+            self._host.join(2.0)
+            self.stopped.emit()
+
+    def _dispatch(self, envelopes: list) -> bool:
+        """Route a drained group of envelopes; return ``True`` once STOPPED seen."""
+        batch: list = []
+        saw_stop = False
+        for env in envelopes:
+            if isinstance(env, FrameBatch):
+                batch.extend(env.messages)
+            elif isinstance(env, DecodeErrors):
+                if env.errors:
+                    self.decode_errors.emit(list(env.errors))
+            elif isinstance(env, StatsUpdate):
+                self.stats.emit(env.stats)
+            elif isinstance(env, RawByteCount):
+                self.raw_byte_count.emit(env.n_bytes)
+            elif isinstance(env, Overflow):
+                self.overflow.emit()
+            elif isinstance(env, Lifecycle):
+                if env.event == FAILED:
+                    self.failed.emit(env.detail)
+                elif env.event == STOPPED:
+                    saw_stop = True
+        if batch:
+            if self._inbox is not None:
+                # Direct, lock-guarded hand-off to the GUI's pull buffer — no Qt
+                # signal, so the GUI event loop is never flooded under load.
+                self._inbox.append(batch)
+            else:
+                self.messages.emit(batch)
+        return saw_stop
+
+    @Slot()
+    def request_stop(self) -> None:
+        self._running = False
+        self._host.request_stop()

--- a/tools/data_forwarder_host/session/states.py
+++ b/tools/data_forwarder_host/session/states.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Session lifecycle state machine (5 states)."""
+
+from __future__ import annotations
+
+from enum import Enum, auto
+
+
+class SessionState(Enum):
+    CONFIGURED = auto()
+    RUNNING = auto()
+    STOPPED = auto()
+    ERROR = auto()
+
+
+# Allowed transitions. Exactly one component (the session) is the sole writer.
+#
+# * CONFIGURED → RUNNING   (opening the source is an entry action of RUNNING)
+# * RUNNING    → STOPPED   (stopping the source is an entry action of STOPPED)
+# * STOPPED    → CONFIGURED / RUNNING (re-run)
+# * any state  → ERROR
+# * ERROR      → CONFIGURED (reset path)
+_ALLOWED: dict[SessionState, frozenset[SessionState]] = {
+    SessionState.CONFIGURED: frozenset({SessionState.RUNNING, SessionState.ERROR}),
+    SessionState.RUNNING: frozenset({SessionState.STOPPED, SessionState.ERROR}),
+    SessionState.STOPPED: frozenset(
+        {SessionState.CONFIGURED, SessionState.RUNNING, SessionState.ERROR}
+    ),
+    SessionState.ERROR: frozenset({SessionState.CONFIGURED}),  # reset() only
+}
+
+
+def can_transition(src: SessionState, dst: SessionState) -> bool:
+    """Return ``True`` if ``src -> dst`` is an allowed transition."""
+    if src == dst:
+        return True
+    return dst in _ALLOWED.get(src, frozenset())

--- a/tools/data_forwarder_host/source/__init__.py
+++ b/tools/data_forwarder_host/source/__init__.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Data-source layer — byte sources (UART implemented, BLE NUS declared).
+
+A single tiny ``source_for_kind`` factory maps the two known source kinds to
+their classes. There is no pluggable registry abstraction.
+"""
+
+from __future__ import annotations
+
+from data_forwarder_host.source.base import (
+    ConfigField,
+    ConfigSchema,
+    RoleMode,
+    Source,
+    SourceInfo,
+)
+from data_forwarder_host.source.ble_nus import BleNusSource
+from data_forwarder_host.source.uart import UartSource
+
+# The two — and only two — supported source kinds.
+SOURCE_KINDS: tuple[str, ...] = (UartSource.kind, BleNusSource.kind)
+
+_BY_KIND: dict[str, type[Source]] = {
+    UartSource.kind: UartSource,
+    BleNusSource.kind: BleNusSource,
+}
+
+
+def source_for_kind(kind: str) -> type[Source]:
+    """Return the :class:`Source` subclass for *kind* (``"uart"`` or ``"ble"``)."""
+    try:
+        return _BY_KIND[kind]
+    except KeyError:
+        raise ValueError(f"unknown source kind: {kind!r}") from None
+
+
+__all__ = [
+    "ConfigField",
+    "ConfigSchema",
+    "RoleMode",
+    "Source",
+    "SourceInfo",
+    "UartSource",
+    "BleNusSource",
+    "SOURCE_KINDS",
+    "source_for_kind",
+]

--- a/tools/data_forwarder_host/source/base.py
+++ b/tools/data_forwarder_host/source/base.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Data-source ABC and shared types.
+
+Only the LISTENER role exists (device-initiated streaming). There is no
+client/host-initiated mode anywhere in the codebase.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Any
+
+from data_forwarder_host.platform.base import PlatformAdapter
+
+
+class RoleMode(Enum):
+    """Direction of control for a data source.
+
+    Only ``LISTENER`` exists: the device pushes, the host receives.
+    """
+
+    LISTENER = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class SourceInfo:
+    """Lightweight description of a discoverable source endpoint."""
+
+    kind: str
+    id: str                              # stable identifier (e.g. "/dev/ttyACM0")
+    display: str                         # user-facing label
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigField:
+    """Description of a single configurable parameter for a source."""
+
+    name: str
+    label: str
+    kind: str                            # "str" | "int" | "float" | "bool" | "path" | "choice"
+    default: Any = None
+    required: bool = True
+    choices: tuple[str, ...] = ()
+    help: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigSchema:
+    """Ordered set of ``ConfigField`` definitions used by the GUI dialog."""
+
+    fields: tuple[ConfigField, ...] = ()
+
+
+class Source(ABC):
+    """Abstract byte-source (listener role only)."""
+
+    kind: str
+
+    @classmethod
+    @abstractmethod
+    def discover(cls, platform: PlatformAdapter) -> list[SourceInfo]:
+        """Return currently discoverable source endpoints."""
+
+    @abstractmethod
+    def open(self) -> None:
+        """Open the underlying resource."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Close the underlying resource."""
+
+    @abstractmethod
+    def chunks(self) -> Iterator[bytes]:
+        """Yield raw byte chunks until ``close()`` is called or the source ends."""
+
+    @property
+    @abstractmethod
+    def is_open(self) -> bool:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def config_schema(cls) -> ConfigSchema:
+        """Configuration schema used by the New-Session dialog."""

--- a/tools/data_forwarder_host/source/ble_nus.py
+++ b/tools/data_forwarder_host/source/ble_nus.py
@@ -1,0 +1,529 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""BLE NUS (Nordic UART Service) data source.
+
+The host acts as a BLE *central*: it scans for advertising devices, connects to
+a chosen one, and subscribes to notifications on the NUS **TX** characteristic.
+The device-side sample (``samples/data_forwarder``) advertises the NUS service
+UUID under the name ``"nRF DataFwd"`` and streams COBS/CBOR frames out via
+``bt_nus_send`` (TX notifications). The raw notification payloads are handed to
+the same COBS/CBOR decoder used by the UART source.
+
+The cross-platform BLE backend is :mod:`bleak`, which is async. This source
+runs a private asyncio event loop on a background thread and bridges incoming
+notifications to the synchronous :meth:`chunks` generator through a bounded
+queue, so the rest of the pipeline (the :class:`~data_forwarder_host.session.\
+forwarding.IoWorker`) sees the same blocking byte-source contract as UART.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import queue
+import threading
+from collections.abc import Iterator
+from typing import Any
+
+from data_forwarder_host.platform.base import PlatformAdapter
+from data_forwarder_host.source.base import (
+    ConfigSchema,
+    Source,
+    SourceInfo,
+)
+
+log = logging.getLogger(__name__)
+
+# Nordic UART Service UUIDs (the device is the peripheral; the host subscribes
+# to TX notifications to receive streamed data).
+NUS_SERVICE_UUID = "6e400001-b5a3-f393-e0a9-e50e24dcca9e"
+NUS_TX_CHAR_UUID = "6e400003-b5a3-f393-e0a9-e50e24dcca9e"  # peripheral → central (notify)
+
+# Default advertised name of the device-side data_forwarder sample.
+DEFAULT_DEVICE_NAME = "nRF DataFwd"
+
+# The BLE minimum ATT MTU. When the link reports this value the MTU was never
+# upgraded, so every notification carries at most MTU-3 (=20) payload bytes and
+# each sensor frame is fragmented across multiple notifications.
+_DEFAULT_ATT_MTU = 23
+
+# Number of connect attempts and the delay between them. The Windows (WinRT)
+# backend can abort the first fresh GATT discovery (reporting "cancelled" or
+# "Unreachable") even when the device is perfectly reachable, but a retry
+# usually succeeds; the cost on a genuinely absent device is bounded by
+# ``connect_timeout`` per attempt.
+_CONNECT_ATTEMPTS = 3
+_CONNECT_RETRY_DELAY = 1.0
+
+_MISSING_BLEAK_MSG = (
+    "BLE support requires the 'bleak' package. Install it with 'pip install bleak'."
+)
+
+# Friendly explanation for the most common scan failure: there is no usable
+# Bluetooth backend (no running BlueZ daemon / D-Bus system bus / adapter). On
+# Linux this surfaces from the BlueZ backend as a bare
+# ``FileNotFoundError: [Errno 2] No such file or directory`` (the D-Bus socket
+# is absent) or as a D-Bus/org.bluez connection error — both useless to a user.
+_NO_BLUETOOTH_BACKEND_MSG = (
+    "no usable Bluetooth backend was found. BLE scanning needs a running "
+    "Bluetooth stack (BlueZ + D-Bus system bus) with an adapter, which is "
+    "typically unavailable inside a container without host Bluetooth access. "
+    "Run the host on a machine with Bluetooth, or grant the container access "
+    "to the host's Bluetooth (D-Bus system bus + a BLE adapter)."
+)
+
+
+def _describe_scan_failure(exc: BaseException) -> str:
+    """Return a human-readable, actionable reason for a BLE scan failure.
+
+    Recognises the common "no usable Bluetooth backend" signatures (missing
+    D-Bus system bus socket, BlueZ daemon, or adapter) and replaces the cryptic
+    underlying error — e.g. ``[Errno 2] No such file or directory`` when the
+    D-Bus socket is absent — with a clear explanation, instead of leaking a raw
+    errno string to the user. Any other failure is reported verbatim.
+    """
+    text = str(exc).lower()
+    no_backend = (
+        isinstance(exc, (FileNotFoundError, ConnectionError))
+        or "org.bluez" in text
+        or "bluez" in text
+        or "dbus" in text
+        or "d-bus" in text
+        or "no such file or directory" in text
+        or "connection refused" in text
+    )
+    if no_backend:
+        return _NO_BLUETOOTH_BACKEND_MSG
+    return str(exc) or exc.__class__.__name__
+
+
+def infos_matching_name(infos: list[SourceInfo], name: str) -> list[SourceInfo]:
+    """Filter discovered devices to those advertising *name*.
+
+    An empty/blank *name* matches everything (so "Discover…" with no name set
+    lists every device in range). Matching is exact on the advertised name.
+    """
+    wanted = (name or "").strip()
+    if not wanted:
+        return list(infos)
+    return [i for i in infos if (i.details.get("name") or "") == wanted]
+
+
+def _run_blocking(coro: Any, *, timeout: float | None = None) -> Any:
+    """Run *coro* to completion on a throwaway event loop and return its result.
+
+    Works whether or not the calling thread already owns a running event loop
+    (it always uses a fresh loop on a dedicated thread), so it is safe to call
+    from the Qt GUI thread.
+    """
+    box: dict[str, Any] = {}
+
+    def _runner() -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            box["value"] = loop.run_until_complete(coro)
+        except BaseException as exc:  # noqa: BLE001 - re-raised to the caller below
+            box["error"] = exc
+        finally:
+            try:
+                loop.close()
+            finally:
+                asyncio.set_event_loop(None)
+
+    thread = threading.Thread(target=_runner, name="ble-oneshot", daemon=True)
+    thread.start()
+    thread.join(timeout)
+    if "error" in box:
+        raise box["error"]
+    return box.get("value")
+
+
+class BleNusSource(Source):
+    """Bytes from a BLE peripheral's Nordic UART Service (TX notifications)."""
+
+    kind = "ble"
+
+    def __init__(
+        self,
+        *,
+        address: str = "",
+        name: str = "",
+        scan_timeout: float = 6.0,
+        connect_timeout: float = 20.0,
+        **_: Any,
+    ) -> None:
+        # The peripheral is identified by its BLE *address* (chosen from the
+        # live device list in the New Session dialog). A *name* may still be
+        # supplied for display / legacy resolution; when only a name is given
+        # the address is resolved by scanning at open() time.
+        self._address = (address or "").strip()
+        self._name = name.strip()
+        self._scan_timeout = float(scan_timeout)
+        self._connect_timeout = float(connect_timeout)
+
+        self._queue: queue.Queue[bytes | None] = queue.Queue(maxsize=4096)
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._loop_thread: threading.Thread | None = None
+        self._client: Any = None
+        self._open = False
+        self._stop = threading.Event()
+
+    # ------------------------------------------------------------------
+    # Discovery
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def discover(cls, platform: PlatformAdapter) -> list[SourceInfo]:
+        """Scan for advertising BLE devices.
+
+        Returns the list of discoverable devices (possibly empty if the scan
+        genuinely saw nothing). A *backend* failure — ``bleak`` not installed,
+        or no usable Bluetooth stack (BlueZ/D-Bus/adapter unavailable) — raises
+        :class:`RuntimeError` so the caller can tell "BLE is unavailable" apart
+        from "BLE works but no devices are in range", instead of both collapsing
+        into a misleading empty result.
+        """
+        try:
+            from bleak import BleakScanner
+        except ImportError as exc:
+            raise RuntimeError(_MISSING_BLEAK_MSG) from exc
+
+        try:
+            found = _run_blocking(
+                BleakScanner.discover(timeout=6.0, return_adv=True),
+                timeout=20.0,
+            )
+        except Exception as exc:
+            reason = _describe_scan_failure(exc)
+            # Expected, well-understood condition (e.g. no Bluetooth stack in a
+            # container) that is already surfaced to the user by the dialog —
+            # log a concise WARNING (not an alarming ERROR/traceback). The full
+            # traceback is still available at DEBUG level for diagnosis.
+            log.warning("BLE scan failed: %s", reason)
+            log.debug("BLE scan failure detail", exc_info=True)
+            raise RuntimeError(f"BLE unavailable: {reason}") from exc
+
+        return cls._infos_from_scan(found or {})
+
+    @classmethod
+    def probe_bluetooth_state(cls, *, timeout: float = 1.5) -> str:
+        """Best-effort, cross-platform read of the system Bluetooth state.
+
+        Returns one of:
+        - ``"on"``      — a scan started successfully (adapter present & powered);
+        - ``"off"``     — no usable Bluetooth backend (adapter off / BlueZ/D-Bus
+                           or radio unavailable);
+        - ``"unknown"`` — ``bleak`` is missing or the state could not be probed.
+
+        ``bleak`` exposes no uniform adapter-power API across Linux/Windows/
+        macOS, so we run a short scan and classify the outcome with the same
+        logic used for discovery failures. This is the "reflect" half of the
+        reflect-and-guide Bluetooth toggle; the app never powers the adapter.
+        """
+        try:
+            from bleak import BleakScanner
+        except ImportError:
+            return "unknown"
+
+        try:
+            _run_blocking(
+                BleakScanner.discover(timeout=timeout, return_adv=True),
+                timeout=timeout + 10.0,
+            )
+        except Exception as exc:  # noqa: BLE001 - classified below
+            reason = _describe_scan_failure(exc)
+            if reason == _NO_BLUETOOTH_BACKEND_MSG:
+                return "off"
+            log.debug("Bluetooth probe inconclusive: %s", reason)
+            return "unknown"
+        return "on"
+
+    @classmethod
+    def _infos_from_scan(cls, found: dict[str, Any]) -> list[SourceInfo]:
+        """Map a ``{address: (device, advertisement)}`` mapping to ``SourceInfo``."""
+        infos: list[SourceInfo] = []
+        for address, pair in found.items():
+            device, adv = pair if isinstance(pair, tuple) else (pair, None)
+            infos.append(cls._info_from_advertisement(str(address), device, adv))
+        # NUS / Nordic devices first, then by signal strength (strongest first).
+        infos.sort(
+            key=lambda i: (
+                0 if i.details.get("looks_like_nrf") else 1,
+                -(i.details.get("rssi") or -999),
+            )
+        )
+        return infos
+
+    @classmethod
+    def _info_from_advertisement(cls, address: str, device: Any, adv: Any) -> SourceInfo:
+        """Build a :class:`SourceInfo` from a single scan detection.
+
+        Shared by the one-shot :meth:`discover` and the live (streaming)
+        scanner, so both produce identical device records.
+        """
+        service_uuids = [u.lower() for u in (getattr(adv, "service_uuids", None) or [])]
+        has_nus = NUS_SERVICE_UUID in service_uuids
+        name = (
+            getattr(device, "name", None)
+            or getattr(adv, "local_name", None)
+            or ""
+        )
+        looks_like_nrf = (
+            has_nus
+            or name == DEFAULT_DEVICE_NAME
+            or name.lower().startswith("nrf")
+        )
+        rssi = getattr(adv, "rssi", None)
+        display = f"{name or 'unknown'} [{address}]"
+        if rssi is not None:
+            display = f"{display}  {rssi} dBm"
+        return SourceInfo(
+            kind=cls.kind,
+            id=str(address),
+            display=display,
+            details={
+                "name": name,
+                "rssi": rssi,
+                "has_nus": has_nus,
+                "looks_like_nrf": looks_like_nrf,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def open(self) -> None:
+        if self._open:
+            return
+        try:
+            from bleak import BleakClient
+        except ImportError as exc:
+            raise RuntimeError(_MISSING_BLEAK_MSG) from exc
+
+        target = self._address or self._resolve_address_by_name()
+        if not target:
+            name = self._name or DEFAULT_DEVICE_NAME
+            raise RuntimeError(
+                f"no advertising BLE device named {name!r} was found; make sure "
+                "the device is powered and in range, then try again."
+            )
+        self._address = target
+
+        self._stop.clear()
+        self._loop = asyncio.new_event_loop()
+        self._loop_thread = threading.Thread(
+            target=self._loop.run_forever, name="ble-loop", daemon=True
+        )
+        self._loop_thread.start()
+
+        async def _connect() -> None:
+            # ``winrt={"use_cached_services": False}`` forces a *fresh* GATT
+            # service discovery on the Windows (WinRT) backend. Windows defaults
+            # to its cached service table, and for a freshly-flashed/never-bonded
+            # peripheral that cache is stale or empty: the OS Bluetooth driver
+            # waits ~0.5 s for the GATT response, gives up, and aborts discovery
+            # — surfaced by bleak as the misleading
+            # ``[WinError -2147023673] The operation was canceled by the user``.
+            # Disabling the cache is the documented bleak workaround for this and
+            # is inert on the BlueZ/CoreBluetooth backends, so it is cross-platform
+            # safe. A fresh discovery can transiently report "Unreachable" on
+            # Windows, so the connect is retried a few times before giving up.
+            last_exc: BaseException | None = None
+            for attempt in range(1, _CONNECT_ATTEMPTS + 1):
+                if self._stop.is_set():
+                    return
+                self._client = BleakClient(
+                    self._address,
+                    disconnected_callback=self._on_disconnect,
+                    timeout=self._connect_timeout,
+                    winrt={"use_cached_services": False},
+                )
+                try:
+                    await self._client.connect()
+                    break
+                except Exception as exc:  # noqa: BLE001 - retried/re-raised below
+                    last_exc = exc
+                    log.warning(
+                        "BLE connect attempt %d/%d to %s failed: %s",
+                        attempt,
+                        _CONNECT_ATTEMPTS,
+                        self._address,
+                        exc,
+                    )
+                    try:
+                        await self._client.disconnect()
+                    except Exception:  # noqa: BLE001 - best-effort cleanup
+                        pass
+                    self._client = None
+                    if attempt < _CONNECT_ATTEMPTS:
+                        await asyncio.sleep(_CONNECT_RETRY_DELAY)
+            else:
+                raise last_exc if last_exc is not None else RuntimeError("connect failed")
+            # Prefer BlueZ "AcquireNotify" for the high-rate notification stream:
+            # it hands back a dedicated socket that bleak reads directly, instead
+            # of routing every notification through a D-Bus PropertiesChanged
+            # signal. At the default 500 Hz this materially lowers per-notification
+            # overhead and reduces coalesced/dropped notifications. bleak falls
+            # back to "StartNotify" automatically when the characteristic does not
+            # support AcquireNotify, and the argument is inert on the non-BlueZ
+            # (Windows/macOS) backends, so this is cross-platform safe.
+            await self._client.start_notify(
+                NUS_TX_CHAR_UUID,
+                self._on_notify,
+                bluez={"use_start_notify": False},
+            )
+            self._log_link_mtu()
+
+        fut = asyncio.run_coroutine_threadsafe(_connect(), self._loop)
+        # The worker may retry the connect up to ``_CONNECT_ATTEMPTS`` times, so
+        # the outer wait must allow for every attempt (each bounded by
+        # ``connect_timeout``) plus the delays between them, otherwise this
+        # blocking wait would time out and tear the loop down mid-retry.
+        overall_timeout = (
+            self._connect_timeout * _CONNECT_ATTEMPTS
+            + _CONNECT_RETRY_DELAY * (_CONNECT_ATTEMPTS - 1)
+            + 10.0
+        )
+        try:
+            fut.result(timeout=overall_timeout)
+        except Exception as exc:
+            self._teardown_loop()
+            raise RuntimeError(
+                f"failed to connect to BLE device {self._address}: {exc}"
+            ) from exc
+        self._open = True
+        log.info("BLE NUS connected to %s", self._address)
+
+    def _resolve_address_by_name(self) -> str:
+        """Scan and return the address of the first device matching the name filter."""
+        name = self._name or DEFAULT_DEVICE_NAME
+        matches = infos_matching_name(self.discover(PlatformAdapter()), name)
+        return matches[0].id if matches else ""
+
+    def _log_link_mtu(self) -> None:
+        """Best-effort log of the negotiated ATT MTU after connecting.
+
+        Reading ``client.mtu_size`` also drives an MTU acquisition on the BlueZ
+        backend where one has not happened yet; on the Windows/macOS backends the
+        value is already negotiated by the OS. The host cannot *set* the ATT MTU
+        on BlueZ (it is negotiated by the OS Bluetooth stack and must be requested
+        by the peripheral), but surfacing the value lets a user see whether the
+        link came up with the large MTU the device requests — so each ~90-byte
+        sensor frame is carried in a single notification — or silently fell back
+        to the 23-byte minimum, in which case frames are fragmented across many
+        notifications and throughput suffers. Never raises: this is a diagnostic,
+        not a connection requirement.
+        """
+        client = self._client
+        try:
+            mtu = getattr(client, "mtu_size", None)
+        except Exception:  # noqa: BLE001 - diagnostic only, never fail the connect
+            mtu = None
+        if not mtu:
+            return
+        if mtu <= _DEFAULT_ATT_MTU:
+            log.warning(
+                "BLE NUS link is at the default ATT MTU = %s bytes; the peripheral "
+                "did not negotiate a larger MTU, so each sensor frame is fragmented "
+                "across multiple notifications and throughput suffers. A larger MTU "
+                "must be requested by the device firmware — the host cannot set it.",
+                mtu,
+            )
+        else:
+            log.info("BLE NUS link negotiated ATT MTU = %s bytes", mtu)
+
+    def close(self) -> None:
+        self._stop.set()
+        self._open = False
+        # Unblock any chunks() consumer waiting on the queue.
+        try:
+            self._queue.put_nowait(None)
+        except queue.Full:
+            pass
+
+        loop = self._loop
+        client = self._client
+        if loop is not None and client is not None and loop.is_running():
+            async def _disconnect() -> None:
+                try:
+                    await client.stop_notify(NUS_TX_CHAR_UUID)
+                except Exception:
+                    pass
+                try:
+                    await client.disconnect()
+                except Exception:
+                    pass
+
+            try:
+                fut = asyncio.run_coroutine_threadsafe(_disconnect(), loop)
+                fut.result(timeout=5.0)
+            except Exception:
+                log.exception("BLE disconnect failed")
+        self._teardown_loop()
+
+    def _teardown_loop(self) -> None:
+        loop = self._loop
+        if loop is not None and loop.is_running():
+            loop.call_soon_threadsafe(loop.stop)
+        if self._loop_thread is not None:
+            self._loop_thread.join(timeout=5.0)
+        if loop is not None and not loop.is_closed():
+            try:
+                loop.close()
+            except Exception:
+                pass
+        self._loop = None
+        self._loop_thread = None
+        self._client = None
+
+    @property
+    def is_open(self) -> bool:
+        return self._open
+
+    def chunks(self) -> Iterator[bytes]:
+        while self._open and not self._stop.is_set():
+            try:
+                item = self._queue.get(timeout=0.2)
+            except queue.Empty:
+                continue
+            if item is None:
+                break
+            yield item
+
+    # ------------------------------------------------------------------
+    # BLE callbacks (run on the asyncio loop thread)
+    # ------------------------------------------------------------------
+
+    def _on_notify(self, _char: Any, data: bytearray) -> None:
+        if not data:
+            return
+        try:
+            self._queue.put_nowait(bytes(data))
+        except queue.Full:
+            # Drop the oldest queued chunk to make room; capture continues.
+            try:
+                self._queue.get_nowait()
+                self._queue.put_nowait(bytes(data))
+            except (queue.Empty, queue.Full):
+                pass
+
+    def _on_disconnect(self, _client: Any) -> None:
+        log.info("BLE NUS device disconnected")
+        self._open = False
+        try:
+            self._queue.put_nowait(None)
+        except queue.Full:
+            pass
+
+    # ------------------------------------------------------------------
+    # Schema
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def config_schema(cls) -> ConfigSchema:
+        # No user-editable fields. The peripheral is chosen from the live device
+        # list in the New Session dialog (Bluetooth toggle → scan → select →
+        # connect), and its address is stored in the source params for reconnect.
+        return ConfigSchema(fields=())

--- a/tools/data_forwarder_host/source/uart.py
+++ b/tools/data_forwarder_host/source/uart.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""UART data source (pyserial)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import serial
+import serial.tools.list_ports
+
+from data_forwarder_host.platform.base import (
+    PlatformAdapter,
+    _describe_port,  # ported verbatim helper
+    _looks_like_nrf,
+    _short_port,
+    _vid_pid,
+)
+from data_forwarder_host.source.base import (
+    ConfigField,
+    ConfigSchema,
+    Source,
+    SourceInfo,
+)
+
+
+class UartSource(Source):
+    """Bytes from a serial port."""
+
+    kind = "uart"
+
+    def __init__(
+        self,
+        *,
+        port: str,
+        baudrate: int = 115200,
+        timeout: float = 0.1,
+        chunk_size: int = 4096,
+    ) -> None:
+        # Normalize port path: ensure Unix paths start with /
+        port = port.strip()
+        if port and not port.startswith("/") and not port.startswith("COM"):
+            if port.startswith("dev/"):
+                port = "/" + port
+        self._port = port
+        self._baudrate = baudrate
+        self._timeout = timeout
+        self._chunk_size = chunk_size
+        self._serial: serial.Serial | None = None
+
+    # ------------------------------------------------------------------
+    # Discovery — uses the verbatim ported helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def discover(cls, platform: PlatformAdapter) -> list[SourceInfo]:
+        out: list[SourceInfo] = []
+        for p in serial.tools.list_ports.comports():
+            details: dict[str, Any] = {
+                "description": p.description,
+                "manufacturer": p.manufacturer,
+                "product": p.product,
+                "serial_number": p.serial_number,
+                "vid_pid": _vid_pid(p),
+                "looks_like_nrf": _looks_like_nrf(p),
+                "describe": _describe_port(p),
+            }
+            out.append(
+                SourceInfo(
+                    kind=cls.kind,
+                    id=p.device,
+                    display=_short_port(p),
+                    details=details,
+                )
+            )
+        return out
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def open(self) -> None:
+        if self._serial is not None and self._serial.is_open:
+            return
+        try:
+            self._serial = serial.Serial(self._port, self._baudrate, timeout=self._timeout)
+        except serial.SerialException as exc:
+            raise RuntimeError(f"failed to open {self._port}: {exc}") from exc
+
+    def close(self) -> None:
+        if self._serial is not None and self._serial.is_open:
+            try:
+                self._serial.close()
+            except Exception:
+                pass
+        self._serial = None
+
+    @property
+    def is_open(self) -> bool:
+        return self._serial is not None and self._serial.is_open
+
+    def chunks(self) -> Iterator[bytes]:
+        if self._serial is None:
+            raise RuntimeError("source not open")
+        while self._serial is not None and self._serial.is_open:
+            try:
+                data = self._serial.read(self._chunk_size)
+            except (TypeError, OSError, serial.SerialException):
+                # Port was closed by another thread (fd → None) or an OS error
+                # occurred.  Exit the generator cleanly; the caller sees a
+                # normal end-of-iteration.
+                break
+            if data:
+                yield data
+
+    # ------------------------------------------------------------------
+    # Schema
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def config_schema(cls) -> ConfigSchema:
+        return ConfigSchema(
+            fields=(
+                ConfigField("port", "Serial port", "str", required=True,
+                            help="e.g. /dev/ttyACM0, COM5"),
+                ConfigField("baudrate", "Baud rate", "int", default=115200),
+                ConfigField("timeout", "Read timeout (s)", "float", default=0.1),
+                ConfigField("chunk_size", "Read chunk (bytes)", "int", default=4096),
+            )
+        )

--- a/tools/data_forwarder_host/utils/__init__.py
+++ b/tools/data_forwarder_host/utils/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Shared utilities — logging, paths, time helpers, version."""

--- a/tools/data_forwarder_host/utils/debug_stream.py
+++ b/tools/data_forwarder_host/utils/debug_stream.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Rate-limited diagnostics stream for root-causing runtime slowdowns.
+
+Opt-in (off by default) so it never costs anything in normal use. When enabled
+via the ``DFH_DEBUG_STREAM`` environment variable, a per-session timer samples a
+small set of runtime metrics (recorder RAM growth, live-buffer sizes, GC
+generation counts, message rate) at a low cadence and writes one compact line
+per tick to the ``data_forwarder_host.debug`` logger.
+
+Two guards keep the stream cheap to *produce* and cheap to *analyse* (the user
+asked to cap the message count): a minimum interval between emissions and a hard
+ceiling on the total number of lines emitted, after which the stream goes quiet.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from typing import Any
+
+from PySide6.QtCore import QObject, QTimer
+
+log = logging.getLogger("data_forwarder_host.debug")
+
+ENABLED_ENV = "DFH_DEBUG_STREAM"
+
+# Defaults chosen so the stream is informative but bounded: a sample every few
+# seconds, and at most a few hundred lines per session.
+DEFAULT_INTERVAL_S = 3.0
+DEFAULT_MAX_MESSAGES = 200
+
+
+def debug_stream_enabled() -> bool:
+    """True when the debug stream is switched on via the environment."""
+    return os.environ.get(ENABLED_ENV, "").strip().lower() not in ("", "0", "false", "no")
+
+
+def format_metrics(metrics: dict[str, Any]) -> str:
+    """Render a metrics mapping as a compact, stable ``k=v`` line."""
+    parts = []
+    for key, value in metrics.items():
+        if isinstance(value, float):
+            parts.append(f"{key}={value:g}")
+        else:
+            parts.append(f"{key}={value}")
+    return " ".join(parts)
+
+
+class EmissionLimiter:
+    """Pure throttle: cap emissions by both count and (caller-supplied) ticks.
+
+    Kept Qt-free so the gating policy is isolated. The owner calls
+    :meth:`allow` once per timer tick; it returns ``False`` once the message
+    ceiling is reached so the stream stops adding noise (and cost).
+    """
+
+    def __init__(self, max_messages: int = DEFAULT_MAX_MESSAGES) -> None:
+        self._max = max(0, int(max_messages))
+        self._emitted = 0
+
+    @property
+    def emitted(self) -> int:
+        return self._emitted
+
+    @property
+    def exhausted(self) -> bool:
+        return self._emitted >= self._max
+
+    def allow(self) -> bool:
+        """Reserve one emission slot; ``False`` once the ceiling is hit."""
+        if self._emitted >= self._max:
+            return False
+        self._emitted += 1
+        return True
+
+
+class DebugStream(QObject):
+    """Timer-driven, rate-limited runtime-metrics logger (opt-in)."""
+
+    def __init__(
+        self,
+        provider: Callable[[], dict[str, Any]],
+        *,
+        interval_s: float = DEFAULT_INTERVAL_S,
+        max_messages: int = DEFAULT_MAX_MESSAGES,
+        parent: QObject | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._provider = provider
+        self._limiter = EmissionLimiter(max_messages)
+        self._timer = QTimer(self)
+        self._timer.setInterval(int(max(0.1, interval_s) * 1000))
+        self._timer.timeout.connect(self._on_tick)
+
+    def start(self) -> None:
+        self._timer.start()
+        try:
+            from data_forwarder_host.utils.paths import log_file
+
+            where = str(log_file())
+        except Exception:  # pragma: no cover - never block diagnostics
+            where = "<application log>"
+        log.info(
+            "debug stream started (interval=%dms); writing metrics to %s",
+            self._timer.interval(),
+            where,
+        )
+
+    def stop(self) -> None:
+        self._timer.stop()
+
+    def _on_tick(self) -> None:
+        if not self._limiter.allow():
+            # Ceiling reached: go quiet so analysis stays tractable.
+            self._timer.stop()
+            log.info("debug stream reached its message ceiling; stopping")
+            return
+        try:
+            metrics = self._provider()
+        except Exception:  # diagnostics must never crash the app
+            log.exception("debug stream provider failed")
+            return
+        log.info("%s", format_metrics(metrics))

--- a/tools/data_forwarder_host/utils/logging.py
+++ b/tools/data_forwarder_host/utils/logging.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Logging setup — rotating file + optional Qt log handler bridge."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from logging.handlers import RotatingFileHandler
+from typing import Any
+
+from data_forwarder_host.utils.paths import log_file
+
+_LOG_FORMAT = "%(asctime)s %(levelname)-7s %(name)s :: %(message)s"
+_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
+_BACKUP_COUNT = 5
+
+_qt_handler: logging.Handler | None = None
+
+# Dedicated logger for user-initiated actions. Lines logged through it carry a
+# clear "USER ACTION" marker so the user's workflow (what they clicked / chose)
+# can be reconstructed from the console, file and in-app log — making any later
+# error readable in the context of the steps that led to it.
+_action_log = logging.getLogger("data_forwarder_host.action")
+
+
+def log_user_action(message: str, *args: Any) -> None:
+    """Record a user-initiated GUI action to the shared log.
+
+    Emitted at INFO so it appears on the console / log file / in-app panel
+    alongside the rest of the application log. ``args`` are ``%``-formatted
+    lazily by the logging framework (do not pre-format the message).
+    """
+    _action_log.info("USER ACTION: " + message, *args)
+
+
+
+class _CallbackHandler(logging.Handler):
+    """Simple handler that forwards formatted records to a callback."""
+
+    def __init__(self, callback: Callable[[logging.LogRecord, str], None]) -> None:
+        super().__init__()
+        self._callback = callback
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            msg = self.format(record)
+            self._callback(record, msg)
+        except Exception:  # pragma: no cover — never crash the logger
+            self.handleError(record)
+
+
+def configure_logging(level: str = "INFO") -> None:
+    """Configure the root logger. Idempotent."""
+    root = logging.getLogger()
+    root.setLevel(level.upper())
+
+    if not any(
+        isinstance(h, RotatingFileHandler) and getattr(h, "_data_forwarder", False)
+        for h in root.handlers
+    ):
+        fh = RotatingFileHandler(
+            log_file(), maxBytes=_MAX_BYTES, backupCount=_BACKUP_COUNT, encoding="utf-8"
+        )
+        fh.setFormatter(logging.Formatter(_LOG_FORMAT))
+        setattr(fh, "_data_forwarder", True)
+        root.addHandler(fh)
+
+    if not any(isinstance(h, logging.StreamHandler) and not isinstance(h, RotatingFileHandler)
+               for h in root.handlers):
+        sh = logging.StreamHandler()
+        sh.setFormatter(logging.Formatter(_LOG_FORMAT))
+        root.addHandler(sh)
+
+
+def install_qt_handler(callback: Callable[[logging.LogRecord, str], Any]) -> None:
+    """Add a handler that forwards records to a GUI callback (LogPanel)."""
+    global _qt_handler
+    if _qt_handler is not None:
+        return
+    _qt_handler = _CallbackHandler(callback)
+    _qt_handler.setFormatter(logging.Formatter(_LOG_FORMAT))
+    logging.getLogger().addHandler(_qt_handler)
+
+
+def remove_qt_handler() -> None:
+    global _qt_handler
+    if _qt_handler is not None:
+        logging.getLogger().removeHandler(_qt_handler)
+        _qt_handler = None

--- a/tools/data_forwarder_host/utils/open_path.py
+++ b/tools/data_forwarder_host/utils/open_path.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Cross-platform helpers for opening files and folders.
+
+These are GUI-free so they live in the layered ``utils`` package and stay
+isolated. The command builders (:func:`open_command`, :func:`reveal_command`)
+are pure functions returning the ``argv`` to launch; the ``open_*`` wrappers run
+them with a best-effort fallback chain.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# Linux launchers tried in order: a desktop opener first, then common editors as
+# a last resort for headless/minimal environments.
+_LINUX_OPENERS = ("xdg-open", "gio", "code", "gedit", "nano")
+
+
+def _linux_opener(target: str) -> list[str] | None:
+    for tool in _LINUX_OPENERS:
+        exe = shutil.which(tool)
+        if exe is None:
+            continue
+        return [exe, "open", target] if tool == "gio" else [exe, target]
+    return None
+
+
+def open_command(path: str) -> list[str] | None:
+    """Return the ``argv`` to open *path* with the OS default handler.
+
+    Returns ``None`` when the platform opens files via a non-``subprocess``
+    mechanism (Windows ``os.startfile``) or no launcher is available.
+    """
+    if sys.platform.startswith("darwin"):
+        return ["open", path]
+    if os.name == "nt":
+        return None
+    return _linux_opener(path)
+
+
+def reveal_command(path: str) -> list[str] | None:
+    """Return the ``argv`` to open the folder containing *path*."""
+    folder = str(Path(path).resolve().parent)
+    if sys.platform.startswith("darwin"):
+        return ["open", folder]
+    if os.name == "nt":
+        return None
+    return _linux_opener(folder)
+
+
+def _run(argv: list[str]) -> bool:
+    try:
+        subprocess.Popen(argv)  # noqa: S603
+        return True
+    except Exception:
+        log.exception("failed to launch %r", argv)
+        return False
+
+
+def open_file(path: str) -> bool:
+    """Open *path* with the system default application; ``True`` on success."""
+    if os.name == "nt":
+        try:
+            os.startfile(path)  # type: ignore[attr-defined]  # noqa: S606
+            return True
+        except Exception:
+            log.exception("os.startfile failed for %s", path)
+            return False
+    argv = open_command(path)
+    return _run(argv) if argv else False
+
+
+def open_containing_folder(path: str) -> bool:
+    """Open the folder containing *path*; ``True`` on success."""
+    folder = str(Path(path).resolve().parent)
+    if os.name == "nt":
+        try:
+            os.startfile(folder)  # type: ignore[attr-defined]  # noqa: S606
+            return True
+        except Exception:
+            log.exception("os.startfile failed for %s", folder)
+            return False
+    argv = reveal_command(path)
+    return _run(argv) if argv else False

--- a/tools/data_forwarder_host/utils/paths.py
+++ b/tools/data_forwarder_host/utils/paths.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Standard application paths (wraps :mod:`platformdirs`)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from platformdirs import (
+    user_cache_dir,
+    user_config_dir,
+    user_log_dir,
+)
+
+_APP_NAME = "data_forwarder"
+_APP_AUTHOR = "Nordic Semiconductor"
+
+
+def app_config_dir() -> Path:
+    p = Path(user_config_dir(_APP_NAME, _APP_AUTHOR))
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def app_cache_dir() -> Path:
+    p = Path(user_cache_dir(_APP_NAME, _APP_AUTHOR))
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def app_log_dir() -> Path:
+    p = Path(user_log_dir(_APP_NAME, _APP_AUTHOR))
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def settings_file() -> Path:
+    return app_config_dir() / "settings.json"
+
+
+def default_recordings_dir() -> Path:
+    """Return the default CSV output directory ``<package root>/recordings``.
+
+    Used when a session's ``output_dir`` is blank. The directory is
+    NOT created here; the caller creates it on demand at CSV-write time.
+    """
+    # paths.py lives at ``data_forwarder_host/utils/paths.py``; the package root
+    # is two levels up.
+    package_root = Path(__file__).resolve().parent.parent
+    return package_root / "recordings"
+
+
+def log_file() -> Path:
+    return app_log_dir() / "data_forwarder_host.log"
+
+
+def ensure_parent(p: Path) -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def safe_join(base: Path, *parts: str) -> Path:
+    """Join ``parts`` onto ``base``, refusing traversal outside ``base``."""
+    candidate = (base.joinpath(*parts)).resolve()
+    base_resolved = base.resolve()
+    if os.path.commonpath([str(candidate), str(base_resolved)]) != str(base_resolved):
+        raise ValueError(f"path {candidate} escapes base {base_resolved}")
+    return candidate

--- a/tools/data_forwarder_host/utils/slow_span.py
+++ b/tools/data_forwarder_host/utils/slow_span.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Always-on, near-zero-cost stopwatch for GUI-thread spans.
+
+A *span* is a synchronous block of work that runs on the GUI (main) thread. If
+any single span takes longer than a threshold (default 50 ms) it has, by
+definition, blocked the Qt event loop for that long — paint and input events
+could not run, so the UI was unresponsive for the duration. This helper times
+such spans and, only when one is slow, writes a single compact, greppable line
+to the ``data_forwarder_host.debug`` logger::
+
+    slow-span name=drain_inbox ms=4211.3 thresh=50 gc=1 gc_ms=4180.4
+
+so the exact span that froze the UI can be found with ``grep slow-span`` in the
+metrics log (``~/.local/state/data_forwarder/log/data_forwarder_host.log``).
+
+Garbage-collection attribution
+------------------------------
+A span timed by ``monotonic()`` includes any stop-the-world CPython garbage
+collection that happened to run during it — a long span is often a GC pause the
+span merely *witnessed*, not work it performed. To make that visible, a global
+``gc.callbacks`` hook accumulates the wall time and count of collections; each
+span captures that baseline on entry and, when it logs as slow, appends how many
+collections ran during it and their total pause time (``gc=`` / ``gc_ms=``).
+When ``gc_ms`` is close to ``ms`` the span did not really do the work — GC did.
+The hook is registered once at import; disable it with ``DFH_GC_TRACE=0``.
+
+Note: a collection can be triggered by another thread, but CPython holds the GIL
+for the whole collection, so it still froze the GUI thread — attributing it to
+the concurrently-open span is the intended signal.
+
+Design goals
+------------
+* **Zero allocation / logging on the fast path.** When a span finishes inside
+  the threshold nothing is logged and no formatting happens — only a
+  ``monotonic()`` subtraction, two integer reads and a comparison.
+* **Two ergonomic forms.** A context manager (``with slow_span("drain"):``) for
+  wrapping inline blocks, and a decorator (``@slow_span_fn("name")`` / bare
+  ``@slow_span_fn``) for whole functions.
+* **No Qt import.** Usable from any layer in isolation.
+
+The helper does not try to be a profiler: it deliberately reports only the spans
+that actually exceeded the budget, which is exactly the signal needed to locate
+a freeze.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+import os
+from functools import wraps
+from time import monotonic
+from typing import Any, Callable, TypeVar
+
+log = logging.getLogger("data_forwarder_host.debug")
+
+# --- Global garbage-collection accounting -------------------------------
+#
+# These module-level counters are advanced by a ``gc.callbacks`` hook so any
+# span can cheaply read "how much GC happened during me" as the delta of two
+# integers, with no per-span ``gc`` calls on the fast path. A collection only
+# fires the hook a handful of times per second under churn, and each call does a
+# ``monotonic()`` and two additions, so the steady-state cost is negligible.
+_gc_collections = 0      # number of completed collections since import
+_gc_pause_ms = 0.0       # total wall time (ms) spent inside collections
+_gc_phase_t0 = 0.0       # monotonic() captured at the most recent "start" phase
+
+#: GC attribution is on unless explicitly disabled, so diagnostic logs include
+#: it without any extra setup. Set ``DFH_GC_TRACE=0`` to skip registering the
+#: hook entirely (e.g. to rule it out as a source of overhead).
+_GC_TRACE = os.environ.get("DFH_GC_TRACE", "1") not in ("0", "", "false", "False")
+
+
+def _gc_callback(phase: str, _info: dict) -> None:
+    """``gc.callbacks`` hook: accumulate collection count and wall pause time."""
+    global _gc_collections, _gc_pause_ms, _gc_phase_t0
+    if phase == "start":
+        _gc_phase_t0 = monotonic()
+    else:  # "stop"
+        _gc_pause_ms += (monotonic() - _gc_phase_t0) * 1000.0
+        _gc_collections += 1
+
+
+if _GC_TRACE and _gc_callback not in gc.callbacks:
+    gc.callbacks.append(_gc_callback)
+
+#: Default slow-span threshold in milliseconds. A span faster than this is
+#: considered to have left the event loop responsive and is never logged. The
+#: 50 ms value is ~1 missed frame at 20 Hz — small enough to catch a stutter,
+#: large enough that normal per-tick work stays silent. It can be lowered for a
+#: diagnostic session via the ``DFH_SLOW_SPAN_MS`` environment variable (read
+#: once at import) to attribute cost to finer sub-spans.
+DEFAULT_THRESHOLD_MS = float(os.environ.get("DFH_SLOW_SPAN_MS", "50") or "50")
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+class slow_span:  # noqa: N801 — context-manager spelled like a verb on purpose
+    """Time a synchronous span; log ``slow-span`` only if it exceeds *threshold_ms*.
+
+    Use as a context manager::
+
+        with slow_span("drain_inbox"):
+            ...                      # GUI-thread work
+
+        with slow_span("refresh", extra="charts=6") as span:
+            ...
+            span.note("decimate")    # optional sub-label appended to the line
+
+    The optional ``extra`` string and any :meth:`note` labels are appended to the
+    logged line (still only when the span is slow), so a single span can carry a
+    little context about *what* it was doing when it blocked.
+    """
+
+    __slots__ = ("name", "_threshold_ms", "_extra", "_notes", "_t0", "elapsed_ms",
+                 "_gc_n0", "_gc_ms0")
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        threshold_ms: float = DEFAULT_THRESHOLD_MS,
+        extra: str = "",
+    ) -> None:
+        self.name = name
+        self._threshold_ms = threshold_ms
+        self._extra = extra
+        self._notes: list[str] | None = None
+        self._t0 = 0.0
+        self.elapsed_ms = 0.0
+        self._gc_n0 = 0
+        self._gc_ms0 = 0.0
+
+    def note(self, label: str) -> None:
+        """Attach a sub-label, surfaced on the log line if the span is slow."""
+        if self._notes is None:
+            self._notes = []
+        self._notes.append(label)
+
+    def __enter__(self) -> "slow_span":
+        self._gc_n0 = _gc_collections
+        self._gc_ms0 = _gc_pause_ms
+        self._t0 = monotonic()
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        self.elapsed_ms = (monotonic() - self._t0) * 1000.0
+        if self.elapsed_ms < self._threshold_ms:
+            return
+        parts = [f"slow-span name={self.name}", f"ms={self.elapsed_ms:.1f}",
+                 f"thresh={self._threshold_ms:g}"]
+        gc_n = _gc_collections - self._gc_n0
+        if gc_n:
+            parts.append(f"gc={gc_n} gc_ms={_gc_pause_ms - self._gc_ms0:.1f}")
+        if self._extra:
+            parts.append(self._extra)
+        if self._notes:
+            parts.append("notes=" + ",".join(self._notes))
+        log.warning(" ".join(parts))
+
+
+def slow_span_fn(
+    name: str | Callable[..., Any] | None = None,
+    *,
+    threshold_ms: float = DEFAULT_THRESHOLD_MS,
+) -> Any:
+    """Decorator form of :class:`slow_span`.
+
+    Supports both bare and parametrised use::
+
+        @slow_span_fn
+        def _tick(self): ...
+
+        @slow_span_fn("data_model.on_message", threshold_ms=20)
+        def on_message(self, msg): ...
+
+    The span name defaults to the wrapped function's qualified name.
+    """
+
+    def _decorate(func: F, span_name: str) -> F:
+        @wraps(func)
+        def _wrapper(*args: Any, **kwargs: Any) -> Any:
+            gc_n0 = _gc_collections
+            gc_ms0 = _gc_pause_ms
+            t0 = monotonic()
+            try:
+                return func(*args, **kwargs)
+            finally:
+                elapsed_ms = (monotonic() - t0) * 1000.0
+                if elapsed_ms >= threshold_ms:
+                    gc_n = _gc_collections - gc_n0
+                    gc_part = (
+                        f" gc={gc_n} gc_ms={_gc_pause_ms - gc_ms0:.1f}"
+                        if gc_n
+                        else ""
+                    )
+                    log.warning(
+                        "slow-span name=%s ms=%.1f thresh=%g%s",
+                        span_name,
+                        elapsed_ms,
+                        threshold_ms,
+                        gc_part,
+                    )
+
+        return _wrapper  # type: ignore[return-value]
+
+    # Bare @slow_span_fn (called with the function directly).
+    if callable(name):
+        func = name
+        return _decorate(func, func.__qualname__)
+
+    # Parametrised @slow_span_fn("name", ...)
+    def _outer(func: F) -> F:
+        return _decorate(func, name or func.__qualname__)
+
+    return _outer

--- a/tools/data_forwarder_host/utils/syspath.py
+++ b/tools/data_forwarder_host/utils/syspath.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Keep the flat-layout package importable without shadowing stdlib modules.
+
+This package directory contains a subpackage named ``platform`` (a layered
+subpackage). When the application is launched from *inside* that directory
+(``python main.py`` or ``python -m data_forwarder_host`` with the package dir as
+CWD), Python places the package directory first on ``sys.path``; a subsequent
+``import platform`` then resolves to this subpackage instead of the standard
+library, breaking stdlib modules such as ``uuid``.
+
+:func:`corrected_sys_path` returns a repaired copy of ``sys.path`` with the
+package directory removed (so stdlib resolves normally) and its parent present
+and first (so ``data_forwarder_host`` itself stays importable). The function is
+pure; callers assign the result to ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def corrected_sys_path(package_dir: str, path: list[str], *, cwd: str) -> list[str]:
+    """Return a copy of ``path`` safe to use from inside ``package_dir``.
+
+    Every entry whose absolute form equals ``package_dir`` is dropped (an empty
+    ``""`` entry is interpreted as ``cwd``, matching CPython). The parent of
+    ``package_dir`` is ensured to be present and first so the package remains
+    importable. Idempotent.
+    """
+    pkg = os.path.abspath(package_dir)
+    parent = os.path.dirname(pkg)
+    cleaned = [p for p in path if os.path.abspath(p or cwd) != pkg]
+    if not any(os.path.abspath(p or cwd) == parent for p in cleaned):
+        cleaned.insert(0, parent)
+    return cleaned
+
+
+def repair_launcher_path() -> None:
+    """Apply :func:`corrected_sys_path` to the live ``sys.path`` in place.
+
+    Shared by the two in-tree launchers (``main.py`` and ``__main__.py``) so the
+    single definition of *how* the correction is applied — the package directory
+    (derived from this module's own location) and the ``cwd`` semantics — cannot
+    drift between them. Impure by design: it mutates ``sys.path``.
+    """
+    package_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[:] = corrected_sys_path(package_dir, sys.path, cwd=os.getcwd())

--- a/tools/data_forwarder_host/utils/timeutil.py
+++ b/tools/data_forwarder_host/utils/timeutil.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Time helpers — host monotonic milliseconds and UTC ISO-8601 strings."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+
+
+def host_monotonic_ms() -> int:
+    """Host monotonic clock in integer milliseconds."""
+    return int(time.monotonic() * 1000.0)
+
+
+def utc_iso8601_now() -> str:
+    """ISO-8601 UTC timestamp with microsecond precision, ``Z`` suffix."""
+    dt = datetime.now(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond:06d}Z"
+
+
+def utc_iso8601_from_epoch_us(epoch_us: int) -> str:
+    """Convert microseconds since the Unix epoch to ISO-8601 UTC."""
+    s, us = divmod(epoch_us, 1_000_000)
+    dt = datetime.fromtimestamp(s, tz=timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{us:06d}Z"
+
+
+def stamp_for_filename() -> str:
+    """``YYYYMMDD-HHMMSS`` (local time), suitable as a filename component."""
+    return datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/tools/data_forwarder_host/utils/version.py
+++ b/tools/data_forwarder_host/utils/version.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""Version helper."""
+
+from __future__ import annotations
+
+from data_forwarder_host import __version__
+
+
+def get_version() -> str:
+    return __version__


### PR DESCRIPTION
## Description
This PR adds `data_forwarder_host`, a new cross-platform desktop GUI tool that receives, visualises, records and exports sensor data forwarded from an nRF device over **UART** or **BLE NUS** (Nordic UART Service). It is the host-side counterpart to the `data_forwarder` device sample and decodes the device's COBS + CBOR v1 frame format. Multiple capture sessions can run side by side, each in its own tab.

## Highlights
- **Sources**: UART (pyserial) and BLE NUS (bleak), with a New Session dialog that scans for and connects to advertising BLE devices.
- **Out-of-process acquisition**: byte reading + COBS/CBOR decode run in a `spawn` child process so the GUI stays responsive regardless of backend load. The GUI process drains decoded frames over an IPC queue at its own cadence with bounded, consumer-paced back-pressure that never drops control/metadata frames. Set `DFH_SINGLE_PROCESS=1` to fall back to the in-GUI path.
- **Visualisation**: combined overlay plot and collapsible per-channel charts (QtCharts), render-time min/max decimation, rolling time window, recording start/stop markers, and live ASCII / decoded-frame log consoles.
- **Recording**: RAM-buffered capture dumped to CSV on stop (written incrementally off the event loop), each paired with a `{stem}.txt` metadata sidecar (host, transport, timing, device session info, channels, errors). A persistent banner shows the last saved file with open-file / open-folder shortcuts.
- **Diagnostics**: live bandwidth/throughput readout, host CPU/RAM metrics, per-category error & loss analysis with transport-loss confirmation windows, First Failure Data Capture, and an animated pipeline-flow view of stage utilisation/back-pressure.
- **Architecture**: strictly layered (`platform` -> `source` -> `protocol` -> `pipeline` -> `core` -> `session` -> `gui`). The acquisition/transport layers (`platform`, `source`, `protocol`, `pipeline`) are Qt-free and run in the headless child process; the data-model, session and GUI layers run in the GUI process and use Qt.

## How to try it (recommended)
The easiest, dependency-free way to run and test the app — and the default way to try this PR — is to build the standalone single-file binary:

```bash
tools/data_forwarder_host$ ./scripts/build_linux_binary.sh
```

This provisions an isolated venv and runs PyInstaller, emitting the single file:

```
dist/data-forwarder-host
```

Run it directly (no Python or dependencies required on the machine):

```bash
tools/data_forwarder_host$ ./dist/data-forwarder-host
```

## How to run (from source)
```bash
cd tools/data_forwarder_host
pip install -r requirements.txt
data-forwarder-host        # or: python -m data_forwarder_host / python main.py
```

Requires Python 3.12+ on Linux, Windows or macOS. PySide6 (Qt 6 with QtCharts) is a base dependency and is always installed. On Linux, UART sources need serial-port access (usually `dialout` group membership); on Ubuntu/Debian the Qt xcb platform plugin also needs `sudo apt install libxcb-cursor0`.

The matching device-side firmware is the `data_forwarder` sample (`edge-ai/samples/data_forwarder`); without it running there is no data to receive.

## Verification
Manually verified UART and BLE NUS capture, multi-session tabs, recording → CSV + metadata sidecar, and GUI responsiveness under flood (out-of-process path) using the `scripts/repro_freeze.py` harness. Validated on Ubuntu; macOS and Windows are expected to run via bleak/CoreBluetooth/WinRT but are not yet validated.

## Notes
- All files are new additions; no existing code is modified.
- Every file carries the SPDX header `LicenseRef-Nordic-5-Clause`.

## Jira
NCSDK-39472