### PR TITLE
tools: data_forwarder_host: bump version to 0.1.1

### DIFF
--- a/tools/data_forwarder_host/__init__.py
+++ b/tools/data_forwarder_host/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 """Data Forwarder Host — receives, visualises and exports sensor data from an nRF device."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 
 def main() -> int:

--- a/tools/data_forwarder_host/pyproject.toml
+++ b/tools/data_forwarder_host/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "data-forwarder-host"
-version = "0.1.0"
+version = "0.1.1"
 description = "Cross-platform host GUI that receives, visualises, records and exports sensor data forwarded from an nRF device."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Bump the tool version ahead of the next binary release to pick up the truncated Y-axis label fix.

Jira: NCSDK-40803