### PR TITLE
tools: add Windows PyInstaller build script for data_forwarder_host

### DIFF
--- a/tools/data_forwarder_host/.gitignore
+++ b/tools/data_forwarder_host/.gitignore
@@ -15,3 +15,4 @@ __pycache__/
 # matches this build SCRIPT by name. It is a tracked source deliverable, so
 # re-include it explicitly.
 !scripts/build_linux_binary.sh
+!scripts/build_windows_binary.ps1

--- a/tools/data_forwarder_host/README.md
+++ b/tools/data_forwarder_host/README.md
@@ -74,30 +74,23 @@ Set `DFH_SINGLE_PROCESS=1` to fall back to the legacy in-GUI acquisition path.
 ## Standalone single-file binary (no install on the target)
 
 To run the application on a machine that has **no Python and no dependencies
-installed**, build a single self-contained executable with PyInstaller:
+installed**, build a single self-contained executable with PyInstaller. Each
+platform script creates an isolated `.build-venv` (gitignored) from a standard
+system CPython — not nrfutil's toolchain Python — and runs PyInstaller from
+that environment against `data_forwarder_host.spec`. The result bundles the
+Python interpreter, Qt6 and every dependency into one file (~100 MB).
 
-```bash
-./scripts/build_linux_binary.sh
-```
+Build on the **oldest** OS version you intend to support. On Linux, glibc is
+forward-compatible only — a binary built on Ubuntu 22.04 runs on 22.04+, but one
+built on 24.04 may not run on 22.04.
 
-This produces one file, `dist/data-forwarder-host`, that bundles the Python
-interpreter, Qt6 and every dependency. Copy that single file to any reasonably
-recent x86_64 Ubuntu machine and run it directly — nothing has to be installed
-there:
+| Platform | Build command | Output |
+|----------|---------------|--------|
+| Linux | `./scripts/build_linux_binary.sh` | `dist/data-forwarder-host` |
+| Windows | `powershell -ExecutionPolicy Bypass -File .\scripts\build_windows_binary.ps1` | `dist\data-forwarder-host.exe` |
 
-```bash
-./data-forwarder-host
-```
-
-Notes:
-
-- Build on the **oldest** Ubuntu you intend to support: glibc is forward- but
-  not backward-compatible, so a binary built on 22.04 runs on 22.04+, while one
-  built on 24.04 may not run on 22.04.
-- The build is driven by `data_forwarder_host.spec`; `scripts/build_linux_binary.sh`
-  just provisions an isolated build virtualenv (kept out of git) and invokes
-  PyInstaller against that spec.
-- The binary is large (~100 MB) because the whole Qt6 stack is embedded.
+Copy the output file to a target machine and run it directly — nothing has to be
+installed there.
 
 ## First-time use
 

--- a/tools/data_forwarder_host/scripts/build_linux_binary.sh
+++ b/tools/data_forwarder_host/scripts/build_linux_binary.sh
@@ -65,9 +65,12 @@ python -m pip install --upgrade pip wheel >/dev/null
 python -m pip install "." "pyinstaller>=6.6"
 
 # 3. Clean previous artefacts and build from the spec.
+#    -I (isolated): the package root contains a `platform/` subpackage; without
+#    isolation, CWD on sys.path shadows stdlib `platform` and PyInstaller dies
+#    with "module 'platform' has no attribute 'system'" / missing `win32_ver`.
 echo ">> Building single-file binary"
 rm -rf build dist
-pyinstaller --noconfirm --clean data_forwarder_host.spec
+python -I -m PyInstaller --noconfirm --clean data_forwarder_host.spec
 
 BIN="$PKG_DIR/dist/data-forwarder-host"
 if [ -x "$BIN" ]; then

