### PR TITLE
Doc: refer to "compile your own model" lab feature and consolidate data collection documentation

### DIFF
--- a/applications/gesture_recognition/README.rst
+++ b/applications/gesture_recognition/README.rst
@@ -32,6 +32,7 @@ Based on accelerometer and gyroscope data, the nRF Edge AI model recognizes eigh
 
 The neural network model is trained using the `Nordic Edge AI Lab`_.
 The whole process how to capture data and train the model is described in the `Nordic Edge AI Lab documentation`_.
+Alternatively, you can collect training data using the :ref:`data_forwarder_sample` sample together with the :ref:`data_forwarder_host_tool`.
 You can also see `Gesture recognition use-case demo video`_.
 
 Requirements
@@ -269,6 +270,13 @@ Building firmware for data collection
 It is possible to create a build that outputs raw data from the accelerometer and gyro sensors on the serial port.
 No inference is performed in this mode.
 This allows to capture data for training new models and to test and implement new use cases.
+
+.. note::
+
+   As an alternative to the built-in data collection mode, use the :ref:`data_forwarder_sample` sample with the :ref:`data_forwarder_host_tool` to stream sensor data to your host for `Nordic Edge AI Lab`_ workflows.
+   The data forwarder sample is a dedicated firmware for collecting training data.
+   It supports additional sensors and exports data in a format compatible with Edge AI Lab data collection.
+
 The output consists of 16-bit integers separated by a comma, in the following order:
 
 .. code-block::

--- a/doc/axon_compiler.rst
+++ b/doc/axon_compiler.rst
@@ -3,9 +3,9 @@
 Axon NPU compiler
 #################
 
-The following pages describes the :ref:`TinyML sample models <axon_compiler_tiny_models>` provided with the :ref:`Axon TFLite compiler <axon_npu_tflite_compiler>`.
+The following pages describe the :ref:`TinyML sample models <axon_compiler_tiny_models>` provided with the :ref:`Axon TFLite compiler <axon_npu_tflite_compiler>`.
 They cover instructions on how the compiler is used to compile and run machine learning models on the Axon NPU.
-The TinyML models serve as reference implementations and show how to prepare data, compile models using the compiler, and validate inference on Axon.
+The TinyML models serve as reference implementations and show how to prepare data, compile models using the local compiler, and validate inference on Axon.
 Each model includes an overview and a dedicated subpage with model‑specific details and usage instructions.
 
 .. toctree::

