### PR TITLE
ci: align compliance link check with nrf workflow

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -114,37 +114,22 @@ jobs:
         run: |
           RE='.. _`(.*)`: (.*)'
           LINKS=$(git diff --unified=0 "${{ github.event.pull_request.base.sha }}..HEAD" -- "doc/links.txt" | \
-                  grep "^+" || true | \
-                  grep -Ev "^(---|\+\+\+)" || true)
-
-          NCS_VERSION_NUMBER=$(python3 -c "
-          import sys
-          import west.manifest
-          try:
-              projects = west.manifest.Manifest.from_topdir().get_projects(['nrf'])
-              if not projects or not projects[0].revision:
-                  raise RuntimeError('nrf project missing or has no revision')
-              rev = projects[0].revision
-              print(rev[1:] if rev.startswith('v') else rev)
-          except Exception as e:
-              print(f'::error ::Could not determine NCS version from west manifest: {e}', file=sys.stderr)
-              sys.exit(1)
-          ")
-
-          echo "Resolved NCS version from manifest: ${NCS_VERSION_NUMBER}"
+            grep "^+" | grep -Ev "^\+\+\+" || true)
 
           while IFS= read -r link; do
+            link="${link#+}"
             if [[ $link =~ $RE ]]; then
               NAME=${BASH_REMATCH[1]}
               URL=${BASH_REMATCH[2]}
-              URL="${URL//|ncs_version_number|/${NCS_VERSION_NUMBER}}"
 
               echo -n "Checking URL for '$NAME' ($URL)... "
-              if [[ "$URL" == *"files.nordicsemi.com"* ]]; then
-                # files.nordicsemi.com server does not allow downloading only headers
-                status=$(curl --write-out "%{http_code}" --output /dev/null --silent "$URL" || true)
+              if [[ "$URL" == *"nordicsemi.com"* ]]; then
+                # Nordic hosts often reject HEAD from CI; /bundle/ URLs redirect to /r/
+                status=$(curl --write-out "%{http_code}" --output /dev/null --silent --location \
+                  --user-agent "NCS-compliance-link-check" "$URL" || true)
               else
-                status=$(curl --write-out "%{http_code}" --output /dev/null --silent --head "$URL" || true)
+                status=$(curl --write-out "%{http_code}" --output /dev/null --silent --location --head \
+                  "$URL" || true)
               fi
 
               if [[ "$status" -ne 200 ]]; then


### PR DESCRIPTION
Drop ncs_version_number URL substitution now that doc links use intersphinx mapping instead. Port the remaining link-check fixes from the nrf repo: strip diff '+' prefixes, tighten grep filtering, and improve curl handling for nordicsemi.com redirects in CI.