--- a/tools/data_forwarder_host/scripts/build_windows_binary.ps1
+++ b/tools/data_forwarder_host/scripts/build_windows_binary.ps1
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+# Build a single self-contained Windows executable for the Data Forwarder Host.
+#
+# The result is ONE file, dist\data-forwarder-host.exe, that bundles the Python
+# interpreter and every dependency (PySide6/Qt6, numpy, bleak, ...). Copy it to
+# another Windows machine and run it directly - nothing has to be installed there.
+#
+# Usage (from the package directory or anywhere):
+#   powershell -ExecutionPolicy Bypass -File .\scripts\build_windows_binary.ps1
+#
+# Notes:
+#   * Build on the OLDEST Windows version you intend to support (e.g. Windows 10
+#     or 11). Test on a clean VM before distributing broadly.
+#   * Requires a standard Windows CPython 3.12+ on PATH (python.org or winget).
+#     Do not use the nrfutil/NCS toolchain Python - use $env:PYTHON_BIN to point
+#     at a normal install, e.g.  py -3.12
+#   * Internet access for the one-time dependency download.
+#   * Unsigned executables may trigger SmartScreen on first run; code-sign for
+#     external distribution.
+#   * BLE on Windows is implemented but not yet validated in project docs - test
+#     UART and BLE after building.
+
+#Requires -Version 5.1
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$PkgDir = Split-Path -Parent $ScriptDir
+Set-Location $PkgDir
+
+$PythonBin = if ($env:PYTHON_BIN) { $env:PYTHON_BIN } else { "python" }
+$BuildVenv = if ($env:BUILD_VENV) { $env:BUILD_VENV } else { Join-Path $PkgDir ".build-venv" }
+$VenvPython = Join-Path $BuildVenv "Scripts\python.exe"
+
+Write-Host ">> Using interpreter: $(& $PythonBin --version)"
+$InterpreterPath = & $PythonBin -c "import sys; print(sys.executable)"
+Write-Host ">> Interpreter path:   $InterpreterPath"
+$Platform = & $PythonBin -c "import sys; print(sys.platform)"
+if ($Platform -ne "win32") {
+    Write-Error "!! Expected Windows CPython (sys.platform=win32), got '$Platform'. Use a standard python.org install."
+}
+
+function Test-VenvUsable {
+    if (-not (Test-Path -LiteralPath $VenvPython)) {
+        return $false
+    }
+    & $VenvPython -m pip --version *> $null
+    return $LASTEXITCODE -eq 0
+}
+
+# 1. Isolated build environment (kept out of git via .gitignore).
+#    Reuse only if python -m pip works; stale/copied venvs get recreated.
+if (-not (Test-VenvUsable)) {
+    if (Test-Path -LiteralPath $BuildVenv) {
+        Write-Host ">> Existing build venv is unusable (stale/foreign) - recreating"
+        Remove-Item -LiteralPath $BuildVenv -Recurse -Force
+    }
+    Write-Host ">> Creating build venv at $BuildVenv"
+    & $PythonBin -m venv $BuildVenv
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "!! Failed to create venv. Install Python 3.12+ with the venv module."
+    }
+}
+
+# 2. Install the app's runtime deps (from pyproject.toml) + PyInstaller.
+Write-Host ">> Installing runtime dependencies and PyInstaller"
+& $VenvPython -m pip install --upgrade pip wheel *> $null
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "!! pip upgrade failed."
+}
+# pywin32-ctypes is required by PyInstaller on Windows (imported from compat.py).
+& $VenvPython -m pip install "." "pyinstaller>=6.6" "pywin32-ctypes>=0.2"
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "!! Dependency install failed."
+}
+
+# 3. Clean previous artefacts and build from the spec.
+#    -I (isolated): the package root contains a `platform/` subpackage; without
+#    isolation, CWD on sys.path shadows stdlib `platform` and PyInstaller dies
+#    with "module 'platform' has no attribute 'win32_ver'".
+Write-Host ">> Building single-file binary"
+foreach ($dir in @("build", "dist")) {
+    if (Test-Path -LiteralPath $dir) {
+        Remove-Item -LiteralPath $dir -Recurse -Force
+    }
+}
+& $VenvPython -I -m PyInstaller --noconfirm --clean data_forwarder_host.spec
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "!! PyInstaller build failed."
+}
+
+$Bin = Join-Path $PkgDir "dist\data-forwarder-host.exe"
+if (Test-Path -LiteralPath $Bin) {
+    $sizeMb = [math]::Round((Get-Item -LiteralPath $Bin).Length / 1MB, 1)
+    Write-Host ""
+    Write-Host ">> Done. Single-file binary:"
+    Write-Host "     $Bin"
+    Write-Host "     size: ${sizeMb} MB"
+    Write-Host ">> Run it with:  $Bin"
+} else {
+    Write-Error "!! Build finished but $Bin was not produced."
+}


### PR DESCRIPTION
Add `scripts/build_windows_binary.ps1` to produce `dist/data-forwarder-host.exe` via PyInstaller.
Mirrors the existing Linux flow: isolated .build-venv, install app + PyInstaller, one-file bundle.