--- a/doc/axon_compiler/Axon_npu_tflite_compiler.rst
+++ b/doc/axon_compiler/Axon_npu_tflite_compiler.rst
@@ -17,6 +17,24 @@ The Axon NPU TFLite compiler converts a TensorFlow Lite (``.tflite`` or ``.lite`
 Optionally, the compiler can run inference on a provided test dataset to validate that the compiled model produces results that match TensorFlow Lite accuracy.
 When test data is provided, the compiler can also generate test vectors for on‑target verification.
 
+.. _axon_compile_model_options:
+
+Compilation options
+===================
+
+You can compile TensorFlow Lite models for Axon in two ways:
+
+Nordic Edge AI Lab
+   Use the `Nordic Edge AI Lab Compile your own model`_ feature to upload an int8-quantized ``.tflite`` or ``.lite`` file and download Axon-optimized header files from the cloud.
+   This option does not require a local Python environment or access to the compiler binaries in this repository.
+
+   See :ref:`axon_compile_model` for how this method fits into the Axon driver workflow.
+
+Local Axon NPU TFLite compiler
+   Use the executor and compiler library described in the rest of this guide when you need local compilation, custom YAML configuration, accuracy validation with test data, test vector generation, or variant exploration.
+
+Both options use the same Axon NPU compiler technology and produce header files compatible with the Axon driver API.
+
 Workflow
 ========
 

--- a/doc/libraries/axon.rst
+++ b/doc/libraries/axon.rst
@@ -19,8 +19,10 @@ You can create applications that target the SoC (running zephyr) or a software s
 Neural Net Workflow
 *******************
 
-The neural net compiler for Axon NPU is provided in :file:`compiler/scripts`.
-It has two components; an executor script and a compiler shared object/dll.
+You can compile TensorFlow Lite models for Axon in `Nordic Edge AI Lab`_ using the `Nordic Edge AI Lab Compile your own model`_ feature, or locally with the neural net compiler provided in :file:`compiler/scripts`.
+See :ref:`axon_compile_model_options` for a comparison of both options.
+
+The local compiler has two components; an executor script and a compiler shared object/dll.
 The compiler can work with a .tflite file (bare minimum) or the complete Keras model.
 The complete model with a test data set is needed if the user wants to measure quantization loss.
 The user is responsible for populating a configuration .yml file with various parameters.

--- a/doc/links.txt
+++ b/doc/links.txt
@@ -32,6 +32,7 @@
 .. _`Nordic Edge AI Lab Analytics Tools`: https://docs.nordicsemi.com/r/bundle/edge-ai-lab/page/analytics_tools.html
 .. _`Nordic Edge AI Lab Anomaly detection`: https://docs.nordicsemi.com/r/bundle/edge-ai-lab/page/anomaly_detection.html
 .. _`Nordic Edge AI Lab Wake Word Detection`: https://docs.nordicsemi.com/r/bundle/edge-ai-lab/page/wake_word.html
+.. _`Nordic Edge AI Lab Compile your own model`: https://docs.nordicsemi.com/r/bundle/edge-ai-lab/page/compile_model.html
 .. _`EdgeAI Inference Runner`: https://docs.nordicsemi.com/r/bundle/edge-ai-lab/page/model_creating_pipeline/run_inference_on_the_desktop.html
 .. _`Signal Processing Block`: https://docs.nordicsemi.com/r/bundle/edge-ai-lab/page/model_creating_pipeline/signal_processing.html
 

--- a/doc/links.txt
+++ b/doc/links.txt
@@ -95,6 +95,7 @@
 
 .. _`Setting up Podman container`: https://github.com/podman-container-tools/podman/blob/main/docs/tutorials/podman_tutorial.md#running-a-sample-container
 .. _`edge-impulse-sdk-zephyr`: https://github.com/edgeimpulse/edge-impulse-sdk-zephyr
+.. _`Edge AI Add-on GitHub repository`: https://github.com/nrfconnect/sdk-edge-ai
 .. _`MCUnet`: https://github.com/mit-han-lab/mcunet
 .. _`Person detection demo repository`: https://github.com/nordicsemi/app-axon-person-detection
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -45,7 +45,7 @@ If you are unsure which solution fits your use case, refer to the table below fo
      - High-level API
      - Broad device compatibility with ultra-low memory footprint
    * - :ref:`Axon driver inference <solution_axon_driver_inference>`
-     - :ref:`Axon NPU TFLite compiler <axon_npu_tflite_compiler>`
+     - :ref:`Axon NPU TFLite compiler <axon_npu_tflite_compiler>` or `Nordic Edge AI Lab`_
      - Axon NPU
      - Low-level driver API
      - Custom inference pipelines, direct NPU control, and advanced optimization
@@ -152,13 +152,13 @@ Axon driver inference
 =====================
 
 This solution gives you direct access to the Axon NPU through the Axon driver API for running compiled neural network models.
-You compile TensorFlow Lite models with the :ref:`Axon NPU TFLite compiler <axon_npu_tflite_compiler>` and implement custom inference pipelines using the driver's synchronous or asynchronous execution modes.
+You can compile TensorFlow Lite models using the :ref:`Axon NPU TFLite compiler <axon_npu_tflite_compiler>` or the `Nordic Edge AI Lab Compile your own model`_ feature and implement custom inference pipelines using the driver's synchronous or asynchronous execution modes.
 
 Use this solution when you need maximum control over inference scheduling, memory management, and NPU resource utilization, or when your application requires custom pre- and post-processing that goes beyond what higher-level APIs provide.
 
 Key characteristics:
 
-* Models are compiled from TensorFlow Lite format using the :ref:`Axon NPU TFLite compiler <axon_npu_tflite_compiler>`.
+* Models are compiled from TensorFlow Lite format using the :ref:`Axon NPU TFLite compiler <axon_npu_tflite_compiler>` or `Nordic Edge AI Lab`_.
 * The driver supports both synchronous (blocking) and asynchronous (callback-based) inference.
 * Memory is managed through a shared interlayer buffer, sized to the largest model in the system.
 * Provides a host-based software simulator for development and testing without hardware.

--- a/doc/quick_start/axon_driver_inference.rst
+++ b/doc/quick_start/axon_driver_inference.rst
@@ -31,14 +31,21 @@ Software requirements
 
 To start working with the Axon NPU, complete the setup based on your use case:
 
-* If you want to deploy models on the device, you just need to complete :ref:`setup_sdk` to install |NCS| and toolchain.
-* If you want to prepare models for deployment, you only need to set up a Python environment to run the :ref:`axon_npu_tflite_compiler`.
-  Follow instructions in :ref:`axon_setup_compiler` to set up the environment.
+* If you want to deploy models on the device, complete :ref:`setup_sdk` to install |NCS| and toolchain.
+* If you want to prepare models for deployment, choose one of the following:
+
+  * Compile a TensorFlow Lite model in `Nordic Edge AI Lab`_ using the `Nordic Edge AI Lab Compile your own model`_ feature.
+    See :ref:`axon_compile_model`.
+  * Set up a local Python environment to run the :ref:`axon_npu_tflite_compiler`.
+    Follow instructions in :ref:`axon_setup_compiler`.
 
 .. _axon_setup_compiler:
 
 Setting up Axon TFlite Compiler
 ===============================
+
+The following setup applies when you compile models locally with the :ref:`axon_npu_tflite_compiler`.
+If you use `Nordic Edge AI Lab`_ instead, go to :ref:`axon_compile_model` section.
 
 Before you can run the :ref:`axon_npu_tflite_compiler`, you need to set up a Python environment with the required dependencies.
 The executor of the compiler is compatible with Python ``3.11``.
@@ -118,9 +125,10 @@ You can set up the Python environment using one of the methods below.
 Model compilation
 *****************
 
-With the compiler environment ready, you can transform your TensorFlow Lite model into Axon-optimized code and verify that inference produces correct results.
+With the Axon compiler, you can transform your TensorFlow Lite model into Axon-optimized code and verify that inference produces correct results.
 
 .. rst-class:: numbered-step
+.. _axon_compile_model:
 
 Compile your model
 ==================
@@ -128,7 +136,28 @@ Compile your model
 The Axon compiler analyzes your model's operations, maps them to hardware accelerators, and generates efficient code for the NPU.
 Whether you're using a pre-trained model or one you have trained yourself, you will need to run it through this compilation process.
 
-Follow the :ref:`axon_npu_tflite_compiler_setup_executor` instructions to transform your TFLite model into an Axon-optimized model.
+You can compile your TensorFlow Lite model in `Nordic Edge AI Lab`_ or with the local :ref:`axon_npu_tflite_compiler`.
+For context on how these options differ, see the :ref:`axon_compile_model_options` section.
+
+.. tabs::
+
+   .. group-tab:: Nordic Edge AI Lab
+
+      Use `Nordic Edge AI Lab`_ when you want to compile a model without installing the local compiler toolchain.
+
+      #. Create a `Nordic Edge AI Lab`_ account if you do not already have one.
+      #. Follow the `Nordic Edge AI Lab Compile your own model`_ guide to upload your int8-quantized ``.tflite`` or ``.lite`` model and compile it for Axon.
+      #. Download the compiled model package when compilation completes.
+
+         The package contains Axon header files (for example, :file:`nrf_axon_model_<model_name>_.h`) that you can integrate into your application using the Axon driver API.
+
+      .. note::
+
+         Use this option when you already have a TensorFlow Lite model and want a quick path to Axon-optimized headers.
+
+   .. group-tab:: Local Axon NPU TFlite compiler
+
+      Follow the :ref:`axon_npu_tflite_compiler_setup_executor` instructions to transform your TFLite model into an Axon-optimized model.
 
 .. rst-class:: numbered-step
 

--- a/doc/quick_start/sdk_setup.rst
+++ b/doc/quick_start/sdk_setup.rst
@@ -14,6 +14,7 @@ Get the nRF Edge AI Add-on code
 
 The |EAI| is distributed as a Git repository, and is managed through its own west manifest.
 The compatible |NCS| version is specified in the :file:`west.yml` file.
+Follow the `Edge AI Add-on GitHub repository`_ link to browse the codebase.
 To get the |EAI| code, you can either:
 
 * Use the `nRF Connect for Visual Studio Code`_ extension, which provides a convenient way to clone the Add-on and compatible |NCS| version.


### PR DESCRIPTION
- mention "compile your own model feature" in the docs where it's relevant
- consolidate information on data collection for model training (data_forwarder sample)