### PR TITLE
ci: add doc-required label and CODEOWNERS for docs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,15 @@
+# https://github.com/actions/labeler/blob/main/README.md
+#
+# When extending this, remember that in the PR, the labeler will run against
+# the labeler.yml in main, more info:
+# https://github.com/actions/labeler/issues/12
+# This means your changes won't be tested. To test your branch, make a second
+# branch with dummy changes, and open a PR on your own fork, against the
+# first branch.
+
+"doc-required":
+- changed-files:
+  - any-glob-to-any-file:
+    - "doc/**/*"
+    - "**/*.rst"
+    - "**/*.md"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: 'Pull Request Labeler'
+on:
+  - pull_request_target
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          sync-labels: true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+# CODEOWNERS for autoreview assigning in github
+
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Order is important; the last matching pattern takes the most
+# precedence.
+
+# Documentation changes require review from the tech writer team.
+doc/**/*      @nrfconnect/ncs-sdk-edge-ai-doc
+**/*.rst      @nrfconnect/ncs-sdk-edge-ai-doc
+**/*.md       @nrfconnect/ncs-sdk-edge-ai-doc


### PR DESCRIPTION
Add a doc-required label rule and labeler workflow so PRs touching doc/**/*, *.rst or *.md files are automatically flagged for tech writer visibility. Add a CODEOWNERS file assigning those same paths to @nrfconnect/ncs-sdk-edge-ai-doc so their review can be enforced once "Require review from Code Owners" is enabled on the main branch.

Jira: NCSDK-40163