### PR TITLE
applications: gesture_recognition: disable mcuboot serial recovery

### DIFF
--- a/applications/gesture_recognition/configuration/thingy53_nrf5340_cpuapp/images/mcuboot/prj_release.conf
+++ b/applications/gesture_recognition/configuration/thingy53_nrf5340_cpuapp/images/mcuboot/prj_release.conf
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
+CONFIG_MCUBOOT_SERIAL=n
 CONFIG_GPIO=n
 CONFIG_SERIAL=n
 CONFIG_CONSOLE=n

--- a/applications/gesture_recognition/configuration/thingy53_nrf5340_cpuapp/images/mcuboot/prj_release_no_ble.conf
+++ b/applications/gesture_recognition/configuration/thingy53_nrf5340_cpuapp/images/mcuboot/prj_release_no_ble.conf
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
+CONFIG_MCUBOOT_SERIAL=n
 CONFIG_GPIO=n
 CONFIG_SERIAL=n
 CONFIG_CONSOLE=n


### PR DESCRIPTION
Disable the serial recovery option explicitly. It's not used, but the default has changed to 'enabled'. The release config in this app assumes serial recovery is disabled.
Note: "Known Issue" to be added in the respective doc PR.