### PR TITLE
doc: Fix path to requirements.txt in the Axon setup page

### DIFF
--- a/doc/setting_up/axon_setup.rst
+++ b/doc/setting_up/axon_setup.rst
@@ -67,7 +67,7 @@ You can set up the Python environment using one of the methods below.
 
          .. code-block:: console
 
-            cd <project_root>/compiler/scripts
+            cd tools/axon/compiler/scripts
             pip install -r requirements.txt
 
       .. note::


### PR DESCRIPTION
The path was incorrect and users ended up searching the file manually.