### PR TITLE
tools: data_forwarder_host: fix truncated Y-axis labels on plots

### DIFF
--- a/tools/data_forwarder_host/gui/widgets/charts_panel.py
+++ b/tools/data_forwarder_host/gui/widgets/charts_panel.py
@@ -60,7 +60,7 @@ class _ChannelChart(QChartView):
         super().__init__(chart, parent)
         self.setRenderHint(QPainter.RenderHint.Antialiasing)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
-        self.setMinimumHeight(120)
+        self.setMinimumHeight(200)
 
         self._series = QLineSeries()
         self._series.setColor(QColor(color))


### PR DESCRIPTION
Increased the minimum height of the per-channel chart from 120px to 200px. QtCharts reduces the default 5-tick Y-axis labels to "..." when it doesn't have enough vertical space to render them.

Jira: NCSDK-40803