### PR TITLE
doc: link to data forwarder host tool

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -50,6 +50,7 @@ See the following documentation:
    integrations.rst
    axon_compiler.rst
    libraries.rst
+   tools.rst
    glossary.rst
    release_notes.rst
    known_issues.rst

--- a/doc/links.txt
+++ b/doc/links.txt
@@ -6,6 +6,7 @@
 .. ### Source: www.nordicsemi.com
 
 .. _`training dataset`: https://files.nordicsemi.com/ui/native/edge-ai/external/
+.. _`Data Forwarder Host artifacts`: https://files.nordicsemi.com/artifactory/edge-ai/external/tools/dfh
 .. _`Nordic Thingy:53 Multi-protocol IoT prototyping platform`: https://www.nordicsemi.com/Products/Development-hardware/Nordic-Thingy-53
 .. _`Nordic Edge AI Lab`: https://ai.lab.nordicsemi.com/
 .. _`nRF54LM20B`: https://www.nordicsemi.com/Products/nRF54LM20B

--- a/doc/tools.rst
+++ b/doc/tools.rst
@@ -1,0 +1,14 @@
+.. _tools:
+
+Tools
+#####
+
+The |EAI| provides host-side utilities that support Edge AI development workflows on a PC.
+Use these tools alongside the on-device samples and libraries.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :caption: Subpages:
+
+   tools/data_forwarder_host

--- a/doc/tools/data_forwarder_host.rst
+++ b/doc/tools/data_forwarder_host.rst
@@ -1,0 +1,11 @@
+.. _data_forwarder_host_tool:
+
+Data Forwarder Host tool
+########################
+
+The Data Forwarder Host is a cross-platform desktop GUI for receiving, visualizing, recording, and exporting sensor data from a device running Data Forwarder Sample over UART or `Nordic UART Service (NUS)`_.
+
+For installation, usage, and development details, see :file:`tools/data_forwarder_host/README.md` in the |EAI| repository.
+For Bluetooth LE throughput tuning (disconnecting competing devices, OS-specific host settings), see :file:`tools/data_forwarder_host/docs/ble_throughput_tuning.md`.
+
+Alternatively, use the prebuilt `Data Forwarder Host standalone executable <Data Forwarder Host artifacts_>`_ -- no Python installation required.


### PR DESCRIPTION
Create new top-level page tools and subpage for data forwarder host tool linking to the standalone documentation.

Jira: NCSDK-39920