### PR TITLE
ci: Add patch step to compliance workflow

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -45,6 +45,10 @@ jobs:
           [[ "$(git rev-list --merges --count origin/${BASE_REF}..)" == "0" ]] || \
             (echo "::error ::Merge commits not allowed, rebase instead";false)
 
+      - name: Apply patches
+        working-directory: ncs
+        run: west patch --src-module edge-ai apply
+
       - name: Run Compliance Tests
         continue-on-error: true
         id: compliance

--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -1,0 +1,12 @@
+patches:
+  - path: zephyr/compliance-skip-release-notes-kconfig.patch
+    sha256sum: a64472881036e71f321149642db3c296115e944277aa2725be5245bf087e8c22
+    module: zephyr
+    author: Szymon Antkowiak
+    email: szymon.antkowiak@nordicsemi.no
+    date: 2026-07-09
+    upstreamable: true
+    comments: |
+      Skip doc/release_notes_and_migration in the undefined Kconfig symbol check.
+      Edge AI add-on release notes document renamed or removed Kconfig options,
+      matching the exclusion used for doc/nrf/releases_and_maturity in NCS.

--- a/zephyr/patches/zephyr/compliance-skip-release-notes-kconfig.patch
+++ b/zephyr/patches/zephyr/compliance-skip-release-notes-kconfig.patch
@@ -1,0 +1,12 @@
+diff --git a/scripts/ci/check_compliance.py b/scripts/ci/check_compliance.py
+index dfec13c96f7..bcae798c2b2 100755
+--- a/scripts/ci/check_compliance.py
++++ b/scripts/ci/check_compliance.py
+@@ -1562,6 +1562,7 @@ Missing SoC names or CONFIG_SOC vs soc.yml out of sync:
+             ":!/doc/nrf/libraries/bin/lwm2m_carrier/CHANGELOG.rst",
+             ":!/doc/nrf/app_dev/device_guides/nrf70/wifi_advanced_security_modes.rst",
+             ":!/doc/nrf-bm/release_notes",
++            ":!/doc/release_notes_and_migration",
+             cwd=GIT_TOP,
+         )
+ 


### PR DESCRIPTION
Add patching step to compliance workflow.
Add patch to Zephyr fixing complaince issues with now-removed symbols.