### PR TITLE
doc: add Demos section with person_detection reference page

### DIFF
--- a/doc/demos.rst
+++ b/doc/demos.rst
@@ -1,0 +1,21 @@
+.. _demos:
+
+Demos
+#####
+
+.. contents::
+   :local:
+   :depth: 2
+
+This section lists demo applications that showcase the |EAI| in real-world use cases.
+
+Unlike the applications and samples in this repository, each demo lives in its own repository outside the |EAI| tree.
+Each is a `Workspace application`_ that pins a compatible |EAI| release in its :file:`west.yml` file.
+Demos are not kept in sync with every |EAI| release and are not guaranteed to keep working or receive fixes.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+   :caption: Subpages:
+
+   demos/person_detection

--- a/doc/demos/person_detection.rst
+++ b/doc/demos/person_detection.rst
@@ -1,0 +1,16 @@
+.. _demo_person_detection:
+
+Person detection
+################
+
+This demo shows real-time person detection from a camera stream, running on the `Axon NPU`_.
+It is maintained in the `Person detection demo repository`_, separate from the |EAI| repository.
+
+The demo is an enriched version of the :ref:`Person detection application <app_person_detection>` from |EAI|.
+It uses the same hardware, model, and detection pipeline, but adds the following capabilities that are not part of the maintained in the base application:
+
+* Live image and detection streaming to a PC over USB CDC ACM, viewed with a host-side Python script.
+* A customized ArduCam Mega driver tuned for a higher capture framerate to support continuous streaming.
+* GPIO trace pins for measuring current and duration of each processing phase (capture, preprocessing, inference, postprocessing) with a `Power Profiler Kit II (PPK2)`_.
+
+See the `Person detection demo repository`_ for setup, build instructions, and the streaming viewer.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -47,6 +47,7 @@ See the following documentation:
    setting_up_environment.rst
    applications.rst
    samples.rst
+   demos.rst
    integrations.rst
    axon_compiler.rst
    libraries.rst

--- a/doc/links.txt
+++ b/doc/links.txt
@@ -119,6 +119,7 @@
 .. _`Setting up Podman container`: https://github.com/podman-container-tools/podman/blob/main/docs/tutorials/podman_tutorial.md#running-a-sample-container
 .. _`edge-impulse-sdk-zephyr`: https://github.com/edgeimpulse/edge-impulse-sdk-zephyr
 .. _`MCUnet`: https://github.com/mit-han-lab/mcunet
+.. _`Person detection demo repository`: https://github.com/nordicsemi/app-axon-person-detection
 
 .. ## External sources:
 


### PR DESCRIPTION
Add a new top-level Demos section for standalone showcase applications maintained outside the Edge AI Add-on tree. Populate it with a reference page for the person detection demo, pointing to its external repository and summarizing how it differs from the maintained in-tree person detection application.

Jira: NCSDK-39934
Jira: NCSDK-40064