### PR TITLE
doc: add info about transposing and per-channel quantization 

### DIFF
--- a/doc/axon_compiler/supported_operators.rst
+++ b/doc/axon_compiler/supported_operators.rst
@@ -15,7 +15,7 @@ Model structure
 The Axon Compiler has the following constraints on model structure:
 
 * Allows a maximum of 1 external input to the model.
-* Allows a maximum of 20 ouputs of the model.
+* Allows a maximum of 20 outputs of the model.
 * Supports 8-bit quantized input and output for all layers, with an option to use int32 model output with a configurable radix.
 * Supports stateful behavior between inferences when declared using VarHandle, ReadVariable, or AssignVariable.
 * Allows a maximum of two inputs per node.
@@ -27,6 +27,13 @@ The Axon Compiler has the following constraints on model structure:
 
 * Provides native activation functions: ReLU, ReLU6, and LeakyReLU.
 * Provides CPU activation functions: Sigmoid, Tanh, and Softmax.
+
+Performance considerations
+==========================
+
+The Axon performs best with a wider aspect ratio, so models with a greater width than height perform better on the NPU.
+If your model height is bigger than its width, use the ``TRANSPOSE_KERNEL`` option of :ref:`Axon Compiler <axon_npu_tflite_compiler>`.
+Note that this option requires you to transpose the input and output data as well.
 
 .. _supported_operators_reshape:
 
@@ -286,6 +293,10 @@ Quantization guidance
 =====================
 
 To achieve optimal performance and predictable accuracy, train models using 8‑bit quantization awareness when targeting deployment on Axon.
+
+Axon NPU supports per‑tensor and per‑channel quantization for fully connected layers.
+Per‑channel quantization often produces better accuracy, but at the expense of larger :term:`interlayer buffer <Axon interlayer buffer>` and :term:`command buffer <Axon command buffer>` requirements.
+Per‑channel quantization for fully‑connected layers is enabled by default in TensorFlow, but can be disabled with ``converter._experimental_disable_per_channel_quantization_for_dense_layers = True``.
 
 Deployment strategy
 ===================

--- a/doc/doxyfile.in
+++ b/doc/doxyfile.in
@@ -1031,7 +1031,10 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */build*/*
+EXCLUDE_PATTERNS       = */build*/* \
+                         */nrf_edgeai_generated/* \
+                         */generated/* \
+                         */tests/axon/compiled_models/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -5,41 +5,33 @@ Glossary
 
 The glossary defines the key terms used throughout the documentation.
 
-command_buffer
---------------
+.. glossary::
+   :sorted:
 
-The fundamental unit of work for Axon is a command buffer. A command buffer comprises compiled Axon code and a small amount of meta data.
+   Axon command buffer
+      The fundamental unit of work for Axon.
+      A command buffer comprises compiled Axon code and a small amount of meta data.
 
-compiled model
---------------
+   Axon compiled model
+      The Axon NN compiler toolchain produces a header file :file:`nrf_axon_model_<model_name>_.h` that contains the compiled model.
+      The compiled model is entirely contained by the :c:type:`nrf_axon_nn_compiled_model_s` structure.
 
-The Axon NN compiler tool chain produces a header file :file:`nrf_axon_model_<model_name>_.h` that contains the compiled model. 
-The compiled model is entirely contained by an nrf_axon_nn_compiled_model_s structure. This structure is declared in :file:`include/nrf_axon_nn_infer.h`.
+   Inference
+      The act of executing the machine learning model.
 
-inference
----------
+   Axon interlayer buffer
+      A global buffer shared by all Axon models for storing intermediate results.
+      It is declared as ``nrf_axon_interlayer_buffer[NRF_AXON_INTERLAYER_BUFFER_SIZE]`` in the platform code.
 
-The act of executing the compiled model.
+   Axon intrinsic
+      A wrapper function around a small command buffer stored in RAM, allowing certain parameters to be changed at run time.
+      It encapsulates a specific piece of functionality.
 
-interlayer buffer
------------------
+   Packed buffer
+      In the context of Axon, a packed buffer with no gaps between the start of rows in a multi-dimensional shape.
+      Axon hardware writes the start of each row to a 32-bit aligned address, so if the row size is not a multiple of 32 bits, a gap appears between rows.
+      The compiled model structure describes the shape of the inputs and output.
 
-The interlayer buffer is a global buffer shared by all models for storing intermediate results.
-It is declared as nrf_axon_interlayer_buffer[NRF_AXON_INTERLAYER_BUFFER_SIZE] in the platform code. 
-
-intrinsic
----------
-
-An intrinsic is a wrapper function around a small command buffer that is stored in RAM so that certain parameters can be changed at run time. The intrinsic encapsulates specific functionality.
-
-packed buffer
----------------
-
-In the context of Axon, a packed buffer is one where there are no gaps between the start of
-rows in a multi-dimensional shape. Axon hardware writes the start of each row to a 32bit aligned address.
-If the row size is not a multiple of 32bits, there is a gap between the rows. The compiled model structure describes the shape of the inputs and output.
-
-streaming model
----------------
-
-A streaming model uses the TFLite operators VarHandle/AssignVariable/ReadVariable to save/retrieve intermediate results for the next inference. The compiled model will save these results to dedicated buffers outside of the interlayer buffer so that they are preserved between inferences.
+   Streaming model
+      A streaming model uses the TFLite operators VarHandle/AssignVariable/ReadVariable to save/retrieve intermediate results for the next inference.
+      The compiled model saves these results to dedicated buffers outside of the interlayer buffer to preserve them between inferences.


### PR DESCRIPTION
Extend Axon compiler supported operators with information about:
- transposing kernels for high aspect ratio models
- effects of per-channel quantization of Axon models

Jira: NCSDK-40154

2 additional clean up commits